### PR TITLE
Add room support to web UI

### DIFF
--- a/src/deadrop/api.py
+++ b/src/deadrop/api.py
@@ -1301,6 +1301,21 @@ def app_conversation_page(request: Request, slug: str, peer_id: str):
     return HTMLResponse(f"<h1>Conversation</h1><p>With: {peer_id}</p>")
 
 
+@app.get("/app/{slug}/room/{room_id}", response_class=HTMLResponse)
+def app_room_page(request: Request, slug: str, room_id: str):
+    """Web app - room chat view."""
+    if templates:
+        return templates.TemplateResponse(
+            "app.html",
+            {
+                "request": request,
+                "slug": slug,
+                "room_id": room_id,
+            },
+        )
+    return HTMLResponse(f"<h1>Room</h1><p>Room: {room_id}</p>")
+
+
 @app.get("/app/{slug}/archived", response_class=HTMLResponse)
 def app_archived_page(request: Request, slug: str):
     """Web app - archived messages view."""

--- a/src/deadrop/static/css/style.css
+++ b/src/deadrop/static/css/style.css
@@ -505,3 +505,180 @@ textarea.form-input {
         margin: 40px auto;
     }
 }
+
+/* ==================== ROOM STYLES ==================== */
+
+/* Tab Bar */
+.tab-bar {
+    display: flex;
+    gap: 0;
+    padding: 0 16px;
+    background: var(--card-bg);
+    border-bottom: 1px solid var(--border-color);
+}
+
+.tab-bar .tab {
+    padding: 12px 20px;
+    font-weight: 500;
+    color: var(--text-muted);
+    text-decoration: none;
+    border-bottom: 2px solid transparent;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.tab-bar .tab:hover {
+    color: var(--text-color);
+    background: var(--bg-color);
+}
+
+.tab-bar .tab.active {
+    color: var(--primary-color);
+    border-bottom-color: var(--primary-color);
+}
+
+.tab-bar .tab .badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 18px;
+    height: 18px;
+    padding: 0 6px;
+    margin-left: 6px;
+    font-size: 11px;
+    font-weight: 600;
+    color: white;
+    background: var(--primary-color);
+    border-radius: 9px;
+}
+
+/* Room List Item */
+.room-item {
+    display: flex;
+    align-items: center;
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--border-color);
+    cursor: pointer;
+    transition: background 0.15s ease;
+}
+
+.room-item:hover {
+    background: var(--bg-color);
+}
+
+.room-item .room-icon {
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--primary-color), #7c3aed);
+    color: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 18px;
+    margin-right: 12px;
+    flex-shrink: 0;
+}
+
+.room-item .room-content {
+    flex: 1;
+    min-width: 0;
+}
+
+.room-item .room-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    margin-bottom: 2px;
+}
+
+.room-item .room-name {
+    font-weight: 600;
+    color: var(--text-color);
+}
+
+.room-item .room-time {
+    font-size: 12px;
+    color: var(--text-muted);
+}
+
+.room-item .room-preview {
+    font-size: 14px;
+    color: var(--text-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.room-item.has-unread .room-name {
+    color: var(--text-color);
+}
+
+.room-item .unread-badge {
+    background: var(--primary-color);
+    color: white;
+    font-size: 11px;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: 10px;
+    margin-left: 8px;
+}
+
+/* Room Message (with sender) */
+.room-message {
+    padding: 8px 20px;
+    margin: 4px 0;
+}
+
+.room-message .sender-name {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--primary-color);
+    margin-bottom: 2px;
+}
+
+.room-message.from-me .sender-name {
+    color: var(--text-muted);
+}
+
+.room-message .message-bubble {
+    display: inline-block;
+    max-width: 80%;
+    padding: 10px 14px;
+    border-radius: var(--radius);
+    background: var(--bg-color);
+    word-wrap: break-word;
+}
+
+.room-message.from-me {
+    text-align: right;
+}
+
+.room-message.from-me .message-bubble {
+    background: var(--primary-color);
+    color: white;
+}
+
+.room-message .message-time {
+    font-size: 11px;
+    color: var(--text-muted);
+    margin-top: 4px;
+}
+
+.room-message.from-me .message-time {
+    color: rgba(255, 255, 255, 0.7);
+}
+
+/* Actions toolbar */
+.toolbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 20px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.toolbar-actions {
+    display: flex;
+    gap: 8px;
+}

--- a/src/deadrop/static/js/api.js
+++ b/src/deadrop/static/js/api.js
@@ -108,6 +108,76 @@ const DeadropAPI = {
     async deleteMessage(credentials, mid) {
         return this.request('DELETE', `/${credentials.ns}/inbox/${credentials.id}/${mid}`, { credentials });
     },
+
+    // ==================== ROOM API ====================
+
+    /**
+     * List rooms the user is a member of.
+     */
+    async listRooms(credentials) {
+        return this.request('GET', `/${credentials.ns}/rooms`, { credentials });
+    },
+
+    /**
+     * Get room details.
+     */
+    async getRoom(credentials, roomId) {
+        return this.request('GET', `/${credentials.ns}/rooms/${roomId}`, { credentials });
+    },
+
+    /**
+     * Get room messages.
+     * @param {object} credentials - User credentials
+     * @param {string} roomId - Room ID
+     * @param {object} options - Optional parameters
+     * @param {string} options.afterMid - Get messages after this message ID
+     * @param {number} options.limit - Max messages to return
+     * @param {number} options.wait - Long-poll timeout in seconds
+     */
+    async getRoomMessages(credentials, roomId, { afterMid = null, limit = null, wait = null } = {}) {
+        let path = `/${credentials.ns}/rooms/${roomId}/messages`;
+        const params = new URLSearchParams();
+        if (afterMid) params.set('after', afterMid);
+        if (limit) params.set('limit', limit.toString());
+        if (wait) params.set('wait', wait.toString());
+        if (params.toString()) path += '?' + params.toString();
+        
+        return this.request('GET', path, { credentials });
+    },
+
+    /**
+     * Send a message to a room.
+     */
+    async sendRoomMessage(credentials, roomId, body, contentType = 'text/plain') {
+        return this.request('POST', `/${credentials.ns}/rooms/${roomId}/messages`, {
+            body: { body, content_type: contentType },
+            credentials,
+        });
+    },
+
+    /**
+     * Get unread count for a room.
+     */
+    async getRoomUnread(credentials, roomId) {
+        return this.request('GET', `/${credentials.ns}/rooms/${roomId}/unread`, { credentials });
+    },
+
+    /**
+     * Update read cursor for a room.
+     */
+    async updateRoomReadCursor(credentials, roomId, lastReadMid) {
+        return this.request('POST', `/${credentials.ns}/rooms/${roomId}/read`, {
+            body: { last_read_mid: lastReadMid },
+            credentials,
+        });
+    },
+
+    /**
+     * List room members.
+     */
+    async listRoomMembers(credentials, roomId) {
+        return this.request('GET', `/${credentials.ns}/rooms/${roomId}/members`, { credentials });
+    },
 };
 
 // Export for use in other modules

--- a/src/deadrop/templates/app.html
+++ b/src/deadrop/templates/app.html
@@ -45,9 +45,15 @@
             </div>
         </div>
         
-        <div style="padding: 16px 20px; border-bottom: 1px solid var(--border-color); display: flex; justify-content: space-between; align-items: center;">
-            <span style="font-weight: 600;">Inbox</span>
-            <div style="display: flex; gap: 8px;">
+        <!-- Tab Bar -->
+        <div class="tab-bar">
+            <a href="#" class="tab active" id="tab-inbox">📥 Inbox</a>
+            <a href="#" class="tab" id="tab-rooms">💬 Rooms <span class="badge hidden" id="rooms-badge">0</span></a>
+        </div>
+        
+        <div class="toolbar">
+            <span style="font-weight: 600;" id="inbox-section-title">Inbox</span>
+            <div class="toolbar-actions">
                 <a href="#" id="archived-link" class="btn btn-small btn-secondary">📦 Archived</a>
                 <button id="compose-btn" class="btn btn-small btn-primary">✏️ Compose</button>
             </div>
@@ -66,7 +72,44 @@
         </div>
     </div>
     
-    <!-- Conversation View -->
+    <!-- Rooms List View -->
+    <div id="view-rooms" class="view hidden">
+        <div class="header">
+            <a href="/app" class="back-link" id="rooms-back">←</a>
+            <div>
+                <h1 id="rooms-title">Namespace</h1>
+                <div class="subtitle" id="rooms-subtitle">as Identity</div>
+            </div>
+            <div style="margin-left: auto;">
+                <a href="#" id="rooms-settings" class="btn btn-icon">⚙️</a>
+            </div>
+        </div>
+        
+        <!-- Tab Bar -->
+        <div class="tab-bar">
+            <a href="#" class="tab" id="tab-inbox-2">📥 Inbox</a>
+            <a href="#" class="tab active" id="tab-rooms-2">💬 Rooms <span class="badge hidden" id="rooms-badge-2">0</span></a>
+        </div>
+        
+        <div class="toolbar">
+            <span style="font-weight: 600;">Rooms</span>
+            <div class="toolbar-actions"></div>
+        </div>
+        
+        <div id="rooms-loading" class="loading hidden">
+            <div class="spinner"></div>
+        </div>
+        
+        <div id="room-list"></div>
+        
+        <div id="rooms-empty" class="empty-state hidden">
+            <div class="empty-state-icon">💬</div>
+            <div class="empty-state-title">No rooms yet</div>
+            <p>You're not a member of any rooms.</p>
+        </div>
+    </div>
+    
+    <!-- Conversation View (1:1) -->
     <div id="view-conversation" class="view hidden">
         <div class="header">
             <a href="#" class="back-link" id="conversation-back">←</a>
@@ -79,6 +122,25 @@
             <textarea id="message-input" class="compose-input" 
                       placeholder="Type a message..." rows="1"></textarea>
             <button id="send-btn" class="btn btn-primary">Send ➤</button>
+        </div>
+    </div>
+    
+    <!-- Room Chat View -->
+    <div id="view-room-chat" class="view hidden">
+        <div class="header">
+            <a href="#" class="back-link" id="room-chat-back">←</a>
+            <div>
+                <h1 id="room-chat-title">Room</h1>
+                <div class="subtitle" id="room-chat-members"></div>
+            </div>
+        </div>
+        
+        <div id="room-message-list" class="message-list"></div>
+        
+        <div class="compose-area">
+            <textarea id="room-message-input" class="compose-input" 
+                      placeholder="Type a message..." rows="1"></textarea>
+            <button id="room-send-btn" class="btn btn-primary">Send ➤</button>
         </div>
     </div>
     
@@ -133,20 +195,33 @@
     let currentSlug = {{ slug | tojson if slug else 'null' }};
     let currentPeerId = {{ peer_id | tojson if peer_id is defined and peer_id else 'null' }};
     let currentView = {{ view | tojson if view is defined and view else 'null' }};
+    let currentRoomId = null;
     let credentials = null;
     let peers = [];
     let messages = [];
+    let rooms = [];
+    let roomMessages = [];
+    let roomMembers = {};
+    let roomPollController = null;  // For canceling long-polls
     
     // DOM elements
     const views = {
         namespaces: document.getElementById('view-namespaces'),
         inbox: document.getElementById('view-inbox'),
+        rooms: document.getElementById('view-rooms'),
         conversation: document.getElementById('view-conversation'),
+        roomChat: document.getElementById('view-room-chat'),
         archived: document.getElementById('view-archived'),
     };
     
     // Utility functions
     function showView(name) {
+        // Cancel any ongoing room polling when leaving room view
+        if (name !== 'roomChat' && roomPollController) {
+            roomPollController.abort();
+            roomPollController = null;
+        }
+        
         Object.values(views).forEach(v => v.classList.add('hidden'));
         views[name].classList.remove('hidden');
     }
@@ -167,8 +242,8 @@
     }
     
     function formatExpiry(expiresAt, ttlHours) {
-        if (ttlHours === 0) return null; // Persistent
-        if (!expiresAt) return null; // Unread
+        if (ttlHours === 0) return null;
+        if (!expiresAt) return null;
         
         const remaining = new Date(expiresAt) - new Date();
         if (remaining <= 0) return { text: 'expired', style: 'urgent' };
@@ -186,7 +261,14 @@
         return peer?.metadata?.display_name || id.substring(0, 8) + '...';
     }
     
