### PR TITLE
perf: optimize room endpoints with caching and combined queries

### DIFF
--- a/src/deadrop/cache.py
+++ b/src/deadrop/cache.py
@@ -1,0 +1,185 @@
+"""In-memory caching with TTL for deadrop.
+
+This module provides a simple TTL-based cache that doesn't require external
+dependencies. It's designed for caching auth-related data to reduce database
+round-trips.
+
+Cache keys are designed to be invalidated when the underlying data changes.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, TypeVar
+
+from .metrics import metrics
+
+T = TypeVar("T")
+
+
+@dataclass
+class CacheEntry:
+    """A single cache entry with expiration."""
+
+    value: Any
+    expires_at: float
+
+    def is_expired(self) -> bool:
+        return time.time() > self.expires_at
+
+
+@dataclass
+class TTLCache:
+    """Thread-safe TTL cache.
+
+    Args:
+        name: Name of the cache (for metrics)
+        default_ttl: Default TTL in seconds
+        max_size: Maximum number of entries (LRU eviction when exceeded)
+    """
+
+    name: str
+    default_ttl: float = 60.0
+    max_size: int = 1000
+    _data: dict[str, CacheEntry] = field(default_factory=dict)
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+    _access_order: list[str] = field(default_factory=list)
+
+    def get(self, key: str) -> tuple[bool, Any]:
+        """Get a value from the cache.
+
+        Returns:
+            (hit, value) tuple. If hit is False, value is None.
+        """
+        with self._lock:
+            entry = self._data.get(key)
+            if entry is None:
+                metrics.record_cache_miss(self.name)
+                return False, None
+
+            if entry.is_expired():
+                del self._data[key]
+                if key in self._access_order:
+                    self._access_order.remove(key)
+                metrics.record_cache_miss(self.name)
+                return False, None
+
+            # Update access order for LRU
+            if key in self._access_order:
+                self._access_order.remove(key)
+            self._access_order.append(key)
+
+            metrics.record_cache_hit(self.name)
+            return True, entry.value
+
+    def set(self, key: str, value: Any, ttl: float | None = None) -> None:
+        """Set a value in the cache.
+
+        Args:
+            key: Cache key
+            value: Value to cache
+            ttl: TTL in seconds (uses default_ttl if not specified)
+        """
+        if ttl is None:
+            ttl = self.default_ttl
+
+        with self._lock:
+            # Evict expired entries periodically
+            if len(self._data) >= self.max_size:
+                self._evict_expired()
+
+            # If still at max, evict LRU
+            while len(self._data) >= self.max_size and self._access_order:
+                oldest_key = self._access_order.pop(0)
+                self._data.pop(oldest_key, None)
+
+            self._data[key] = CacheEntry(
+                value=value,
+                expires_at=time.time() + ttl,
+            )
+            if key in self._access_order:
+                self._access_order.remove(key)
+            self._access_order.append(key)
+
+    def delete(self, key: str) -> bool:
+        """Delete a key from the cache.
+
+        Returns:
+            True if the key existed.
+        """
+        with self._lock:
+            if key in self._data:
+                del self._data[key]
+                if key in self._access_order:
+                    self._access_order.remove(key)
+                return True
+            return False
+
+    def invalidate_prefix(self, prefix: str) -> int:
+        """Invalidate all keys starting with a prefix.
+
+        Returns:
+            Number of keys invalidated.
+        """
+        with self._lock:
+            keys_to_delete = [k for k in self._data if k.startswith(prefix)]
+            for key in keys_to_delete:
+                del self._data[key]
+                if key in self._access_order:
+                    self._access_order.remove(key)
+            return len(keys_to_delete)
+
+    def clear(self) -> None:
+        """Clear all entries from the cache."""
+        with self._lock:
+            self._data.clear()
+            self._access_order.clear()
+
+    def _evict_expired(self) -> None:
+        """Evict all expired entries. Must be called with lock held."""
+        now = time.time()
+        expired_keys = [k for k, v in self._data.items() if v.expires_at <= now]
+        for key in expired_keys:
+            del self._data[key]
+            if key in self._access_order:
+                self._access_order.remove(key)
+
+    def stats(self) -> dict:
+        """Get cache statistics."""
+        with self._lock:
+            return {
+                "size": len(self._data),
+                "max_size": self.max_size,
+            }
+
+
+# Global cache instances
+# Room info cache - rooms rarely change
+room_cache = TTLCache(name="room", default_ttl=300.0, max_size=500)  # 5 min TTL
+
+# Room membership cache - memberships change occasionally
+membership_cache = TTLCache(name="membership", default_ttl=60.0, max_size=2000)  # 1 min TTL
+
+# Identity hash cache - secret hashes never change (identity would be deleted and recreated)
+identity_hash_cache = TTLCache(name="identity_hash", default_ttl=600.0, max_size=1000)  # 10 min TTL
+
+
+def invalidate_room(room_id: str) -> None:
+    """Invalidate all caches related to a room."""
+    room_cache.delete(f"room:{room_id}")
+    membership_cache.invalidate_prefix(f"member:{room_id}:")
+
+
+def invalidate_identity(ns: str, identity_id: str) -> None:
+    """Invalidate all caches related to an identity."""
+    identity_hash_cache.delete(f"identity:{ns}:{identity_id}")
+    membership_cache.invalidate_prefix("member:")  # Broad invalidation
+
+
+def clear_all_caches() -> None:
+    """Clear all caches (useful for testing)."""
+    room_cache.clear()
+    membership_cache.clear()
+    identity_hash_cache.clear()

--- a/src/deadrop/metrics.py
+++ b/src/deadrop/metrics.py
@@ -1,0 +1,182 @@
+"""Simple metrics and telemetry for deadrop.
+
+This module provides:
+- Request timing middleware
+- Database operation timing
+- Cache hit/miss tracking
+- Simple in-memory metrics that can be exposed via an endpoint
+
+Metrics are designed to be lightweight and not require external dependencies.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections import defaultdict
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from functools import wraps
+from threading import Lock
+from typing import Any, Callable, TypeVar
+
+logger = logging.getLogger(__name__)
+
+# Type variable for generic function decoration
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+@dataclass
+class TimingStats:
+    """Statistics for a timed operation."""
+
+    count: int = 0
+    total_ms: float = 0.0
+    min_ms: float = float("inf")
+    max_ms: float = 0.0
+
+    def record(self, duration_ms: float) -> None:
+        """Record a timing measurement."""
+        self.count += 1
+        self.total_ms += duration_ms
+        self.min_ms = min(self.min_ms, duration_ms)
+        self.max_ms = max(self.max_ms, duration_ms)
+
+    @property
+    def avg_ms(self) -> float:
+        """Average duration in milliseconds."""
+        return self.total_ms / self.count if self.count > 0 else 0.0
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "count": self.count,
+            "total_ms": round(self.total_ms, 2),
+            "avg_ms": round(self.avg_ms, 2),
+            "min_ms": round(self.min_ms, 2) if self.count > 0 else 0,
+            "max_ms": round(self.max_ms, 2),
+        }
+
+
+@dataclass
+class CacheStats:
+    """Statistics for cache operations."""
+
+    hits: int = 0
+    misses: int = 0
+
+    def record_hit(self) -> None:
+        self.hits += 1
+
+    def record_miss(self) -> None:
+        self.misses += 1
+
+    @property
+    def hit_rate(self) -> float:
+        """Cache hit rate as a percentage."""
+        total = self.hits + self.misses
+        return (self.hits / total * 100) if total > 0 else 0.0
+
+    def to_dict(self) -> dict:
+        return {
+            "hits": self.hits,
+            "misses": self.misses,
+            "hit_rate_pct": round(self.hit_rate, 2),
+        }
+
+
+@dataclass
+class Metrics:
+    """Global metrics collector."""
+
+    _lock: Lock = field(default_factory=Lock)
+    db_operations: dict[str, TimingStats] = field(default_factory=lambda: defaultdict(TimingStats))
+    cache_stats: dict[str, CacheStats] = field(default_factory=lambda: defaultdict(CacheStats))
+    request_stats: dict[str, TimingStats] = field(default_factory=lambda: defaultdict(TimingStats))
+    _start_time: float = field(default_factory=time.time)
+
+    def record_db_operation(self, operation: str, duration_ms: float) -> None:
+        """Record a database operation timing."""
+        with self._lock:
+            self.db_operations[operation].record(duration_ms)
+
+    def record_cache_hit(self, cache_name: str) -> None:
+        """Record a cache hit."""
+        with self._lock:
+            self.cache_stats[cache_name].record_hit()
+
+    def record_cache_miss(self, cache_name: str) -> None:
+        """Record a cache miss."""
+        with self._lock:
+            self.cache_stats[cache_name].record_miss()
+
+    def record_request(self, endpoint: str, duration_ms: float) -> None:
+        """Record a request timing."""
+        with self._lock:
+            self.request_stats[endpoint].record(duration_ms)
+
+    def to_dict(self) -> dict:
+        """Export metrics as a dictionary."""
+        with self._lock:
+            return {
+                "uptime_seconds": round(time.time() - self._start_time, 1),
+                "db_operations": {k: v.to_dict() for k, v in self.db_operations.items()},
+                "cache": {k: v.to_dict() for k, v in self.cache_stats.items()},
+                "requests": {k: v.to_dict() for k, v in self.request_stats.items()},
+            }
+
+    def reset(self) -> None:
+        """Reset all metrics (useful for testing)."""
+        with self._lock:
+            self.db_operations.clear()
+            self.cache_stats.clear()
+            self.request_stats.clear()
+            self._start_time = time.time()
+
+
+# Global metrics instance
+metrics = Metrics()
+
+
+@contextmanager
+def timed_db_operation(operation: str):
+    """Context manager to time a database operation.
+
+    Usage:
+        with timed_db_operation("get_room"):
+            cursor = conn.execute(...)
+    """
+    start = time.perf_counter()
+    try:
+        yield
+    finally:
+        duration_ms = (time.perf_counter() - start) * 1000
+        metrics.record_db_operation(operation, duration_ms)
+        if duration_ms > 100:  # Log slow queries
+            logger.warning(f"Slow DB operation: {operation} took {duration_ms:.1f}ms")
+
+
+def timed_operation(operation_name: str) -> Callable[[F], F]:
+    """Decorator to time a function and record as a DB operation.
+
+    Usage:
+        @timed_operation("get_room")
+        def get_room(room_id: str) -> dict | None:
+            ...
+    """
+
+    def decorator(func: F) -> F:
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            start = time.perf_counter()
+            try:
+                return func(*args, **kwargs)
+            finally:
+                duration_ms = (time.perf_counter() - start) * 1000
+                metrics.record_db_operation(operation_name, duration_ms)
+                if duration_ms > 100:
+                    logger.warning(f"Slow operation: {operation_name} took {duration_ms:.1f}ms")
+
+        return wrapper  # type: ignore
+
+    return decorator


