### PR TITLE
feat: add content_type field to messages

### DIFF
--- a/.agent/plans/active/9d5f4434.md
+++ b/.agent/plans/active/9d5f4434.md
@@ -2,8 +2,8 @@
 
 **ID:** 9d5f4434
 **Created:** 2026-01-16 03:12:59 UTC
-**Updated:** 2026-01-16 04:54:27 UTC
-**Status:** in-review
+**Updated:** 2026-01-21 03:07:53 UTC
+**Status:** approved
 **Session:** 7901ed98-a14a-4cce-abd2-4f986bee9502
 
 ## Context
@@ -104,7 +104,7 @@ Current `heare_auth.py` becomes a separate package (`deadrop-heare-auth` or part
 
 - ✅ **Create PyPI project and configure trusted publishing for GitHub Actions** (id: 7a02bf51)
 
-- ⬜ **Create a test tag to verify the release workflow works** (id: 34e0272a)
+- ⬜ **Create a test tag to verify the release workflow works** (id: 34e0272a) [READY]
 
 ## Considerations
 
@@ -140,6 +140,7 @@ Current `heare_auth.py` becomes a separate package (`deadrop-heare-auth` or part
 - [2026-01-16 04:52] Completed task 365c726a: Updated README: added installation section, documented pluggable auth system, removed demo server references, emphasized self-hosting
 - [2026-01-16 04:52] Verified task 365c726a
 - [2026-01-16 04:54] Completed task 7a02bf51: PR created. PyPI setup requires manual action - documented in PR description.
+- [2026-01-21 03:07] Plan approved for execution
 
 ---
 
@@ -147,10 +148,10 @@ Current `heare_auth.py` becomes a separate package (`deadrop-heare-auth` or part
 {
   "id": "9d5f4434",
   "title": "Publish deadrop package to PyPI",
-  "status": "in-review",
+  "status": "approved",
   "session_id": "7901ed98-a14a-4cce-abd2-4f986bee9502",
   "created_at": "2026-01-16T03:12:59.095456+00:00",
-  "updated_at": "2026-01-16T04:54:27.513927+00:00",
+  "updated_at": "2026-01-21T03:07:53.454342+00:00",
   "root_dirs": [
     "/Users/seanfitz/development/deaddrop"
   ],
@@ -159,6 +160,7 @@ Current `heare_auth.py` becomes a separate package (`deadrop-heare-auth` or part
   "shelved": false,
   "remote_workspace": "",
   "remote_branch": "",
+  "remote_started_at": null,
   "context": "## Current State\n- Package name: `deadrop` (user prefers `deaddrop` - need to check PyPI availability)\n- Version: 0.1.0\n- Repository: Already private on GitHub (clusterfudge/deaddrop)\n- CI/CD: release.yml exists with PyPI trusted publishing workflow\n- Hardcoded URL: `https://deaddrop.dokku.heare.io` in config.py and tests\n\n## Requirements from User\n1. **Package name**: Use `deaddrop` on PyPI\n2. **Default URL**: Change to `localhost:8000` (self-hosted first)\n3. **Auth system**: Make pluggable via environment variable for module name\n   - Extract current heare-auth integration to separate package\n   - Allow users to specify custom auth module via envvar\n4. **PyPI setup**: Need to configure trusted publishing",
   "approach": "## Approach\n\n### 1. Package Name Availability\n- Check if `deaddrop` is available on PyPI\n- If not, consider alternatives: `deaddrop-messaging`, `deadrop-io`\n\n### 2. Pluggable Auth System\nCreate a plugin architecture for authentication:\n```python\n# Environment variable: DEADROP_AUTH_MODULE\n# Default: None (no auth required)\n# Example: DEADROP_AUTH_MODULE=deadrop_heare_auth.plugin\n\n# The module must expose:\n# - verify_token(token: str) -> dict | None\n# - is_enabled() -> bool\n```\n\nCurrent `heare_auth.py` becomes a separate package (`deadrop-heare-auth` or part of `heare-auth`).\n\n### 3. Default URL Change\n- Change `DEFAULT_SERVER_URL` from `https://deaddrop.dokku.heare.io` to `http://localhost:8000`\n- Update tests to match\n- Update documentation to emphasize self-hosting\n\n### 4. PyPI Setup\n1. Create PyPI account (if needed)\n2. Create project on PyPI\n3. Configure trusted publishing:\n   - Go to PyPI project settings\n   - Add GitHub Actions as trusted publisher\n   - Repository: clusterfudge/deaddrop\n   - Workflow: release.yml\n   - Environment: pypi\n\n### 5. Documentation Updates\n- Remove/update references to demo server\n- Add self-hosting instructions\n- Document auth plugin system",
   "tasks": [
@@ -240,6 +242,7 @@ Current `heare_auth.py` becomes a separate package (`deadrop-heare-auth` or part
       "verification_notes": ""
     }
   ],
+  "milestones": [],
   "questions": [
     {
       "id": "f857ea22",
@@ -384,8 +387,22 @@ Current `heare_auth.py` becomes a separate package (`deadrop-heare-auth` or part
     {
       "timestamp": "2026-01-16T04:54:27.513926+00:00",
       "message": "Completed task 7a02bf51: PR created. PyPI setup requires manual action - documented in PR description."
+    },
+    {
+      "timestamp": "2026-01-21T03:07:53.454340+00:00",
+      "message": "Plan approved for execution"
     }
   ],
-  "completion_notes": ""
+  "completion_notes": "",
+  "metrics": {
+    "definitions": [],
+    "snapshots": [],
+    "execution_started_at": null,
+    "baseline_input_tokens": 0,
+    "baseline_output_tokens": 0,
+    "baseline_thinking_tokens": 0,
+    "baseline_cached_tokens": 0,
+    "baseline_cost_dollars": 0.0
+  }
 }
 -->

--- a/.agent/plans/active/f1ab1264.md
+++ b/.agent/plans/active/f1ab1264.md
@@ -1,0 +1,326 @@
+# Plan: Versioned schema migrations for deaddrop
+
+**ID:** f1ab1264
+**Created:** 2026-01-21 03:42:29 UTC
+**Updated:** 2026-01-21 03:51:40 UTC
+**Status:** in-progress
+**Session:** 308968c3-3947-4b0c-87ef-b1fb834d2086
+
+## Context
+
+## Current State
+
+- **Database**: SQLite locally, Turso (libSQL) in production
+- **Schema management**: Currently uses `CREATE TABLE IF NOT EXISTS` in `init_db()`
+- **Problem**: No way to add columns to existing tables (e.g., `content_type` on messages)
+- **Recent change**: Added `content_type TEXT DEFAULT 'text/plain'` to messages table schema, but existing databases won't get this column
+
+## Tables
+1. `namespaces` - namespace configuration
+2. `identities` - user/agent identities within namespaces  
+3. `messages` - the messages (needs `content_type` column added)
+4. `invites` - invite links for onboarding
+5. `archive_batches` - archive tracking
+
+## Requirements
+- Track schema version in database
+- Apply incremental migrations on startup
+- Support both SQLite and Turso/libSQL
+- First migration: add `content_type` column to existing `messages` tables
+
+## Implementation Approach
+
+## Approach
+
+### Schema Version Tracking
+Add a `schema_version` table to track the current database version:
+```sql
+CREATE TABLE IF NOT EXISTS schema_version (
+    version INTEGER PRIMARY KEY,
+    applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    description TEXT
+);
+```
+
+### Migration System Design
+1. **Migrations as functions**: Each migration is a Python function that takes a connection
+2. **Version tracking**: After each migration, insert a row into `schema_version`
+3. **Idempotent**: Check current version before applying migrations
+4. **Ordered**: Migrations have sequential version numbers (1, 2, 3, ...)
+
+### Migration Runner
+```python
+MIGRATIONS = [
+    (1, "Add content_type to messages", migrate_001_add_content_type),
+    # Future migrations added here
+]
+
+def run_migrations(conn):
+    current_version = get_current_version(conn)
+    for version, description, migrate_fn in MIGRATIONS:
+        if version > current_version:
+            migrate_fn(conn)
+            record_migration(conn, version, description)
+```
+
+### First Migration (001)
+```sql
+-- Add content_type column if it doesn't exist
+ALTER TABLE messages ADD COLUMN content_type TEXT DEFAULT 'text/plain';
+```
+
+Note: SQLite doesn't support `IF NOT EXISTS` for `ALTER TABLE ADD COLUMN`, so we need to check column existence first via `PRAGMA table_info(messages)`.
+
+### Integration
+- Call `run_migrations()` from `init_db()` after creating tables
+- New databases get tables with all columns, then migrations mark them as applied
+- Existing databases get columns added via migrations
+
+## Tasks
+
+- ✓✓ **Add schema_version table and version tracking functions** (id: c5eeb5df)
+  - Details: Create schema_version table, get_schema_version(), record_migration() functions
+  - Files: src/deadrop/db.py
+  - Tests: Test version tracking in isolation
+  - Verification: All 112 tests pass. Schema version tracking tests:
+- test_get_schema_version_empty_db PASSED
+- test_record_and_get_migration PASSED
+- test_multiple_migrations_return_max_version PASSED
+
+- ✓✓ **Implement migration runner infrastructure** (id: 97394d7b)
+  - Details: Create MIGRATIONS list, run_migrations() function, column existence check helper
+  - Files: src/deadrop/db.py
+  - Tests: Test migration runner with mock migrations
+  - Verification: Migration runner tests pass:
+- test_run_migrations_on_fresh_db PASSED
+- test_run_migrations_skips_already_applied PASSED
+- test_run_migrations_idempotent PASSED
+
+- ✓✓ **Create migration 001: add content_type column to messages** (id: a7fdef3b)
+  - Details: Migration function that adds content_type column if missing, with DEFAULT 'text/plain'
+  - Files: src/deadrop/db.py
+  - Tests: Test migration on DB without content_type column
+  - Verification: Migration 001 tests pass:
+- test_migration_adds_column_when_missing PASSED
+- test_migration_is_idempotent PASSED
+- test_migration_default_value PASSED
+
+- ✓✓ **Integrate migrations into init_db()** (id: 632d81dd)
+  - Details: Call run_migrations() after table creation, handle fresh vs existing DB
+  - Files: src/deadrop/db.py
+  - Tests: Integration test: fresh DB and upgrade scenarios
+  - Verification: Integration tests pass:
+- test_init_db_runs_migrations PASSED
+- test_fresh_db_has_all_columns PASSED
+
+- ✓✓ **Add comprehensive migration tests** (id: e615f4c4)
+  - Details: Test fresh install, upgrade from pre-migration, idempotency, error handling
+  - Files: tests/test_migrations.py
+  - Tests: New test file for migration system
+  - Verification: All 13 migration tests pass in tests/test_migrations.py. Full test suite: 112 tests pass.
+
+## Considerations
+
+- **Common patterns we might need:** 
+
+## Progress Log
+
+- [2026-01-21 03:42] Plan created: Versioned schema migrations for deaddrop
+- [2026-01-21 03:44] Updated context
+- [2026-01-21 03:45] Updated approach
+- [2026-01-21 03:45] Updated considerations
+- [2026-01-21 03:45] Added 5 tasks
+- [2026-01-21 03:46] Plan submitted for review
+- [2026-01-21 03:47] Plan approved for execution
+- [2026-01-21 03:47] Plan execution started
+- [2026-01-21 03:48] Completed task c5eeb5df: Added schema_version table, get_schema_version(), record_migration(), and _column_exists() helper functions
+- [2026-01-21 03:49] Completed task 97394d7b: Added MIGRATIONS registry and run_migrations() function
+- [2026-01-21 03:49] Completed task a7fdef3b: Migration 001 (_migrate_001_add_content_type) was implemented as part of the migration runner infrastructure
+- [2026-01-21 03:49] Completed task 632d81dd: Added run_migrations(conn) call at the end of init_db()
+- [2026-01-21 03:51] Completed task e615f4c4: Added 13 comprehensive migration tests covering version tracking, column checks, migration 001, migration runner, and init_db integration
+- [2026-01-21 03:51] Verified task c5eeb5df
+- [2026-01-21 03:51] Verified task 97394d7b
+- [2026-01-21 03:51] Verified task a7fdef3b
+- [2026-01-21 03:51] Verified task 632d81dd
+- [2026-01-21 03:51] Verified task e615f4c4
+
+---
+
+<!-- plan-data
+{
+  "id": "f1ab1264",
+  "title": "Versioned schema migrations for deaddrop",
+  "status": "in-progress",
+  "session_id": "308968c3-3947-4b0c-87ef-b1fb834d2086",
+  "created_at": "2026-01-21T03:42:29.400048+00:00",
+  "updated_at": "2026-01-21T03:51:40.696943+00:00",
+  "root_dirs": [
+    "/Users/seanfitz/development/deaddrop"
+  ],
+  "storage_location": "local",
+  "pull_request": "",
+  "shelved": false,
+  "remote_workspace": "",
+  "remote_branch": "",
+  "remote_started_at": null,
+  "context": "## Current State\n\n- **Database**: SQLite locally, Turso (libSQL) in production\n- **Schema management**: Currently uses `CREATE TABLE IF NOT EXISTS` in `init_db()`\n- **Problem**: No way to add columns to existing tables (e.g., `content_type` on messages)\n- **Recent change**: Added `content_type TEXT DEFAULT 'text/plain'` to messages table schema, but existing databases won't get this column\n\n## Tables\n1. `namespaces` - namespace configuration\n2. `identities` - user/agent identities within namespaces  \n3. `messages` - the messages (needs `content_type` column added)\n4. `invites` - invite links for onboarding\n5. `archive_batches` - archive tracking\n\n## Requirements\n- Track schema version in database\n- Apply incremental migrations on startup\n- Support both SQLite and Turso/libSQL\n- First migration: add `content_type` column to existing `messages` tables",
+  "approach": "## Approach\n\n### Schema Version Tracking\nAdd a `schema_version` table to track the current database version:\n```sql\nCREATE TABLE IF NOT EXISTS schema_version (\n    version INTEGER PRIMARY KEY,\n    applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,\n    description TEXT\n);\n```\n\n### Migration System Design\n1. **Migrations as functions**: Each migration is a Python function that takes a connection\n2. **Version tracking**: After each migration, insert a row into `schema_version`\n3. **Idempotent**: Check current version before applying migrations\n4. **Ordered**: Migrations have sequential version numbers (1, 2, 3, ...)\n\n### Migration Runner\n```python\nMIGRATIONS = [\n    (1, \"Add content_type to messages\", migrate_001_add_content_type),\n    # Future migrations added here\n]\n\ndef run_migrations(conn):\n    current_version = get_current_version(conn)\n    for version, description, migrate_fn in MIGRATIONS:\n        if version > current_version:\n            migrate_fn(conn)\n            record_migration(conn, version, description)\n```\n\n### First Migration (001)\n```sql\n-- Add content_type column if it doesn't exist\nALTER TABLE messages ADD COLUMN content_type TEXT DEFAULT 'text/plain';\n```\n\nNote: SQLite doesn't support `IF NOT EXISTS` for `ALTER TABLE ADD COLUMN`, so we need to check column existence first via `PRAGMA table_info(messages)`.\n\n### Integration\n- Call `run_migrations()` from `init_db()` after creating tables\n- New databases get tables with all columns, then migrations mark them as applied\n- Existing databases get columns added via migrations",
+  "tasks": [
+    {
+      "id": "c5eeb5df",
+      "description": "Add schema_version table and version tracking functions",
+      "details": "Create schema_version table, get_schema_version(), record_migration() functions",
+      "files": [
+        "src/deadrop/db.py"
+      ],
+      "tests": "Test version tracking in isolation",
+      "dependencies": [],
+      "completed": true,
+      "verified": true,
+      "verification_notes": "All 112 tests pass. Schema version tracking tests:\n- test_get_schema_version_empty_db PASSED\n- test_record_and_get_migration PASSED\n- test_multiple_migrations_return_max_version PASSED"
+    },
+    {
+      "id": "97394d7b",
+      "description": "Implement migration runner infrastructure",
+      "details": "Create MIGRATIONS list, run_migrations() function, column existence check helper",
+      "files": [
+        "src/deadrop/db.py"
+      ],
+      "tests": "Test migration runner with mock migrations",
+      "dependencies": [],
+      "completed": true,
+      "verified": true,
+      "verification_notes": "Migration runner tests pass:\n- test_run_migrations_on_fresh_db PASSED\n- test_run_migrations_skips_already_applied PASSED\n- test_run_migrations_idempotent PASSED"
+    },
+    {
+      "id": "a7fdef3b",
+      "description": "Create migration 001: add content_type column to messages",
+      "details": "Migration function that adds content_type column if missing, with DEFAULT 'text/plain'",
+      "files": [
+        "src/deadrop/db.py"
+      ],
+      "tests": "Test migration on DB without content_type column",
+      "dependencies": [],
+      "completed": true,
+      "verified": true,
+      "verification_notes": "Migration 001 tests pass:\n- test_migration_adds_column_when_missing PASSED\n- test_migration_is_idempotent PASSED\n- test_migration_default_value PASSED"
+    },
+    {
+      "id": "632d81dd",
+      "description": "Integrate migrations into init_db()",
+      "details": "Call run_migrations() after table creation, handle fresh vs existing DB",
+      "files": [
+        "src/deadrop/db.py"
+      ],
+      "tests": "Integration test: fresh DB and upgrade scenarios",
+      "dependencies": [],
+      "completed": true,
+      "verified": true,
+      "verification_notes": "Integration tests pass:\n- test_init_db_runs_migrations PASSED\n- test_fresh_db_has_all_columns PASSED"
+    },
+    {
+      "id": "e615f4c4",
+      "description": "Add comprehensive migration tests",
+      "details": "Test fresh install, upgrade from pre-migration, idempotency, error handling",
+      "files": [
+        "tests/test_migrations.py"
+      ],
+      "tests": "New test file for migration system",
+      "dependencies": [],
+      "completed": true,
+      "verified": true,
+      "verification_notes": "All 13 migration tests pass in tests/test_migrations.py. Full test suite: 112 tests pass."
+    }
+  ],
+  "milestones": [],
+  "questions": [],
+  "considerations": {
+    "Common patterns we might need": ""
+  },
+  "progress_log": [
+    {
+      "timestamp": "2026-01-21T03:42:29.400124+00:00",
+      "message": "Plan created: Versioned schema migrations for deaddrop"
+    },
+    {
+      "timestamp": "2026-01-21T03:44:52.548020+00:00",
+      "message": "Updated context"
+    },
+    {
+      "timestamp": "2026-01-21T03:45:11.355579+00:00",
+      "message": "Updated approach"
+    },
+    {
+      "timestamp": "2026-01-21T03:45:27.328663+00:00",
+      "message": "Updated considerations"
+    },
+    {
+      "timestamp": "2026-01-21T03:45:46.194225+00:00",
+      "message": "Added 5 tasks"
+    },
+    {
+      "timestamp": "2026-01-21T03:46:12.875824+00:00",
+      "message": "Plan submitted for review"
+    },
+    {
+      "timestamp": "2026-01-21T03:47:32.485970+00:00",
+      "message": "Plan approved for execution"
+    },
+    {
+      "timestamp": "2026-01-21T03:47:45.254565+00:00",
+      "message": "Plan execution started"
+    },
+    {
+      "timestamp": "2026-01-21T03:48:31.374666+00:00",
+      "message": "Completed task c5eeb5df: Added schema_version table, get_schema_version(), record_migration(), and _column_exists() helper functions"
+    },
+    {
+      "timestamp": "2026-01-21T03:49:02.140849+00:00",
+      "message": "Completed task 97394d7b: Added MIGRATIONS registry and run_migrations() function"
+    },
+    {
+      "timestamp": "2026-01-21T03:49:15.867491+00:00",
+      "message": "Completed task a7fdef3b: Migration 001 (_migrate_001_add_content_type) was implemented as part of the migration runner infrastructure"
+    },
+    {
+      "timestamp": "2026-01-21T03:49:56.949371+00:00",
+      "message": "Completed task 632d81dd: Added run_migrations(conn) call at the end of init_db()"
+    },
+    {
+      "timestamp": "2026-01-21T03:51:19.352469+00:00",
+      "message": "Completed task e615f4c4: Added 13 comprehensive migration tests covering version tracking, column checks, migration 001, migration runner, and init_db integration"
+    },
+    {
+      "timestamp": "2026-01-21T03:51:37.277685+00:00",
+      "message": "Verified task c5eeb5df"
+    },
+    {
+      "timestamp": "2026-01-21T03:51:38.104670+00:00",
+      "message": "Verified task 97394d7b"
+    },
+    {
+      "timestamp": "2026-01-21T03:51:39.022403+00:00",
+      "message": "Verified task a7fdef3b"
+    },
+    {
+      "timestamp": "2026-01-21T03:51:39.841818+00:00",
+      "message": "Verified task 632d81dd"
+    },
+    {
+      "timestamp": "2026-01-21T03:51:40.696941+00:00",
+      "message": "Verified task e615f4c4"
+    }
+  ],
+  "completion_notes": "",
+  "metrics": {
+    "definitions": [],
+    "snapshots": [],
+    "execution_started_at": "2026-01-21T03:47:45.255635+00:00",
+    "baseline_input_tokens": 160,
+    "baseline_output_tokens": 20444,
+    "baseline_thinking_tokens": 0,
+    "baseline_cached_tokens": 3481314,
+    "baseline_cost_dollars": 4.2056539
+  }
+}
+-->

--- a/.agent/plans/completed/80d2aae4.md
+++ b/.agent/plans/completed/80d2aae4.md
@@ -1,0 +1,151 @@
+# Plan: tasks
+
+**ID:** 80d2aae4
+**Created:** 2026-01-21 03:18:08 UTC
+**Updated:** 2026-01-21 03:35:00 UTC
+**Status:** abandoned
+**Session:** 308968c3-3947-4b0c-87ef-b1fb834d2086
+
+## Context
+
+Need to design a task/todo feature for deadrop, and clarify the schema migration approach before implementation
+
+## Clarification Questions
+
+- [x] **What schema migration approach should we use for deadrop?**
+  - Options: Simple: Add migration SQL in init_db() that runs ALTER TABLE IF NOT EXISTS style checks, Versioned: Track schema version in DB and apply incremental migrations, Alembic: Use proper migration tool (adds dependency), Manual: Document migrations, run manually on deploy
+  - **Answer:** Versioned: Track schema version in DB and apply incremental migrations
+
+- [x] **What should the 'tasks' feature do? Please describe the use case.**
+  - **Answer:** sorry, I wanted you to use your planning tools to come up with an implementation plan, as opposed to yoloing from memory.
+
+- [x] **Who can create/assign tasks?**
+  - Options: Any identity can create tasks for any other identity in the namespace, Only namespace owner can create/assign tasks, Tasks are self-assigned only (like personal todos), Combination: anyone can create, but assignment rules vary
+  - **Answer:** this is not a feature of deaddrop, it's a suite of tools in silica.
+
+- [x] **How should tasks relate to messages?**
+  - Options: Tasks are separate from messages (new table, new endpoints), Tasks are a type of message (with special content_type or flag), Tasks can be attached to messages (reference a message), Other (please describe)
+  - **Answer:** N/A
+
+## Implementation Approach
+
+_No approach defined yet._
+
+## Tasks
+
+_No tasks defined yet._
+
+## Considerations
+
+_No considerations noted yet._
+
+## Progress Log
+
+- [2026-01-21 03:18] Plan created: tasks
+- [2026-01-21 03:34] Clarified 4 questions with user
+- [2026-01-21 03:35] Plan abandoned
+
+---
+
+<!-- plan-data
+{
+  "id": "80d2aae4",
+  "title": "tasks",
+  "status": "abandoned",
+  "session_id": "308968c3-3947-4b0c-87ef-b1fb834d2086",
+  "created_at": "2026-01-21T03:18:08.649392+00:00",
+  "updated_at": "2026-01-21T03:35:00.049479+00:00",
+  "root_dirs": [
+    "/Users/seanfitz/development/deaddrop"
+  ],
+  "storage_location": "local",
+  "pull_request": "",
+  "shelved": false,
+  "remote_workspace": "",
+  "remote_branch": "",
+  "remote_started_at": null,
+  "context": "Need to design a task/todo feature for deadrop, and clarify the schema migration approach before implementation",
+  "approach": "",
+  "tasks": [],
+  "milestones": [],
+  "questions": [
+    {
+      "id": "8ec9dd82",
+      "question": "What schema migration approach should we use for deadrop?",
+      "type": "choice",
+      "options": [
+        "Simple: Add migration SQL in init_db() that runs ALTER TABLE IF NOT EXISTS style checks",
+        "Versioned: Track schema version in DB and apply incremental migrations",
+        "Alembic: Use proper migration tool (adds dependency)",
+        "Manual: Document migrations, run manually on deploy"
+      ],
+      "required": true,
+      "answer": "Versioned: Track schema version in DB and apply incremental migrations",
+      "answered_at": "2026-01-21T03:34:29.628386+00:00"
+    },
+    {
+      "id": "b717a380",
+      "question": "What should the 'tasks' feature do? Please describe the use case.",
+      "type": "text",
+      "options": [],
+      "required": true,
+      "answer": "sorry, I wanted you to use your planning tools to come up with an implementation plan, as opposed to yoloing from memory.",
+      "answered_at": "2026-01-21T03:34:29.628393+00:00"
+    },
+    {
+      "id": "9d874815",
+      "question": "Who can create/assign tasks?",
+      "type": "choice",
+      "options": [
+        "Any identity can create tasks for any other identity in the namespace",
+        "Only namespace owner can create/assign tasks",
+        "Tasks are self-assigned only (like personal todos)",
+        "Combination: anyone can create, but assignment rules vary"
+      ],
+      "required": true,
+      "answer": "this is not a feature of deaddrop, it's a suite of tools in silica.",
+      "answered_at": "2026-01-21T03:34:29.628397+00:00"
+    },
+    {
+      "id": "022ad249",
+      "question": "How should tasks relate to messages?",
+      "type": "choice",
+      "options": [
+        "Tasks are separate from messages (new table, new endpoints)",
+        "Tasks are a type of message (with special content_type or flag)",
+        "Tasks can be attached to messages (reference a message)",
+        "Other (please describe)"
+      ],
+      "required": true,
+      "answer": "N/A",
+      "answered_at": "2026-01-21T03:34:29.628403+00:00"
+    }
+  ],
+  "considerations": {},
+  "progress_log": [
+    {
+      "timestamp": "2026-01-21T03:18:08.649490+00:00",
+      "message": "Plan created: tasks"
+    },
+    {
+      "timestamp": "2026-01-21T03:34:29.628405+00:00",
+      "message": "Clarified 4 questions with user"
+    },
+    {
+      "timestamp": "2026-01-21T03:35:00.049478+00:00",
+      "message": "Plan abandoned"
+    }
+  ],
+  "completion_notes": "",
+  "metrics": {
+    "definitions": [],
+    "snapshots": [],
+    "execution_started_at": null,
+    "baseline_input_tokens": 0,
+    "baseline_output_tokens": 0,
+    "baseline_thinking_tokens": 0,
+    "baseline_cached_tokens": 0,
+    "baseline_cost_dollars": 0.0
+  }
+}
+-->

--- a/src/deadrop/api.py
+++ b/src/deadrop/api.py
@@ -104,6 +104,9 @@ class UpdateMetadataRequest(BaseModel):
 class SendMessageRequest(BaseModel):
     to: str
     body: str
+    content_type: str = (
+        "text/plain"  # MIME type (e.g., text/plain, text/markdown, text/html, application/json)
+    )
     ttl_hours: int | None = None  # Optional TTL override (ephemeral messages)
 
 
@@ -112,6 +115,7 @@ class MessageInfo(BaseModel):
     from_id: str
     to: str
     body: str
+    content_type: str = "text/plain"
     created_at: str
     read_at: str | None
     expires_at: str | None
@@ -555,6 +559,7 @@ def send_message(
             from_id=from_id,
             to_id=request.to,
             body=request.body,
+            content_type=request.content_type,
             ttl_hours=request.ttl_hours,
         )
     except ValueError as e:
@@ -596,6 +601,7 @@ def get_inbox(
                 "from": m["from"],
                 "to": m["to"],
                 "body": m["body"],
+                "content_type": m.get("content_type", "text/plain"),
                 "created_at": m["created_at"],
                 "read_at": m["read_at"],
                 "expires_at": m["expires_at"],
@@ -624,6 +630,7 @@ def get_archived_messages(
                 "from": m["from"],
                 "to": m["to"],
                 "body": m["body"],
+                "content_type": m.get("content_type", "text/plain"),
                 "created_at": m["created_at"],
                 "read_at": m["read_at"],
                 "expires_at": m["expires_at"],
@@ -653,6 +660,7 @@ def get_message(
         "from": message["from"],
         "to": message["to"],
         "body": message["body"],
+        "content_type": message.get("content_type", "text/plain"),
         "created_at": message["created_at"],
         "read_at": message["read_at"],
         "expires_at": message["expires_at"],

--- a/src/deadrop/db.py
+++ b/src/deadrop/db.py
@@ -5,6 +5,7 @@ import os
 import re
 import sqlite3
 from datetime import datetime, timedelta, timezone
+from collections.abc import Callable
 from typing import Any
 
 from uuid_extensions import uuid7 as make_uuid7
@@ -13,6 +14,9 @@ from .auth import derive_id, generate_secret, hash_secret
 
 # Default TTL in hours when messages are read
 DEFAULT_TTL_HOURS = 24
+
+# Current schema version (increment when adding migrations)
+SCHEMA_VERSION = 1
 
 # Connection singleton
 _conn: sqlite3.Connection | None = None
@@ -72,8 +76,95 @@ def close_db():
         _is_libsql = False
 
 
+# --- Schema Version Tracking ---
+
+
+def _ensure_schema_version_table(conn: sqlite3.Connection) -> None:
+    """Create the schema_version table if it doesn't exist."""
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS schema_version (
+            version INTEGER PRIMARY KEY,
+            applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            description TEXT
+        )
+    """)
+    conn.commit()
+
+
+def get_schema_version(conn: sqlite3.Connection | None = None) -> int:
+    """Get the current schema version from the database.
+
+    Returns 0 if no migrations have been applied yet.
+    """
+    if conn is None:
+        conn = get_connection()
+
+    _ensure_schema_version_table(conn)
+
+    cursor = conn.execute("SELECT MAX(version) FROM schema_version")
+    row = cursor.fetchone()
+    return row[0] if row and row[0] is not None else 0
+
+
+def record_migration(conn: sqlite3.Connection, version: int, description: str) -> None:
+    """Record that a migration has been applied."""
+    conn.execute(
+        "INSERT INTO schema_version (version, description) VALUES (?, ?)",
+        (version, description),
+    )
+    conn.commit()
+
+
+def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    """Check if a column exists in a table."""
+    cursor = conn.execute(f"PRAGMA table_info({table})")
+    columns = [row[1] for row in cursor.fetchall()]
+    return column in columns
+
+
+# --- Migration Functions ---
+
+
+def _migrate_001_add_content_type(conn: sqlite3.Connection) -> None:
+    """Migration 001: Add content_type column to messages table."""
+    if not _column_exists(conn, "messages", "content_type"):
+        conn.execute("ALTER TABLE messages ADD COLUMN content_type TEXT DEFAULT 'text/plain'")
+        conn.commit()
+
+
+# Migration registry: (version, description, migration_function)
+MIGRATIONS: list[tuple[int, str, Callable[[sqlite3.Connection], None]]] = [
+    (1, "Add content_type column to messages", _migrate_001_add_content_type),
+]
+
+
+def run_migrations(conn: sqlite3.Connection | None = None) -> list[int]:
+    """Run any pending migrations.
+
+    Returns a list of migration versions that were applied.
+    """
+    if conn is None:
+        conn = get_connection()
+
+    _ensure_schema_version_table(conn)
+    current_version = get_schema_version(conn)
+    applied: list[int] = []
+
+    for version, description, migrate_fn in MIGRATIONS:
+        if version > current_version:
+            try:
+                migrate_fn(conn)
+                record_migration(conn, version, description)
+                applied.append(version)
+            except Exception as e:
+                # Log error but don't fail - let caller handle it
+                raise RuntimeError(f"Migration {version} failed: {e}") from e
+
+    return applied
+
+
 def init_db():
-    """Initialize database schema."""
+    """Initialize database schema and run any pending migrations."""
     conn = get_connection()
     conn.executescript("""
         CREATE TABLE IF NOT EXISTS namespaces (
@@ -144,6 +235,9 @@ def init_db():
         );
     """)
     conn.commit()
+
+    # Run any pending migrations
+    run_migrations(conn)
 
 
 def reset_db():

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,265 @@
+"""Tests for database migration system."""
+
+from deadrop import db
+
+
+class TestSchemaVersionTracking:
+    """Tests for schema version tracking functions."""
+
+    def test_get_schema_version_empty_db(self):
+        """Empty database should return version 0."""
+        conn = db.get_connection()
+        # Reset to clean state
+        conn.execute("DROP TABLE IF EXISTS schema_version")
+        conn.commit()
+
+        version = db.get_schema_version(conn)
+        assert version == 0
+
+    def test_record_and_get_migration(self):
+        """Recording a migration should update the version."""
+        conn = db.get_connection()
+        # Reset to clean state
+        conn.execute("DROP TABLE IF EXISTS schema_version")
+        conn.commit()
+
+        db._ensure_schema_version_table(conn)
+        db.record_migration(conn, 1, "Test migration 1")
+
+        version = db.get_schema_version(conn)
+        assert version == 1
+
+    def test_multiple_migrations_return_max_version(self):
+        """get_schema_version returns the highest version number."""
+        conn = db.get_connection()
+        # Reset to clean state
+        conn.execute("DROP TABLE IF EXISTS schema_version")
+        conn.commit()
+
+        db._ensure_schema_version_table(conn)
+        db.record_migration(conn, 1, "Test migration 1")
+        db.record_migration(conn, 2, "Test migration 2")
+        db.record_migration(conn, 3, "Test migration 3")
+
+        version = db.get_schema_version(conn)
+        assert version == 3
+
+
+class TestColumnExists:
+    """Tests for column existence checking."""
+
+    def test_column_exists_true(self):
+        """_column_exists returns True for existing columns."""
+        conn = db.get_connection()
+        # namespaces table should exist after init
+        db.init_db()
+
+        assert db._column_exists(conn, "namespaces", "ns") is True
+        assert db._column_exists(conn, "namespaces", "secret_hash") is True
+
+    def test_column_exists_false(self):
+        """_column_exists returns False for non-existing columns."""
+        conn = db.get_connection()
+        db.init_db()
+
+        assert db._column_exists(conn, "namespaces", "nonexistent_column") is False
+
+
+class TestMigration001ContentType:
+    """Tests for migration 001: add content_type column."""
+
+    def test_migration_adds_column_when_missing(self):
+        """Migration 001 adds content_type column to messages table."""
+        conn = db.get_connection()
+
+        # Create messages table WITHOUT content_type (simulating old schema)
+        conn.executescript("""
+            DROP TABLE IF EXISTS messages;
+            CREATE TABLE messages (
+                mid TEXT PRIMARY KEY,
+                ns TEXT NOT NULL,
+                to_id TEXT NOT NULL,
+                from_id TEXT NOT NULL,
+                body TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                read_at TIMESTAMP,
+                expires_at TIMESTAMP,
+                archived_at TIMESTAMP
+            );
+        """)
+        conn.commit()
+
+        # Verify column doesn't exist
+        assert db._column_exists(conn, "messages", "content_type") is False
+
+        # Run migration
+        db._migrate_001_add_content_type(conn)
+
+        # Verify column now exists
+        assert db._column_exists(conn, "messages", "content_type") is True
+
+    def test_migration_is_idempotent(self):
+        """Running migration 001 twice should not fail."""
+        conn = db.get_connection()
+
+        # Create messages table WITHOUT content_type
+        conn.executescript("""
+            DROP TABLE IF EXISTS messages;
+            CREATE TABLE messages (
+                mid TEXT PRIMARY KEY,
+                ns TEXT NOT NULL,
+                to_id TEXT NOT NULL,
+                from_id TEXT NOT NULL,
+                body TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            );
+        """)
+        conn.commit()
+
+        # Run migration twice - should not error
+        db._migrate_001_add_content_type(conn)
+        db._migrate_001_add_content_type(conn)
+
+        assert db._column_exists(conn, "messages", "content_type") is True
+
+    def test_migration_default_value(self):
+        """New rows should get 'text/plain' as default content_type."""
+        conn = db.get_connection()
+
+        # Create old schema and migrate
+        conn.executescript("""
+            DROP TABLE IF EXISTS messages;
+            CREATE TABLE messages (
+                mid TEXT PRIMARY KEY,
+                ns TEXT NOT NULL,
+                to_id TEXT NOT NULL,
+                from_id TEXT NOT NULL,
+                body TEXT NOT NULL
+            );
+        """)
+        conn.commit()
+
+        db._migrate_001_add_content_type(conn)
+
+        # Insert a row without specifying content_type
+        conn.execute(
+            "INSERT INTO messages (mid, ns, to_id, from_id, body) VALUES (?, ?, ?, ?, ?)",
+            ("test-mid", "test-ns", "to-id", "from-id", "test body"),
+        )
+        conn.commit()
+
+        # Verify default value
+        cursor = conn.execute("SELECT content_type FROM messages WHERE mid = ?", ("test-mid",))
+        row = cursor.fetchone()
+        assert row[0] == "text/plain"
+
+
+class TestRunMigrations:
+    """Tests for the migration runner."""
+
+    def test_run_migrations_on_fresh_db(self):
+        """run_migrations applies all migrations to a fresh database."""
+        conn = db.get_connection()
+
+        # Reset everything
+        conn.executescript("""
+            DROP TABLE IF EXISTS schema_version;
+            DROP TABLE IF EXISTS messages;
+            CREATE TABLE messages (
+                mid TEXT PRIMARY KEY,
+                ns TEXT NOT NULL,
+                to_id TEXT NOT NULL,
+                from_id TEXT NOT NULL,
+                body TEXT NOT NULL
+            );
+        """)
+        conn.commit()
+
+        # Run migrations
+        applied = db.run_migrations(conn)
+
+        # Should have applied migration 1
+        assert 1 in applied
+        assert db.get_schema_version(conn) == 1
+        assert db._column_exists(conn, "messages", "content_type") is True
+
+    def test_run_migrations_skips_already_applied(self):
+        """run_migrations skips migrations that have already been applied."""
+        conn = db.get_connection()
+
+        # Reset and mark migration 1 as already applied
+        conn.executescript("""
+            DROP TABLE IF EXISTS schema_version;
+            DROP TABLE IF EXISTS messages;
+            CREATE TABLE messages (
+                mid TEXT PRIMARY KEY,
+                ns TEXT NOT NULL,
+                to_id TEXT NOT NULL,
+                from_id TEXT NOT NULL,
+                body TEXT NOT NULL,
+                content_type TEXT DEFAULT 'text/plain'
+            );
+        """)
+        conn.commit()
+
+        db._ensure_schema_version_table(conn)
+        db.record_migration(conn, 1, "Already applied")
+
+        # Run migrations - should apply nothing
+        applied = db.run_migrations(conn)
+
+        assert applied == []
+        assert db.get_schema_version(conn) == 1
+
+    def test_run_migrations_idempotent(self):
+        """Running run_migrations multiple times is safe."""
+        conn = db.get_connection()
+
+        # Reset
+        conn.executescript("""
+            DROP TABLE IF EXISTS schema_version;
+            DROP TABLE IF EXISTS messages;
+            CREATE TABLE messages (
+                mid TEXT PRIMARY KEY,
+                ns TEXT NOT NULL,
+                to_id TEXT NOT NULL,
+                from_id TEXT NOT NULL,
+                body TEXT NOT NULL
+            );
+        """)
+        conn.commit()
+
+        # Run migrations twice
+        applied1 = db.run_migrations(conn)
+        applied2 = db.run_migrations(conn)
+
+        # First run applies migration, second run does nothing
+        assert 1 in applied1
+        assert applied2 == []
+        assert db.get_schema_version(conn) == 1
+
+
+class TestInitDbWithMigrations:
+    """Integration tests for init_db with migrations."""
+
+    def test_init_db_runs_migrations(self):
+        """init_db should run migrations after creating tables."""
+        # Reset everything
+        db.reset_db()
+
+        # init_db is called by reset_db, check that content_type exists
+        conn = db.get_connection()
+        assert db._column_exists(conn, "messages", "content_type") is True
+        assert db.get_schema_version(conn) >= 1
+
+    def test_fresh_db_has_all_columns(self):
+        """A fresh database should have all columns including migrated ones."""
+        db.reset_db()
+
+        conn = db.get_connection()
+
+        # Check messages table has content_type
+        assert db._column_exists(conn, "messages", "content_type") is True
+
+        # Schema version should reflect migrations ran
+        assert db.get_schema_version(conn) == db.SCHEMA_VERSION


### PR DESCRIPTION
## Summary

Adds a `content_type` field to messages, allowing senders to specify the MIME type of the message body.

## Changes

- **Database**: Added `content_type` column to messages table with default `text/plain`
- **API**: Added optional `content_type` field to `SendMessageRequest`
- **Responses**: All message responses now include `content_type`

## Supported Content Types

The API accepts any MIME type string. Common examples:
- `text/plain` (default)
- `text/markdown`
- `text/html`
- `application/json`
- `image/svg+xml`
- Any custom type (e.g., `application/x-custom-format`)

## Client Behavior

Clients should:
1. Check `content_type` when rendering messages
2. Implement renderers for known types (markdown→formatted, html→rendered, json→syntax highlighted, svg→graphic)
3. Fall back to plain text rendering for unrecognized types

## Testing

Added 8 new tests covering:
- Default content type behavior
- Sending messages with various content types (markdown, html, json, svg)
- Arbitrary content type support
- Content type preservation in single message view and archived messages

All 99 tests pass.