-    // Namespace list
+    function getMemberName(id) {
+        if (id === credentials?.id) return 'You';
+        const member = roomMembers[id];
+        return member?.display_name || id.substring(0, 8) + '...';
+    }
+    
+    // ==================== NAMESPACE LIST ====================
+    
     function renderNamespaceList() {
         const list = document.getElementById('namespace-list');
         const empty = document.getElementById('no-namespaces');
@@ -214,7 +296,8 @@
         `).join('');
     }
     
-    // Open namespace
+    // ==================== OPEN NAMESPACE ====================
+    
     async function openNamespace(slug) {
         currentSlug = slug;
         credentials = CredentialStore.getCredentials(slug);
@@ -223,20 +306,21 @@
             return;
         }
         
-        // Update URL
         history.pushState({}, '', `/app/${slug}`);
         
-        // Show inbox view
-        document.getElementById('inbox-title').textContent = 
-            CredentialStore.getNamespace(slug)?.displayName || slug;
-        document.getElementById('inbox-subtitle').textContent = 
-            `as ${credentials.displayName || credentials.id.substring(0, 8)}`;
+        const nsDisplay = CredentialStore.getNamespace(slug)?.displayName || slug;
+        document.getElementById('inbox-title').textContent = nsDisplay;
+        document.getElementById('inbox-subtitle').textContent = `as ${credentials.displayName || credentials.id.substring(0, 8)}`;
+        document.getElementById('rooms-title').textContent = nsDisplay;
+        document.getElementById('rooms-subtitle').textContent = `as ${credentials.displayName || credentials.id.substring(0, 8)}`;
         
         showView('inbox');
         loadInbox();
+        loadRoomsInBackground();
     }
     
-    // Load inbox
+    // ==================== INBOX ====================
+    
     async function loadInbox() {
         const loading = document.getElementById('inbox-loading');
         const list = document.getElementById('conversation-list');
@@ -246,7 +330,6 @@
         list.innerHTML = '';
         
         try {
-            // Load peers and messages
             const [peersResult, inboxResult] = await Promise.all([
                 DeadropAPI.listPeers(credentials),
                 DeadropAPI.getInbox(credentials),
@@ -257,7 +340,6 @@
             
             loading.classList.add('hidden');
             
-            // Group by peer
             const conversations = {};
             messages.forEach(msg => {
                 const peerId = msg.from === credentials.id ? msg.to : msg.from;
@@ -270,7 +352,6 @@
                 }
             });
             
-            // Sort by latest message
             const sorted = Object.values(conversations).sort((a, b) => {
                 const aLatest = a.messages[a.messages.length - 1].created_at;
                 const bLatest = b.messages[b.messages.length - 1].created_at;
@@ -312,7 +393,6 @@
         }
     }
     
-    // Open conversation
     function openConversation(peerId) {
         currentPeerId = peerId;
         history.pushState({}, '', `/app/${currentSlug}/${peerId}`);
@@ -322,7 +402,6 @@
         renderConversation();
     }
     
-    // Render conversation
     function renderConversation() {
         const list = document.getElementById('message-list');
         const peerMessages = messages.filter(m => 
@@ -348,11 +427,9 @@
             `;
         }).join('');
         