### PR DESCRIPTION
## Problem

Room endpoints were unacceptably slow in production (~300-400ms per request). Investigation revealed:

- **3-4 sequential database round-trips** per request
- Each round-trip to Turso takes **~70-90ms** due to network latency
- Auth checks alone consuming **~170ms (69% of request time)**
- Total request latency: **~250ms** for simple room message fetches

## Root Cause

The `require_room_member()` function was making 3 separate sequential DB calls:
1. `db.get_room()` - ~80ms
2. `db.is_room_member()` - ~70ms  
3. `db.verify_identity_secret()` - ~70ms

Plus the actual data fetch (e.g., `get_room_messages()`) - another ~80ms.

## Solution

### 1. TTL-based In-Memory Caching (new `cache.py`)
- **Room info**: 5 min TTL - rooms rarely change
- **Room membership**: 1 min TTL - memberships change occasionally
- **Identity secret hashes**: 10 min TTL - never change (identity deleted/recreated)

### 2. Combined Query (`verify_room_access()`)
Single query that fetches room info, membership, and identity hash via JOINs - reduces 3 round-trips to 1.

### 3. Metrics/Telemetry (new `metrics.py`)
- Request timing middleware with `X-Response-Time-Ms` header
- Database operation timing
- Cache hit/miss rates
- `/metrics` endpoint for monitoring (requires admin auth)

## Results

Benchmarked against Turso (production database):

| Scenario | Latency | Improvement |
|----------|---------|-------------|
| Old approach (3 DB calls) | 246ms | baseline |
| New approach (cold cache) | 128ms | **48% faster** |
| New approach (warm cache) | 89ms | **64% faster** |

Auth overhead reduction: **169ms → 0.02ms** on cache hit

## Testing

- All 343 tests pass
- Local benchmarks with Apache Bench show consistent performance
- Metrics endpoint confirms cache hit rates >99% under load

## Files Changed

- `src/deadrop/cache.py` (new): TTL cache implementation with LRU eviction
- `src/deadrop/metrics.py` (new): Metrics collection and timing utilities
- `src/deadrop/db.py`: Added `verify_room_access()` combined query + cached variants
- `src/deadrop/api.py`: Updated `require_room_member()`, added middleware and `/metrics` endpoint