-        // Scroll to bottom
         list.scrollTop = list.scrollHeight;
     }
     
-    // Send message
     async function sendMessage() {
         const input = document.getElementById('message-input');
         const body = input.value.trim();
@@ -362,7 +439,6 @@
             await DeadropAPI.sendMessage(credentials, currentPeerId, body);
             input.value = '';
             
-            // Refresh inbox
             const result = await DeadropAPI.getInbox(credentials);
             messages = result.messages;
             renderConversation();
@@ -371,7 +447,6 @@
         }
     }
     
-    // Archive message
     async function archiveMessage(mid) {
         if (!confirm('Archive this message?')) return;
         try {
@@ -383,7 +458,6 @@
         }
     }
     
-    // Delete message
     async function deleteMessage(mid) {
         if (!confirm('Delete this message permanently?')) return;
         try {
@@ -395,18 +469,197 @@
         }
     }
     
-    // Compose modal
+    // ==================== ROOMS ====================
+    
+    async function loadRoomsInBackground() {
+        try {
+            const result = await DeadropAPI.listRooms(credentials);
+            rooms = result || [];
+            
+            // Update badge if there are rooms
+            const badge = document.getElementById('rooms-badge');
+            const badge2 = document.getElementById('rooms-badge-2');
+            if (rooms.length > 0) {
+                // Count total unread (we'd need unread API for this)
+                // For now, just show count
+                badge.classList.add('hidden');
+                badge2.classList.add('hidden');
+            }
+        } catch (e) {
+            console.error('Failed to load rooms:', e);
+        }
+    }
+    
+    async function loadRooms() {
+        const loading = document.getElementById('rooms-loading');
+        const list = document.getElementById('room-list');
+        const empty = document.getElementById('rooms-empty');
+        
+        loading.classList.remove('hidden');
+        list.innerHTML = '';
+        
+        try {
+            const result = await DeadropAPI.listRooms(credentials);
+            rooms = result || [];
+            
+            loading.classList.add('hidden');
+            
+            if (rooms.length === 0) {
+                empty.classList.remove('hidden');
+                return;
+            }
+            
+            empty.classList.add('hidden');
+            list.innerHTML = rooms.map(room => `
+                <div class="room-item" onclick="openRoom('${room.room_id}')">
+                    <div class="room-icon">💬</div>
+                    <div class="room-content">
+                        <div class="room-header">
+                            <span class="room-name">${room.display_name || 'Unnamed Room'}</span>
+                            <span class="room-time">${room.created_at ? formatTime(room.created_at) : ''}</span>
+                        </div>
+                        <div class="room-preview">${room.member_count || '?'} members</div>
+                    </div>
+                </div>
+            `).join('');
+            
+        } catch (e) {
+            loading.classList.add('hidden');
+            list.innerHTML = `<div class="error-message">${e.message}</div>`;
+        }
+    }
+    
+    async function openRoom(roomId) {
+        currentRoomId = roomId;
+        history.pushState({}, '', `/app/${currentSlug}/room/${roomId}`);
+        
+        // Load room details and members
+        try {
+            const [roomDetails, members] = await Promise.all([
+                DeadropAPI.getRoom(credentials, roomId),
+                DeadropAPI.listRoomMembers(credentials, roomId),
+            ]);
+            
+            document.getElementById('room-chat-title').textContent = roomDetails.display_name || 'Room';
+            
+            // Build member map for name lookups
+            roomMembers = {};
+            (members || []).forEach(m => {
+                roomMembers[m.identity_id] = m;
+            });
+            
+            document.getElementById('room-chat-members').textContent = 
+                `${Object.keys(roomMembers).length} members`;
+            
+            showView('roomChat');
+            await loadRoomMessages();
+            startRoomPolling();
+            
+        } catch (e) {
+            alert('Failed to open room: ' + e.message);
+        }
+    }
+    
+    async function loadRoomMessages() {
+        const list = document.getElementById('room-message-list');
+        
+        try {
+            const result = await DeadropAPI.getRoomMessages(credentials, currentRoomId);
+            roomMessages = result || [];
+            renderRoomMessages();
+        } catch (e) {
+            list.innerHTML = `<div class="error-message">${e.message}</div>`;
+        }
+    }
+    
+    function renderRoomMessages() {
+        const list = document.getElementById('room-message-list');
+        
+        list.innerHTML = roomMessages.map(msg => {
+            const isMe = msg.from_id === credentials.id;
+            
+            return `
+                <div class="room-message ${isMe ? 'from-me' : ''}">
+                    <div class="sender-name">${getMemberName(msg.from_id)}</div>
+                    <div class="message-bubble">${msg.body}</div>
+                    <div class="message-time">${formatTime(msg.created_at)}</div>
+                </div>
+            `;
+        }).join('');
+        
+        list.scrollTop = list.scrollHeight;
+        
+        // Update read cursor
+        if (roomMessages.length > 0) {
+            const lastMid = roomMessages[roomMessages.length - 1].mid;
+            DeadropAPI.updateRoomReadCursor(credentials, currentRoomId, lastMid).catch(() => {});
+        }
+    }
+    
+    async function sendRoomMessage() {
+        const input = document.getElementById('room-message-input');
+        const body = input.value.trim();
+        if (!body) return;
+        
+        try {
+            await DeadropAPI.sendRoomMessage(credentials, currentRoomId, body);
+            input.value = '';
+            
+            // Reload messages
+            await loadRoomMessages();
+        } catch (e) {
+            alert('Failed to send: ' + e.message);
+        }
+    }
+    
+    function startRoomPolling() {
+        if (roomPollController) {
+            roomPollController.abort();
+        }
+        
+        roomPollController = new AbortController();
+        pollRoomMessages(roomPollController.signal);
+    }
+    
+    async function pollRoomMessages(signal) {
+        while (!signal.aborted) {
+            try {
+                const afterMid = roomMessages.length > 0 ? roomMessages[roomMessages.length - 1].mid : null;
+                
+                // Use long-polling (wait up to 30 seconds)
+                const result = await DeadropAPI.getRoomMessages(credentials, currentRoomId, {
+                    afterMid,
+                    wait: 30,
+                });
+                
+                if (signal.aborted) break;
+                
+                if (result && result.length > 0) {
+                    // Add new messages
+                    roomMessages = [...roomMessages, ...result];
+                    renderRoomMessages();
+                }
+                
+            } catch (e) {
+                if (signal.aborted) break;
+                console.error('Room poll error:', e);
+                // Wait a bit before retrying on error
+                await new Promise(r => setTimeout(r, 5000));
+            }
+        }
+    }
+    
+    // ==================== COMPOSE MODAL ====================
+    
     function showCompose() {
         const modal = document.getElementById('compose-modal');
         const select = document.getElementById('compose-to');
         
-        // Populate peer list
         select.innerHTML = peers
             .filter(p => p.id !== credentials.id)
             .map(p => `<option value="${p.id}">${p.metadata?.display_name || p.id}</option>`)
             .join('');
         
-        // Add self option for notes
         select.innerHTML += `<option value="${credentials.id}">Notes to Self</option>`;
         
         modal.classList.remove('hidden');
@@ -432,13 +685,43 @@
         }
     }
     
-    // Event listeners
+    // ==================== TAB NAVIGATION ====================
+    
+    function switchToInbox() {
+        document.getElementById('tab-inbox').classList.add('active');
+        document.getElementById('tab-inbox-2').classList.add('active');
+        document.getElementById('tab-rooms').classList.remove('active');
+        document.getElementById('tab-rooms-2').classList.remove('active');
+        showView('inbox');
+        history.pushState({}, '', `/app/${currentSlug}`);
+    }
+    
+    function switchToRooms() {
+        document.getElementById('tab-inbox').classList.remove('active');
+        document.getElementById('tab-inbox-2').classList.remove('active');
+        document.getElementById('tab-rooms').classList.add('active');
+        document.getElementById('tab-rooms-2').classList.add('active');
+        showView('rooms');
+        loadRooms();
+        history.pushState({}, '', `/app/${currentSlug}/rooms`);
+    }
+    
+    // ==================== EVENT LISTENERS ====================
+    
     document.getElementById('invite-go-btn').addEventListener('click', () => {
         const url = document.getElementById('invite-url-input').value.trim();
         if (url) window.location.href = url;
     });
     
     document.getElementById('inbox-back').addEventListener('click', (e) => {
+        e.preventDefault();
+        history.pushState({}, '', '/app');
+        currentSlug = null;
+        showView('namespaces');
+        renderNamespaceList();
+    });
+    
+    document.getElementById('rooms-back').addEventListener('click', (e) => {
         e.preventDefault();
         history.pushState({}, '', '/app');
         currentSlug = null;
@@ -453,6 +736,18 @@
         showView('inbox');
     });
     
+    document.getElementById('room-chat-back').addEventListener('click', (e) => {
+        e.preventDefault();
+        currentRoomId = null;
+        switchToRooms();
+    });
+    
+    // Tab navigation
+    document.getElementById('tab-inbox').addEventListener('click', (e) => { e.preventDefault(); switchToInbox(); });
+    document.getElementById('tab-inbox-2').addEventListener('click', (e) => { e.preventDefault(); switchToInbox(); });
+    document.getElementById('tab-rooms').addEventListener('click', (e) => { e.preventDefault(); switchToRooms(); });
+    document.getElementById('tab-rooms-2').addEventListener('click', (e) => { e.preventDefault(); switchToRooms(); });
+    
     document.getElementById('compose-btn').addEventListener('click', showCompose);
     document.getElementById('compose-cancel').addEventListener('click', hideCompose);
     document.getElementById('compose-close').addEventListener('click', hideCompose);
@@ -463,6 +758,14 @@
         if (e.key === 'Enter' && !e.shiftKey) {
             e.preventDefault();
             sendMessage();
+        }
+    });
+    
+    document.getElementById('room-send-btn').addEventListener('click', sendRoomMessage);
+    document.getElementById('room-message-input').addEventListener('keypress', (e) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            sendRoomMessage();
         }
     });
     
@@ -513,14 +816,14 @@
     async function unarchiveMessage(mid) {
         try {
             await DeadropAPI.unarchiveMessage(credentials, mid);
-            // Refresh archived list
             document.getElementById('archived-link').click();
         } catch (e) {
             alert('Failed to restore: ' + e.message);
         }
     }
     
-    // Initialize
+    // ==================== INITIALIZE ====================
+    
     function init() {
         if (currentSlug) {
             credentials = CredentialStore.getCredentials(currentSlug);

--- a/src/deadrop/templates/app.html
+++ b/src/deadrop/templates/app.html
@@ -195,7 +195,7 @@
     let currentSlug = {{ slug | tojson if slug else 'null' }};
     let currentPeerId = {{ peer_id | tojson if peer_id is defined and peer_id else 'null' }};
     let currentView = {{ view | tojson if view is defined and view else 'null' }};
-    let currentRoomId = null;
+    let currentRoomId = {{ room_id | tojson if room_id is defined and room_id else 'null' }};
     let credentials = null;
     let peers = [];
     let messages = [];
@@ -833,6 +833,9 @@
                         CredentialStore.getNamespace(currentSlug)?.displayName || currentSlug;
                     showView('archived');
                     document.getElementById('archived-link').click();
+                } else if (currentRoomId) {
+                    // Deep link to room
+                    openNamespace(currentSlug).then(() => openRoom(currentRoomId));
                 } else if (currentPeerId) {
                     openNamespace(currentSlug).then(() => openConversation(currentPeerId));
                 } else {


### PR DESCRIPTION
## Summary
Adds room (group chat) support to the deaddrop web UI.

## Changes
- **api.js**: Added 7 room API methods (listRooms, getRoomMessages, sendRoomMessage, etc.)
- **app.html**: Added room list view, room chat view, tab navigation between Inbox/Rooms
- **style.css**: Added styles for tabs, room list items, room messages with sender names
- **api.py**: Added `/app/{slug}/room/{room_id}` route for deep-linking

## Features
- Tab navigation between Inbox and Rooms
- Room list showing all rooms you're a member of
- Room chat view with sender names on each message
- Real-time updates via long-polling (30s wait)
- Deep-link support for direct room URLs

## Testing
- Manual testing with local server
- Room created and tested with Twin namespace