### PR TITLE
feat: subscription system with vector clock polling and SSE streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ pip install deaddrop[turso]
 - **Identity/Mailbox**: An agent's inbox within a namespace. ID is derived from a secret (`id = hash(secret)[:16]`).
 - **Message**: A blob sent from one identity to another within a namespace. Uses UUIDv7 (timestamp-sortable).
 - **Room**: A shared space for multi-user group messaging. Any member can read/write. See [docs/ROOMS.md](docs/ROOMS.md).
+- **Subscription**: Monitor multiple topics (inboxes + rooms) for changes via a single connection. See [docs/SUBSCRIPTIONS.md](docs/SUBSCRIPTIONS.md).
 
 ## Auth Model
 
@@ -428,6 +429,20 @@ POST /{ns}/rooms/{room_id}/read
 
 # Get unread count
 GET /{ns}/rooms/{room_id}/unread
+```
+
+### Subscription Endpoint
+
+Subscribe to changes across multiple topics (inboxes and rooms) with a single connection. See [docs/SUBSCRIPTIONS.md](docs/SUBSCRIPTIONS.md) for full details.
+
+```bash
+# Poll mode: blocks until event or timeout
+POST /{ns}/subscribe
+{"topics": {"inbox:{id}": null, "room:{room_id}": null}, "mode": "poll", "timeout": 30}
+
+# Stream mode: returns Server-Sent Events
+POST /{ns}/subscribe
+{"topics": {"inbox:{id}": null, "room:{room_id}": null}, "mode": "stream"}
 ```
 
 ## Environment Variables

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -348,6 +348,58 @@ print(f'Alice invite: http://localhost:8000/join/{secrets.invite_id}#{secrets.ke
 
 ---
 
+## Listening for Messages (Subscriptions)
+
+Instead of polling individual inboxes and rooms, you can use the **subscription system** to monitor everything at once.
+
+### Via CLI
+
+```bash
+# Listen to all topics (inbox + rooms)
+deadrop listen <namespace>
+
+# Output:
+# Subscribing to: inbox:abc123, room:def456, room:ghi789
+# Waiting for events... (Ctrl+C to stop)
+#
+# [room:def45678] alice123: Hello everyone!
+# [inbox] bob98765: Hey, got your message
+
+# JSON output for piping to other tools
+deadrop listen <namespace> --json-output
+```
+
+### Via Python
+
+```python
+from deadrop import Deaddrop
+
+client = Deaddrop.remote(url="https://deaddrop.example.com")
+
+# Monitor multiple topics simultaneously
+topics = {
+    f"inbox:{my_id}": None,       # Subscribe to my inbox
+    f"room:{room_id}": None,      # Subscribe to a room
+}
+
+for topic, mid in client.listen_all(ns, secret, topics):
+    print(f"New activity on {topic}")
+```
+
+### Via REST API
+
+```bash
+# Poll mode (blocks until event or timeout)
+curl -X POST "http://localhost:8000/{ns}/subscribe" \
+  -H "Content-Type: application/json" \
+  -H "X-Inbox-Secret: {secret}" \
+  -d '{"topics": {"inbox:{id}": null, "room:{room_id}": null}, "timeout": 30}'
+```
+
+See [docs/SUBSCRIPTIONS.md](SUBSCRIPTIONS.md) for full details on the subscription system.
+
+---
+
 ## Security Considerations
 
 - **Invite links are single-use**: Once claimed, they cannot be reused

--- a/docs/ROOMS.md
+++ b/docs/ROOMS.md
@@ -280,6 +280,28 @@ client.send_room_message(
 # No need to CC the moderator on every message!
 ```
 
+## Subscribing to Room Changes
+
+For monitoring multiple rooms (and your inbox) simultaneously, use the **subscription system** instead of per-room long-polling. See [SUBSCRIPTIONS.md](SUBSCRIPTIONS.md) for full details.
+
+```python
+# Subscribe to inbox + all rooms at once
+topics = {
+    f"inbox:{my_id}": None,
+    f"room:{room1_id}": None,
+    f"room:{room2_id}": None,
+}
+
+for topic, mid in client.listen_all(ns, secret, topics):
+    if topic.startswith("room:"):
+        room_id = topic.split(":", 1)[1]
+        messages = client.get_room_messages(ns, room_id, secret, after_mid=mid)
+        for msg in messages:
+            print(f"[{room_id}] {msg['from_id']}: {msg['body']}")
+```
+
+This is more efficient than running separate `listen_room()` calls per room, as it uses a single connection for all topics.
+
 ## Rooms vs 1:1 Messaging
 
 | Feature | 1:1 Messaging | Rooms |

--- a/docs/SUBSCRIPTIONS.md
+++ b/docs/SUBSCRIPTIONS.md
@@ -1,0 +1,282 @@
+# Subscriptions
+
+Deadrop supports a **subscription system** that lets clients efficiently monitor multiple topics (inboxes and rooms) for new messages through a single connection, rather than making separate long-poll requests per topic.
+
+## Concepts
+
+### Vector Clock
+
+Clients subscribe by providing a **vector clock** — a map of topic keys to the last message ID they've seen on that topic. The server compares this against its own state and reports which topics have new activity.
+
+```json
+{
+    "inbox:fa3b2109": "01961234-0000-7000-8000-000000000001",
+    "room:abc123":    "01961235-0000-7000-8000-000000000042",
+    "room:def456":    null
+}
+```
+
+- Each key is a **topic** (`inbox:{identity_id}` or `room:{room_id}`)
+- Each value is the **last seen message ID** (`null` = never seen, notify on any activity)
+- UUIDv7 message IDs are lexicographically sortable, so `mid > last_seen` is a valid "has changes" check
+
+### Events, Not Payloads
+
+The subscription system returns **events** (which topics changed), not message contents. Clients are responsible for:
+
+1. Receiving the event notification
+2. Fetching content from the changed topic via existing REST endpoints (using the cursor)
+3. Updating their local cursor with the latest message ID from the fetch
+
+This keeps the subscription system simple and avoids duplicating auth checks for message content.
+
+### Topic Keys
+
+| Format | Description | Access Rule |
+|--------|-------------|-------------|
+| `inbox:{identity_id}` | Direct message inbox | Only the inbox owner |
+| `room:{room_id}` | Chat room | Any room member |
+
+## API Reference
+
+### `POST /{ns}/subscribe`
+
+Subscribe to topic changes within a namespace.
+
+**Auth**: `X-Inbox-Secret` header required. Must be a valid identity in the namespace.
+
+#### Request Body
+
+```json
+{
+    "topics": {
+        "inbox:fa3b2109": "01961234-0000-7000-8000-000000000001",
+        "room:abc123": null
+    },
+    "mode": "poll",
+    "timeout": 30
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `topics` | `object` | *required* | Map of topic_key → last_seen_mid (null = never seen) |
+| `mode` | `string` | `"poll"` | `"poll"` or `"stream"` |
+| `timeout` | `integer` | `30` | Seconds to wait (1-60, poll mode only) |
+
+#### Poll Mode Response
+
+Blocks until any topic has new messages or timeout is reached.
+
+```json
+{
+    "events": {
+        "room:abc123": "01961299-0000-7000-8000-000000000099"
+    },
+    "timeout": false
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `events` | `object` | Map of changed topic_key → latest_mid |
+| `timeout` | `boolean` | `true` if no events before timeout |
+
+#### Stream Mode (SSE)
+
+Returns a `text/event-stream` response for continuous Server-Sent Events:
+
+```
+event: connected
+data: {}
+
+event: change
+data: {"topic": "room:abc123", "latest_mid": "01961299-0000-7000-8000-000000000099"}
+
+event: change
+data: {"topic": "inbox:fa3b2109", "latest_mid": "01961300-0000-7000-8000-000000000100"}
+```
+
+Events:
+- `connected` — Initial event confirming the stream is active
+- `change` — A topic has new messages
+
+#### Error Responses
+
+| Status | Reason |
+|--------|--------|
+| 400 | Invalid topic format, unknown topic type, or empty topics |
+| 401 | Missing `X-Inbox-Secret` header |
+| 403 | Invalid secret, subscribing to another identity's inbox, or not a room member |
+| 404 | Room not found in this namespace |
+
+## Client Usage
+
+### Python
+
+#### Poll Mode
+
+```python
+from deadrop import Deaddrop
+
+client = Deaddrop.remote(url="https://deaddrop.example.com")
+
+# Subscribe to inbox + rooms
+result = client.subscribe(
+    ns=ns_id,
+    secret=my_secret,
+    topics={
+        f"inbox:{my_id}": last_inbox_mid,  # or None if starting fresh
+        f"room:{room_id}": last_room_mid,
+    },
+    timeout=30,
+)
+
+if not result["timeout"]:
+    for topic, mid in result["events"].items():
+        print(f"New activity on {topic} (latest: {mid})")
+```
+
+#### listen_all() — Continuous Monitoring
+
+```python
+# Monitor multiple topics with automatic cursor tracking
+topics = {
+    f"inbox:{my_id}": None,
+    f"room:{room1_id}": None,
+    f"room:{room2_id}": None,
+}
+
+for topic, mid in client.listen_all(ns, secret, topics):
+    if topic.startswith("inbox:"):
+        messages = client.get_inbox(ns, my_id, secret, after_mid=mid)
+        for msg in messages:
+            print(f"DM from {msg['from']}: {msg['body']}")
+    elif topic.startswith("room:"):
+        room_id = topic.split(":", 1)[1]
+        messages = client.get_room_messages(ns, room_id, secret, after_mid=mid)
+        for msg in messages:
+            print(f"[{room_id}] {msg['from_id']}: {msg['body']}")
+```
+
+#### Streaming Mode
+
+```python
+for event in client.subscribe_stream(ns, secret, topics):
+    print(f"Change on {event['topic']}: {event['latest_mid']}")
+```
+
+### JavaScript (Web Client)
+
+The web client includes a `SubscriptionManager` class that handles SSE streaming with automatic reconnection:
+
+```javascript
+const manager = new SubscriptionManager(credentials);
+
+manager.onEvent = (topic, latestMid) => {
+    console.log(`New activity on ${topic}`);
+    // Fetch content from the changed topic
+};
+
+manager.onStatusChange = (status) => {
+    console.log(`Connection: ${status}`);  // connecting, connected, polling, reconnecting, disconnected
+};
+
+// Build topics and start
+const topics = manager.buildTopics(roomIds, /* includeInbox */ true);
+manager.start(topics);
+
+// Later: stop
+manager.stop();
+```
+
+The manager:
+- Tries SSE first, falls back to poll mode
+- Reconnects automatically with exponential backoff
+- Tracks cursors in `localStorage`
+- Pauses when `stop()` is called
+
+### CLI
+
+```bash
+# Listen to inbox + all rooms
+deadrop listen <namespace>
+
+# Listen to inbox only
+deadrop listen <namespace> --inbox
+
+# Listen to rooms only
+deadrop listen <namespace> --rooms
+
+# JSON output for piping
+deadrop listen <namespace> --json-output
+
+# Specify identity
+deadrop listen <namespace> --identity-id <id>
+```
+
+Output:
+```
+Subscribing to: inbox:fa3b2109, room:abc123, room:def456
+Waiting for events... (Ctrl+C to stop)
+
+[room:abc12345] alice123: Hello everyone!
+[inbox] bob98765: Hey there, got a question
+```
+
+## Reconnection & Cursor Management
+
+### Best Practices
+
+1. **Always track cursors**: Store the latest message ID for each topic after every fetch
+2. **Use cursors on reconnect**: When the subscription connection drops, reconnect with your current cursors to avoid missing messages
+3. **Fetch with cursors**: When fetching content after an event, pass the `after` parameter to only get new messages
+4. **Handle stale cursors**: If a cursor is very old, the server will still correctly report that topic has changes
+
+### Reconnection Flow
+
+```
+1. Connect with initial cursors (null for fresh start)
+2. Receive event: topic X has new messages
+3. Fetch topic X content (with after=cursor)
+4. Update cursor for topic X
+5. Connection drops
+6. Reconnect with updated cursors
+7. Server immediately reports any changes since last cursor
+```
+
+## Architecture
+
+### Event Bus
+
+The subscription system uses an **event bus** abstraction:
+
+```
+EventBus (ABC)
+└── InMemoryEventBus  (current: asyncio.Condition-based)
+└── RedisEventBus     (future: Redis pub/sub)
+```
+
+The in-memory implementation is suitable for single-instance deployments. The interface is designed so a Redis-backed implementation can be swapped in later without changing any callers.
+
+### How Events Flow
+
+```
+Client sends message
+    → API handler (send_message / send_room_message)
+        → db.send_message() / db.send_room_message()
+        → event_bus.publish(ns, topic, mid)
+            → Notify all waiting subscribers
+
+Subscriber waiting on subscribe()
+    → event_bus wakes subscriber
+    → Returns changed topics with latest mids
+    → Client fetches content via existing endpoints
+```
+
+### Performance
+
+- **O(1)** for publish (update latest mid, notify condition)
+- **O(topics)** for subscribe check (compare each topic's cursor)
+- **No busy-polling**: uses `asyncio.Condition` for efficient waiting
+- Replaces N separate long-poll connections with 1 subscription connection

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev = [
     "pre-commit>=4.2.0",
     "ruff>=0.9.0",
     "ty>=0.0.11",
+    "pytest-asyncio>=1.3.0",
 ]
 
 [tool.pytest.ini_options]

--- a/src/deadrop/events.py
+++ b/src/deadrop/events.py
@@ -1,0 +1,255 @@
+"""Event bus for subscription/notification system.
+
+Provides a pub/sub mechanism for notifying clients when topics (inboxes, rooms)
+have new messages. Clients subscribe with a vector clock (map of topic -> last_seen_mid)
+and receive events when any subscribed topic has changes.
+
+Architecture:
+    - EventBus ABC defines the interface (swappable for Redis later)
+    - InMemoryEventBus uses asyncio primitives for single-instance deployments
+    - Events are lightweight notifications (topic + latest_mid), not payloads
+    - Clients fetch actual content via existing REST endpoints
+
+Topic key format:
+    - "inbox:{identity_id}" for direct message inboxes
+    - "room:{room_id}" for chat rooms
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from typing import AsyncIterator
+
+logger = logging.getLogger(__name__)
+
+
+class EventBus(ABC):
+    """Abstract event bus for topic change notifications.
+
+    Implementations must be async-compatible. The interface is designed
+    to be backed by Redis pub/sub later without changing callers.
+    """
+
+    @abstractmethod
+    async def publish(self, namespace: str, topic: str, mid: str) -> None:
+        """Publish that a topic has a new message.
+
+        Args:
+            namespace: Namespace ID
+            topic: Topic key (e.g., "inbox:abc123" or "room:def456")
+            mid: The new message ID (UUIDv7, lexicographically sortable)
+        """
+
+    @abstractmethod
+    async def subscribe(
+        self,
+        namespace: str,
+        topics: dict[str, str | None],
+        timeout: float = 30.0,
+    ) -> dict[str, str]:
+        """Block until any subscribed topic has changes, or timeout.
+
+        Compares the caller's last_seen_mid for each topic against the
+        server's latest_mid. Returns immediately if any topic has unseen
+        messages; otherwise waits for a publish event or timeout.
+
+        Args:
+            namespace: Namespace ID
+            topics: Map of topic_key -> last_seen_mid (None = never seen)
+            timeout: Max seconds to wait (0 = check and return immediately)
+
+        Returns:
+            Map of topic_key -> latest_mid for topics that have changes.
+            Empty dict if timeout reached with no changes.
+        """
+
+    @abstractmethod
+    async def stream(
+        self,
+        namespace: str,
+        topics: dict[str, str | None],
+    ) -> AsyncIterator[dict[str, str]]:
+        """Stream events as they occur.
+
+        Yields dicts of {topic_key: latest_mid} for each change.
+        First yields any immediately-available changes, then waits.
+
+        Args:
+            namespace: Namespace ID
+            topics: Map of topic_key -> last_seen_mid (None = never seen)
+
+        Yields:
+            Single-entry dicts: {"topic": topic_key, "latest_mid": mid}
+        """
+        # Make this an async generator at the ABC level
+        yield {}  # pragma: no cover
+
+    @abstractmethod
+    def get_latest(self, namespace: str, topic: str) -> str | None:
+        """Get the latest known mid for a topic.
+
+        Args:
+            namespace: Namespace ID
+            topic: Topic key
+
+        Returns:
+            Latest message ID, or None if no messages published for this topic.
+        """
+
+
+class InMemoryEventBus(EventBus):
+    """In-memory event bus using asyncio primitives.
+
+    Suitable for single-instance deployments. Uses asyncio.Condition
+    for efficient waiter notification (no busy-polling).
+
+    Thread safety: all operations go through asyncio, which is single-threaded
+    within an event loop. The Condition provides synchronization for concurrent
+    coroutines.
+    """
+
+    def __init__(self) -> None:
+        # latest_mid per (namespace, topic)
+        self._latest: dict[str, dict[str, str]] = defaultdict(dict)
+        # One condition per namespace for waiter notification
+        self._conditions: dict[str, asyncio.Condition] = {}
+
+    def _get_condition(self, namespace: str) -> asyncio.Condition:
+        """Get or create a Condition for a namespace."""
+        if namespace not in self._conditions:
+            self._conditions[namespace] = asyncio.Condition()
+        return self._conditions[namespace]
+
+    async def publish(self, namespace: str, topic: str, mid: str) -> None:
+        """Publish a new message event for a topic."""
+        condition = self._get_condition(namespace)
+        async with condition:
+            self._latest[namespace][topic] = mid
+            condition.notify_all()
+
+    def _check_changes(
+        self,
+        namespace: str,
+        topics: dict[str, str | None],
+    ) -> dict[str, str]:
+        """Check which topics have changes beyond the caller's cursors.
+
+        UUIDv7 message IDs are lexicographically sortable, so string
+        comparison is valid for determining "newer than".
+        """
+        changes: dict[str, str] = {}
+        ns_latest = self._latest.get(namespace, {})
+
+        for topic, last_seen in topics.items():
+            latest = ns_latest.get(topic)
+            if latest is None:
+                # No messages published for this topic yet
+                continue
+            if last_seen is None:
+                # Caller has never seen this topic — any message is new
+                changes[topic] = latest
+            elif latest > last_seen:
+                # There are messages newer than what the caller has seen
+                changes[topic] = latest
+
+        return changes
+
+    async def subscribe(
+        self,
+        namespace: str,
+        topics: dict[str, str | None],
+        timeout: float = 30.0,
+    ) -> dict[str, str]:
+        """Block until any topic has changes, or timeout."""
+        # Immediate check — avoid acquiring condition if possible
+        changes = self._check_changes(namespace, topics)
+        if changes:
+            return changes
+
+        if timeout <= 0:
+            return {}
+
+        condition = self._get_condition(namespace)
+        async with condition:
+            # Re-check under the lock (another publish may have happened)
+            changes = self._check_changes(namespace, topics)
+            if changes:
+                return changes
+
+            # Wait for notification or timeout
+            try:
+                await asyncio.wait_for(
+                    condition.wait(),
+                    timeout=timeout,
+                )
+            except asyncio.TimeoutError:
+                pass
+
+            # Check again after wake-up
+            return self._check_changes(namespace, topics)
+
+    async def stream(
+        self,
+        namespace: str,
+        topics: dict[str, str | None],
+    ) -> AsyncIterator[dict[str, str]]:
+        """Stream events as they occur."""
+        # Track our own cursor so we don't re-yield the same change
+        cursors = dict(topics)
+
+        # First, yield any immediately-available changes
+        changes = self._check_changes(namespace, cursors)
+        for topic, mid in changes.items():
+            cursors[topic] = mid
+            yield {"topic": topic, "latest_mid": mid}
+
+        # Then wait for new events
+        condition = self._get_condition(namespace)
+        while True:
+            async with condition:
+                await condition.wait()
+
+            # Check what changed
+            changes = self._check_changes(namespace, cursors)
+            for topic, mid in changes.items():
+                cursors[topic] = mid
+                yield {"topic": topic, "latest_mid": mid}
+
+    def get_latest(self, namespace: str, topic: str) -> str | None:
+        """Get the latest known mid for a topic."""
+        return self._latest.get(namespace, {}).get(topic)
+
+
+# --- Global singleton ---
+
+_event_bus: EventBus | None = None
+
+
+def get_event_bus() -> EventBus:
+    """Get the global event bus instance.
+
+    Creates an InMemoryEventBus on first call. Use set_event_bus()
+    to swap in a different implementation (e.g., for testing or Redis).
+    """
+    global _event_bus
+    if _event_bus is None:
+        _event_bus = InMemoryEventBus()
+    return _event_bus
+
+
+def set_event_bus(bus: EventBus) -> None:
+    """Replace the global event bus instance.
+
+    Useful for testing or swapping to a Redis-backed implementation.
+    """
+    global _event_bus
+    _event_bus = bus
+
+
+def reset_event_bus() -> None:
+    """Reset the global event bus (for testing)."""
+    global _event_bus
+    _event_bus = None

--- a/src/deadrop/static/js/api.js
+++ b/src/deadrop/static/js/api.js
@@ -178,7 +178,293 @@ const DeadropAPI = {
     async listRoomMembers(credentials, roomId) {
         return this.request('GET', `/${credentials.ns}/rooms/${roomId}/members`, { credentials });
     },
+
+    // ==================== SUBSCRIPTION API ====================
+
+    /**
+     * Subscribe to topic changes (poll mode).
+     * Blocks until an event occurs or timeout.
+     * 
+     * @param {object} credentials - User credentials
+     * @param {object} topics - Map of topic_key -> last_seen_mid (null = never seen)
+     * @param {number} timeout - Max seconds to wait (1-60)
+     * @returns {Promise<{events: object, timeout: boolean}>}
+     */
+    async subscribePoll(credentials, topics, timeout = 30) {
+        return this.request('POST', `/${credentials.ns}/subscribe`, {
+            body: { topics, mode: 'poll', timeout },
+            credentials,
+        });
+    },
+
+    /**
+     * Subscribe to topic changes (SSE stream mode).
+     * Returns a fetch Response for reading SSE events.
+     * 
+     * @param {object} credentials - User credentials
+     * @param {object} topics - Map of topic_key -> last_seen_mid (null = never seen)
+     * @param {AbortSignal} signal - AbortSignal for cancellation
+     * @returns {Promise<Response>} Raw fetch response for SSE parsing
+     */
+    async subscribeStream(credentials, topics, signal = null) {
+        const headers = {
+            'Content-Type': 'application/json',
+            'X-Inbox-Secret': credentials.secret,
+        };
+
+        const options = {
+            method: 'POST',
+            headers,
+            body: JSON.stringify({ topics, mode: 'stream' }),
+        };
+        if (signal) options.signal = signal;
+
+        const response = await fetch(`/${credentials.ns}/subscribe`, options);
+        if (!response.ok) {
+            const error = await response.json().catch(() => ({ detail: response.statusText }));
+            throw new Error(error.detail || 'Subscribe stream failed');
+        }
+        return response;
+    },
 };
 
 // Export for use in other modules
 window.DeadropAPI = DeadropAPI;
+
+
+/**
+ * SubscriptionManager: manages a persistent SSE subscription with
+ * automatic reconnection, cursor tracking, and event dispatch.
+ */
+class SubscriptionManager {
+    constructor(credentials) {
+        this.credentials = credentials;
+        this.cursors = this._loadCursors();
+        this.abortController = null;
+        this.running = false;
+        this.reconnectDelay = 1000;  // Start at 1s, exponential backoff
+        this.maxReconnectDelay = 30000;
+        this.onEvent = null;  // Callback: (topic, latestMid) => void
+        this.onStatusChange = null;  // Callback: (status) => void
+    }
+
+    /**
+     * Get localStorage key for cursors.
+     */
+    _cursorKey() {
+        return `deadrop_cursors_${this.credentials.ns}_${this.credentials.id}`;
+    }
+
+    /**
+     * Load cursors from localStorage.
+     */
+    _loadCursors() {
+        try {
+            const stored = localStorage.getItem(this._cursorKey());
+            return stored ? JSON.parse(stored) : {};
+        } catch (e) {
+            return {};
+        }
+    }
+
+    /**
+     * Save cursors to localStorage.
+     */
+    _saveCursors() {
+        try {
+            localStorage.setItem(this._cursorKey(), JSON.stringify(this.cursors));
+        } catch (e) {
+            console.warn('Failed to save cursors:', e);
+        }
+    }
+
+    /**
+     * Update cursor for a topic.
+     */
+    updateCursor(topic, mid) {
+        if (!this.cursors[topic] || mid > this.cursors[topic]) {
+            this.cursors[topic] = mid;
+            this._saveCursors();
+        }
+    }
+
+    /**
+     * Build the topics map for subscription from current state.
+     * @param {string[]} roomIds - Room IDs to subscribe to
+     * @param {boolean} includeInbox - Whether to include own inbox
+     */
+    buildTopics(roomIds = [], includeInbox = true) {
+        const topics = {};
+        if (includeInbox) {
+            const inboxTopic = `inbox:${this.credentials.id}`;
+            topics[inboxTopic] = this.cursors[inboxTopic] || null;
+        }
+        for (const roomId of roomIds) {
+            const roomTopic = `room:${roomId}`;
+            topics[roomTopic] = this.cursors[roomTopic] || null;
+        }
+        return topics;
+    }
+
+    /**
+     * Start the SSE subscription loop with automatic reconnection.
+     * Falls back to poll mode if SSE fails.
+     * 
+     * @param {object} topics - Initial topics map
+     */
+    async start(topics) {
+        if (this.running) this.stop();
+        this.running = true;
+        this.reconnectDelay = 1000;
+
+        // Try SSE first, fall back to poll
+        while (this.running) {
+            try {
+                if (this.onStatusChange) this.onStatusChange('connecting');
+                await this._runSSE(topics);
+            } catch (e) {
+                if (!this.running) break;
+                console.warn('SSE failed, trying poll fallback:', e.message);
+                try {
+                    await this._runPollLoop(topics);
+                } catch (pollErr) {
+                    if (!this.running) break;
+                    console.error('Poll also failed:', pollErr.message);
+                }
+            }
+
+            if (!this.running) break;
+
+            // Reconnect with backoff
+            if (this.onStatusChange) this.onStatusChange('reconnecting');
+            await new Promise(r => setTimeout(r, this.reconnectDelay));
+            this.reconnectDelay = Math.min(this.reconnectDelay * 2, this.maxReconnectDelay);
+
+            // Refresh topics with latest cursors
+            topics = this._refreshTopics(topics);
+        }
+    }
+
+    /**
+     * Refresh topic cursors from our stored state.
+     */
+    _refreshTopics(topics) {
+        const refreshed = {};
+        for (const key of Object.keys(topics)) {
+            refreshed[key] = this.cursors[key] || null;
+        }
+        return refreshed;
+    }
+
+    /**
+     * Run an SSE stream until disconnect or error.
+     */
+    async _runSSE(topics) {
+        this.abortController = new AbortController();
+        const response = await DeadropAPI.subscribeStream(
+            this.credentials, topics, this.abortController.signal
+        );
+
+        if (this.onStatusChange) this.onStatusChange('connected');
+        this.reconnectDelay = 1000;  // Reset backoff on successful connect
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+
+        try {
+            while (this.running) {
+                const { done, value } = await reader.read();
+                if (done) break;
+
+                buffer += decoder.decode(value, { stream: true });
+                const events = this._parseSSE(buffer);
+                buffer = events.remaining;
+
+                for (const event of events.parsed) {
+                    if (event.type === 'change' && event.data) {
+                        try {
+                            const data = JSON.parse(event.data);
+                            if (data.topic && data.latest_mid) {
+                                this.updateCursor(data.topic, data.latest_mid);
+                                if (this.onEvent) this.onEvent(data.topic, data.latest_mid);
+                            }
+                        } catch (e) {
+                            console.warn('Failed to parse SSE event data:', e);
+                        }
+                    }
+                }
+            }
+        } finally {
+            reader.releaseLock();
+        }
+    }
+
+    /**
+     * Parse SSE events from a buffer.
+     * Returns {parsed: [{type, data}], remaining: string}
+     */
+    _parseSSE(buffer) {
+        const parsed = [];
+        const blocks = buffer.split('\n\n');
+        const remaining = blocks.pop();  // Last incomplete block
+
+        for (const block of blocks) {
+            if (!block.trim()) continue;
+            const event = { type: 'message', data: '' };
+            for (const line of block.split('\n')) {
+                if (line.startsWith('event: ')) {
+                    event.type = line.substring(7).trim();
+                } else if (line.startsWith('data: ')) {
+                    event.data = line.substring(6);
+                }
+            }
+            parsed.push(event);
+        }
+
+        return { parsed, remaining };
+    }
+
+    /**
+     * Run a poll loop as fallback.
+     */
+    async _runPollLoop(topics) {
+        if (this.onStatusChange) this.onStatusChange('polling');
+        this.reconnectDelay = 1000;
+
+        while (this.running) {
+            try {
+                const currentTopics = this._refreshTopics(topics);
+                const result = await DeadropAPI.subscribePoll(
+                    this.credentials, currentTopics, 30
+                );
+
+                if (!this.running) break;
+
+                if (result.events && !result.timeout) {
+                    for (const [topic, mid] of Object.entries(result.events)) {
+                        this.updateCursor(topic, mid);
+                        if (this.onEvent) this.onEvent(topic, mid);
+                    }
+                }
+            } catch (e) {
+                if (!this.running) break;
+                throw e;  // Let outer loop handle reconnection
+            }
+        }
+    }
+
+    /**
+     * Stop the subscription.
+     */
+    stop() {
+        this.running = false;
+        if (this.abortController) {
+            this.abortController.abort();
+            this.abortController = null;
+        }
+        if (this.onStatusChange) this.onStatusChange('disconnected');
+    }
+}
+
+window.SubscriptionManager = SubscriptionManager;

--- a/src/deadrop/templates/app.html
+++ b/src/deadrop/templates/app.html
@@ -697,8 +697,14 @@
     }
     
     function startRoomPolling() {
-        // Legacy function — now handled by subscription manager.
-        // Still start polling as fallback for the active room view.
+        // Skip legacy polling when subscription manager is active —
+        // the subscription onEvent handler already calls fetchNewRoomMessages().
+        if (subscriptionManager) {
+            console.log('[polling] skipped — subscription manager active');
+            return;
+        }
+        
+        // Fallback: use long-polling when subscriptions are unavailable
         if (roomPollController) {
             roomPollController.abort();
         }

--- a/src/deadrop/templates/app.html
+++ b/src/deadrop/templates/app.html
@@ -202,7 +202,8 @@
     let rooms = [];
     let roomMessages = [];
     let roomMembers = {};
-    let roomPollController = null;  // For canceling long-polls
+    let roomPollController = null;  // For canceling long-polls (legacy, kept for compat)
+    let subscriptionManager = null;  // Unified subscription manager
     
     // DOM elements
     const views = {
@@ -322,7 +323,10 @@
         
         showView('inbox');
         loadInbox();
-        loadRoomsInBackground();
+        loadRoomsInBackground().then(() => {
+            // Start unified subscription after we know which rooms we're in
+            startSubscription();
+        });
     }
     
     // ==================== INBOX ====================
@@ -343,6 +347,12 @@
             
             peers = peersResult;
             messages = inboxResult.messages;
+            
+            // Update subscription cursor for inbox
+            if (subscriptionManager && messages.length > 0) {
+                const lastMid = messages[messages.length - 1].mid;
+                subscriptionManager.updateCursor(`inbox:${credentials.id}`, lastMid);
+            }
             
             loading.classList.add('hidden');
             
@@ -595,6 +605,12 @@
             // Save to cache
             localStorage.setItem(cacheKey, JSON.stringify(roomMessages));
             
+            // Update subscription cursor
+            if (subscriptionManager && roomMessages.length > 0) {
+                const lastMid = roomMessages[roomMessages.length - 1].mid;
+                subscriptionManager.updateCursor(`room:${currentRoomId}`, lastMid);
+            }
+            
             renderRoomMessages();
         } catch (e) {
             if (!cached) {
@@ -681,6 +697,8 @@
     }
     
     function startRoomPolling() {
+        // Legacy function — now handled by subscription manager.
+        // Still start polling as fallback for the active room view.
         if (roomPollController) {
             roomPollController.abort();
         }
@@ -709,6 +727,12 @@
                     const cacheKey = `room_messages_${currentRoomId}`;
                     localStorage.setItem(cacheKey, JSON.stringify(roomMessages));
                     renderRoomMessages();
+                    
+                    // Update subscription cursor for this room
+                    if (subscriptionManager) {
+                        const lastMid = result.messages[result.messages.length - 1].mid;
+                        subscriptionManager.updateCursor(`room:${currentRoomId}`, lastMid);
+                    }
                 }
                 
             } catch (e) {
@@ -717,6 +741,93 @@
                 // Wait a bit before retrying on error
                 await new Promise(r => setTimeout(r, 5000));
             }
+        }
+    }
+    
+    // ==================== UNIFIED SUBSCRIPTION ====================
+    
+    /**
+     * Start the unified subscription manager for the current namespace.
+     * Subscribes to inbox + all rooms. Dispatches events to refresh
+     * the appropriate views.
+     */
+    async function startSubscription() {
+        stopSubscription();
+        
+        if (!credentials) return;
+        
+        subscriptionManager = new SubscriptionManager(credentials);
+        
+        subscriptionManager.onEvent = async (topic, latestMid) => {
+            console.log(`[subscription] event on ${topic}: ${latestMid}`);
+            
+            if (topic === `inbox:${credentials.id}`) {
+                // Inbox has new messages — refresh if viewing inbox
+                const inboxView = document.getElementById('view-inbox');
+                if (!inboxView.classList.contains('hidden')) {
+                    loadInbox();
+                }
+                // Could show a badge on inbox tab if viewing rooms
+                const tabInbox = document.getElementById('tab-inbox');
+                if (tabInbox && inboxView.classList.contains('hidden')) {
+                    tabInbox.style.fontWeight = 'bold';
+                }
+            } else if (topic.startsWith('room:')) {
+                const roomId = topic.substring(5);
+                // If we're viewing this room, fetch new messages
+                if (currentRoomId === roomId) {
+                    await fetchNewRoomMessages(roomId);
+                }
+                // Could show badge on rooms tab
+            }
+        };
+        
+        subscriptionManager.onStatusChange = (status) => {
+            console.log(`[subscription] status: ${status}`);
+        };
+        
+        // Build topics: inbox + all rooms
+        const roomIds = rooms.map(r => r.room_id);
+        const topics = subscriptionManager.buildTopics(roomIds, true);
+        
+        // Start in background
+        subscriptionManager.start(topics).catch(e => {
+            console.error('Subscription manager error:', e);
+        });
+    }
+    
+    function stopSubscription() {
+        if (subscriptionManager) {
+            subscriptionManager.stop();
+            subscriptionManager = null;
+        }
+    }
+    
+    /**
+     * Fetch only new room messages (incremental update).
+     */
+    async function fetchNewRoomMessages(roomId) {
+        try {
+            const afterMid = roomMessages.length > 0 
+                ? roomMessages[roomMessages.length - 1].mid 
+                : null;
+            
+            const result = await DeadropAPI.getRoomMessages(credentials, roomId, { afterMid });
+            
+            if (result?.messages?.length > 0) {
+                roomMessages = [...roomMessages, ...result.messages];
+                const cacheKey = `room_messages_${roomId}`;
+                localStorage.setItem(cacheKey, JSON.stringify(roomMessages));
+                renderRoomMessages();
+                
+                // Update subscription cursor
+                if (subscriptionManager) {
+                    const lastMid = result.messages[result.messages.length - 1].mid;
+                    subscriptionManager.updateCursor(`room:${roomId}`, lastMid);
+                }
+            }
+        } catch (e) {
+            console.error('Failed to fetch new room messages:', e);
         }
     }
     
@@ -788,6 +899,7 @@
         e.preventDefault();
         history.pushState({}, '', '/app');
         currentSlug = null;
+        stopSubscription();
         showView('namespaces');
         renderNamespaceList();
     });
@@ -796,6 +908,7 @@
         e.preventDefault();
         history.pushState({}, '', '/app');
         currentSlug = null;
+        stopSubscription();
         showView('namespaces');
         renderNamespaceList();
     });

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,388 @@
+"""Tests for the event bus system."""
+
+import asyncio
+
+import pytest
+
+from deadrop.events import InMemoryEventBus, get_event_bus, reset_event_bus, set_event_bus
+
+
+@pytest.fixture
+def bus():
+    """Create a fresh InMemoryEventBus for each test."""
+    return InMemoryEventBus()
+
+
+@pytest.fixture(autouse=True)
+def _reset_global_bus():
+    """Reset the global event bus between tests."""
+    reset_event_bus()
+    yield
+    reset_event_bus()
+
+
+class TestPublishAndSubscribe:
+    """Tests for basic publish/subscribe behavior."""
+
+    @pytest.mark.asyncio
+    async def test_publish_then_subscribe_returns_immediately(self, bus):
+        """If a topic has changes, subscribe returns without blocking."""
+        await bus.publish("ns1", "room:abc", "01961234-0000-7000-8000-000000000001")
+
+        result = await bus.subscribe(
+            "ns1",
+            {"room:abc": None},
+            timeout=5.0,
+        )
+
+        assert result == {"room:abc": "01961234-0000-7000-8000-000000000001"}
+
+    @pytest.mark.asyncio
+    async def test_subscribe_with_current_cursor_blocks_then_receives(self, bus):
+        """Subscribe with up-to-date cursor blocks, then unblocks on publish."""
+        mid1 = "01961234-0000-7000-8000-000000000001"
+        mid2 = "01961234-0000-7000-8000-000000000002"
+
+        await bus.publish("ns1", "room:abc", mid1)
+
+        async def delayed_publish():
+            await asyncio.sleep(0.1)
+            await bus.publish("ns1", "room:abc", mid2)
+
+        task = asyncio.create_task(delayed_publish())
+        result = await bus.subscribe(
+            "ns1",
+            {"room:abc": mid1},
+            timeout=5.0,
+        )
+        await task
+
+        assert result == {"room:abc": mid2}
+
+    @pytest.mark.asyncio
+    async def test_subscribe_timeout_returns_empty(self, bus):
+        """Subscribe with no activity returns empty dict on timeout."""
+        result = await bus.subscribe(
+            "ns1",
+            {"room:abc": None},
+            timeout=0.1,
+        )
+
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_subscribe_zero_timeout_returns_immediately(self, bus):
+        """Subscribe with timeout=0 checks and returns without waiting."""
+        result = await bus.subscribe(
+            "ns1",
+            {"room:abc": None},
+            timeout=0,
+        )
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_subscribe_zero_timeout_with_changes(self, bus):
+        """Subscribe with timeout=0 returns changes if they exist."""
+        await bus.publish("ns1", "room:abc", "01961234-0000-7000-8000-000000000001")
+
+        result = await bus.subscribe(
+            "ns1",
+            {"room:abc": None},
+            timeout=0,
+        )
+        assert result == {"room:abc": "01961234-0000-7000-8000-000000000001"}
+
+    @pytest.mark.asyncio
+    async def test_subscribe_multiple_topics_one_changed(self, bus):
+        """Subscribe to multiple topics; only the changed one is returned."""
+        mid1 = "01961234-0000-7000-8000-000000000001"
+
+        await bus.publish("ns1", "room:abc", mid1)
+
+        result = await bus.subscribe(
+            "ns1",
+            {
+                "room:abc": None,
+                "room:def": None,
+                "inbox:xyz": None,
+            },
+            timeout=0,
+        )
+
+        assert result == {"room:abc": mid1}
+
+    @pytest.mark.asyncio
+    async def test_subscribe_multiple_topics_multiple_changed(self, bus):
+        """Multiple topics with changes are all returned."""
+        mid1 = "01961234-0000-7000-8000-000000000001"
+        mid2 = "01961234-0000-7000-8000-000000000002"
+
+        await bus.publish("ns1", "room:abc", mid1)
+        await bus.publish("ns1", "inbox:xyz", mid2)
+
+        result = await bus.subscribe(
+            "ns1",
+            {
+                "room:abc": None,
+                "inbox:xyz": None,
+                "room:def": None,
+            },
+            timeout=0,
+        )
+
+        assert result == {"room:abc": mid1, "inbox:xyz": mid2}
+
+    @pytest.mark.asyncio
+    async def test_subscribe_no_change_when_cursor_matches(self, bus):
+        """No changes when cursor matches latest."""
+        mid1 = "01961234-0000-7000-8000-000000000001"
+        await bus.publish("ns1", "room:abc", mid1)
+
+        result = await bus.subscribe(
+            "ns1",
+            {"room:abc": mid1},
+            timeout=0,
+        )
+
+        assert result == {}
+
+
+class TestNamespaceIsolation:
+    """Tests that namespaces are isolated from each other."""
+
+    @pytest.mark.asyncio
+    async def test_publish_in_one_namespace_not_visible_in_another(self, bus):
+        """Publishing in ns1 doesn't affect subscribers in ns2."""
+        await bus.publish("ns1", "room:abc", "01961234-0000-7000-8000-000000000001")
+
+        result = await bus.subscribe(
+            "ns2",
+            {"room:abc": None},
+            timeout=0,
+        )
+
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_publish_wakes_only_same_namespace_subscribers(self, bus):
+        """Publishing wakes subscribers in the same namespace only."""
+        mid = "01961234-0000-7000-8000-000000000001"
+
+        ns1_result = None
+        ns2_result = None
+
+        async def subscribe_ns1():
+            nonlocal ns1_result
+            ns1_result = await bus.subscribe("ns1", {"room:abc": None}, timeout=0.5)
+
+        async def subscribe_ns2():
+            nonlocal ns2_result
+            ns2_result = await bus.subscribe("ns2", {"room:abc": None}, timeout=0.2)
+
+        async def publish_ns1():
+            await asyncio.sleep(0.05)
+            await bus.publish("ns1", "room:abc", mid)
+
+        await asyncio.gather(subscribe_ns1(), subscribe_ns2(), publish_ns1())
+
+        assert ns1_result == {"room:abc": mid}
+        assert ns2_result == {}
+
+
+class TestConcurrentSubscribers:
+    """Tests for multiple concurrent subscribers."""
+
+    @pytest.mark.asyncio
+    async def test_multiple_subscribers_all_notified(self, bus):
+        """Multiple subscribers on the same topic all get notified."""
+        mid = "01961234-0000-7000-8000-000000000001"
+
+        results = []
+
+        async def subscriber(idx):
+            result = await bus.subscribe("ns1", {"room:abc": None}, timeout=2.0)
+            results.append((idx, result))
+
+        async def publisher():
+            await asyncio.sleep(0.1)
+            await bus.publish("ns1", "room:abc", mid)
+
+        await asyncio.gather(
+            subscriber(1),
+            subscriber(2),
+            subscriber(3),
+            publisher(),
+        )
+
+        assert len(results) == 3
+        for idx, result in results:
+            assert result == {"room:abc": mid}, f"Subscriber {idx} got wrong result"
+
+    @pytest.mark.asyncio
+    async def test_subscribers_different_topics_in_same_namespace(self, bus):
+        """Subscribers to different topics in the same namespace."""
+        mid = "01961234-0000-7000-8000-000000000001"
+
+        room_result = None
+        inbox_result = None
+
+        async def room_subscriber():
+            nonlocal room_result
+            room_result = await bus.subscribe("ns1", {"room:abc": None}, timeout=0.5)
+
+        async def inbox_subscriber():
+            nonlocal inbox_result
+            inbox_result = await bus.subscribe("ns1", {"inbox:xyz": None}, timeout=0.3)
+
+        async def publisher():
+            await asyncio.sleep(0.05)
+            await bus.publish("ns1", "room:abc", mid)
+
+        await asyncio.gather(room_subscriber(), inbox_subscriber(), publisher())
+
+        assert room_result == {"room:abc": mid}
+        assert inbox_result == {}
+
+
+class TestPublishUpdatesLatest:
+    """Tests that publish correctly updates the latest mid."""
+
+    @pytest.mark.asyncio
+    async def test_latest_mid_updates_on_publish(self, bus):
+        """Each publish updates the latest mid for the topic."""
+        mid1 = "01961234-0000-7000-8000-000000000001"
+        mid2 = "01961234-0000-7000-8000-000000000002"
+
+        await bus.publish("ns1", "room:abc", mid1)
+        assert bus.get_latest("ns1", "room:abc") == mid1
+
+        await bus.publish("ns1", "room:abc", mid2)
+        assert bus.get_latest("ns1", "room:abc") == mid2
+
+    @pytest.mark.asyncio
+    async def test_get_latest_nonexistent(self, bus):
+        """get_latest returns None for unknown topics."""
+        assert bus.get_latest("ns1", "room:abc") is None
+        assert bus.get_latest("unknown_ns", "room:abc") is None
+
+    @pytest.mark.asyncio
+    async def test_publish_creates_topic(self, bus):
+        """First publish on a topic creates it."""
+        mid = "01961234-0000-7000-8000-000000000001"
+        assert bus.get_latest("ns1", "room:new") is None
+
+        await bus.publish("ns1", "room:new", mid)
+        assert bus.get_latest("ns1", "room:new") == mid
+
+
+class TestStream:
+    """Tests for the SSE-style streaming interface."""
+
+    @pytest.mark.asyncio
+    async def test_stream_yields_existing_changes(self, bus):
+        """Stream immediately yields changes for topics with unseen messages."""
+        mid1 = "01961234-0000-7000-8000-000000000001"
+        await bus.publish("ns1", "room:abc", mid1)
+
+        stream = bus.stream("ns1", {"room:abc": None})
+        event = await asyncio.wait_for(stream.__anext__(), timeout=1.0)
+
+        assert event == {"topic": "room:abc", "latest_mid": mid1}
+
+    @pytest.mark.asyncio
+    async def test_stream_waits_for_new_events(self, bus):
+        """Stream waits and yields when new events arrive."""
+        mid1 = "01961234-0000-7000-8000-000000000001"
+
+        async def delayed_publish():
+            await asyncio.sleep(0.1)
+            await bus.publish("ns1", "room:abc", mid1)
+
+        publish_task = asyncio.create_task(delayed_publish())
+
+        stream = bus.stream("ns1", {"room:abc": None})
+        event = await asyncio.wait_for(stream.__anext__(), timeout=2.0)
+        await publish_task
+
+        assert event == {"topic": "room:abc", "latest_mid": mid1}
+
+    @pytest.mark.asyncio
+    async def test_stream_yields_multiple_events(self, bus):
+        """Stream yields multiple events as they occur."""
+        mid1 = "01961234-0000-7000-8000-000000000001"
+        mid2 = "01961234-0000-7000-8000-000000000002"
+
+        async def publish_sequence():
+            await asyncio.sleep(0.05)
+            await bus.publish("ns1", "room:abc", mid1)
+            await asyncio.sleep(0.05)
+            await bus.publish("ns1", "inbox:xyz", mid2)
+
+        publish_task = asyncio.create_task(publish_sequence())
+
+        events = []
+        stream = bus.stream("ns1", {"room:abc": None, "inbox:xyz": None})
+
+        for _ in range(2):
+            event = await asyncio.wait_for(stream.__anext__(), timeout=2.0)
+            events.append(event)
+
+        await publish_task
+
+        topics = {e["topic"] for e in events}
+        assert "room:abc" in topics
+        assert "inbox:xyz" in topics
+
+    @pytest.mark.asyncio
+    async def test_stream_does_not_repeat_same_change(self, bus):
+        """Stream doesn't re-yield a change after cursor is advanced."""
+        mid1 = "01961234-0000-7000-8000-000000000001"
+        mid2 = "01961234-0000-7000-8000-000000000002"
+
+        await bus.publish("ns1", "room:abc", mid1)
+
+        async def publish_later():
+            await asyncio.sleep(0.1)
+            await bus.publish("ns1", "room:abc", mid2)
+
+        publish_task = asyncio.create_task(publish_later())
+
+        stream = bus.stream("ns1", {"room:abc": None})
+
+        event1 = await asyncio.wait_for(stream.__anext__(), timeout=2.0)
+        assert event1["latest_mid"] == mid1
+
+        event2 = await asyncio.wait_for(stream.__anext__(), timeout=2.0)
+        assert event2["latest_mid"] == mid2
+
+        await publish_task
+
+
+class TestGlobalSingleton:
+    """Tests for the global event bus singleton."""
+
+    def test_get_event_bus_returns_instance(self):
+        """get_event_bus creates an InMemoryEventBus."""
+        bus = get_event_bus()
+        assert isinstance(bus, InMemoryEventBus)
+
+    def test_get_event_bus_returns_same_instance(self):
+        """get_event_bus returns the same instance on repeated calls."""
+        bus1 = get_event_bus()
+        bus2 = get_event_bus()
+        assert bus1 is bus2
+
+    def test_set_event_bus_replaces_global(self):
+        """set_event_bus replaces the global instance."""
+        original = get_event_bus()
+        new_bus = InMemoryEventBus()
+        set_event_bus(new_bus)
+        assert get_event_bus() is new_bus
+        assert get_event_bus() is not original
+
+    def test_reset_event_bus_clears_global(self):
+        """reset_event_bus clears the global so next get creates fresh."""
+        bus1 = get_event_bus()
+        reset_event_bus()
+        bus2 = get_event_bus()
+        assert bus1 is not bus2

--- a/tests/test_subscribe_api.py
+++ b/tests/test_subscribe_api.py
@@ -1,0 +1,539 @@
+"""Tests for the subscribe API endpoint."""
+
+import asyncio
+import threading
+
+import pytest
+from fastapi.testclient import TestClient
+
+from deadrop.api import app
+from deadrop.events import get_event_bus, reset_event_bus
+
+
+@pytest.fixture(autouse=True)
+def _reset_events():
+    """Reset event bus between tests."""
+    reset_event_bus()
+    yield
+    reset_event_bus()
+
+
+@pytest.fixture
+def client():
+    """Create test client."""
+    return TestClient(app)
+
+
+@pytest.fixture
+def admin_headers():
+    """Admin auth headers."""
+    return {"X-Admin-Token": "test-admin-token"}
+
+
+@pytest.fixture
+def setup_namespace(client, admin_headers):
+    """Create a namespace and return its info."""
+    response = client.post("/admin/namespaces", headers=admin_headers)
+    return response.json()
+
+
+@pytest.fixture
+def setup_identities(client, setup_namespace):
+    """Create namespace with two identities."""
+    ns = setup_namespace
+    ns_secret = ns["secret"]
+
+    alice = client.post(
+        f"/{ns['ns']}/identities",
+        headers={"X-Namespace-Secret": ns_secret},
+        json={"metadata": {"display_name": "Alice"}},
+    ).json()
+
+    bob = client.post(
+        f"/{ns['ns']}/identities",
+        headers={"X-Namespace-Secret": ns_secret},
+        json={"metadata": {"display_name": "Bob"}},
+    ).json()
+
+    return {
+        "ns": ns["ns"],
+        "ns_secret": ns_secret,
+        "alice": alice,
+        "bob": bob,
+    }
+
+
+@pytest.fixture
+def setup_with_room(client, setup_identities):
+    """Create identities and a room with both as members."""
+    data = setup_identities
+
+    room = client.post(
+        f"/{data['ns']}/rooms",
+        headers={"X-Inbox-Secret": data["alice"]["secret"]},
+        json={"display_name": "Test Room"},
+    ).json()
+
+    # Add Bob to the room
+    client.post(
+        f"/{data['ns']}/rooms/{room['room_id']}/members",
+        headers={"X-Inbox-Secret": data["alice"]["secret"]},
+        json={"identity_id": data["bob"]["id"]},
+    )
+
+    return {**data, "room": room}
+
+
+class TestSubscribeAuth:
+    """Tests for authentication and authorization."""
+
+    def test_subscribe_requires_auth(self, client, setup_identities):
+        """Subscribe without auth header returns 401."""
+        data = setup_identities
+        response = client.post(
+            f"/{data['ns']}/subscribe",
+            json={"topics": {f"inbox:{data['alice']['id']}": None}},
+        )
+        assert response.status_code == 401
+
+    def test_subscribe_wrong_namespace(self, client, admin_headers, setup_identities):
+        """Identity from ns1 cannot subscribe in ns2."""
+        data = setup_identities
+
+        # Create a second namespace
+        ns2 = client.post("/admin/namespaces", headers=admin_headers).json()
+
+        response = client.post(
+            f"/{ns2['ns']}/subscribe",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+            json={"topics": {f"inbox:{data['alice']['id']}": None}},
+        )
+        assert response.status_code == 403
+
+
+class TestSubscribeTopicValidation:
+    """Tests for topic key validation."""
+
+    def test_subscribe_own_inbox_allowed(self, client, setup_identities):
+        """Can subscribe to own inbox."""
+        data = setup_identities
+        response = client.post(
+            f"/{data['ns']}/subscribe",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+            json={
+                "topics": {f"inbox:{data['alice']['id']}": None},
+                "timeout": 1,
+            },
+        )
+        assert response.status_code == 200
+
+    def test_subscribe_other_inbox_forbidden(self, client, setup_identities):
+        """Cannot subscribe to another identity's inbox."""
+        data = setup_identities
+        response = client.post(
+            f"/{data['ns']}/subscribe",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+            json={
+                "topics": {f"inbox:{data['bob']['id']}": None},
+                "timeout": 1,
+            },
+        )
+        assert response.status_code == 403
+        assert "another identity's inbox" in response.json()["detail"]
+
+    def test_subscribe_room_member_allowed(self, client, setup_with_room):
+        """Can subscribe to a room you're a member of."""
+        data = setup_with_room
+        response = client.post(
+            f"/{data['ns']}/subscribe",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+            json={
+                "topics": {f"room:{data['room']['room_id']}": None},
+                "timeout": 1,
+            },
+        )
+        assert response.status_code == 200
+
+    def test_subscribe_room_non_member_forbidden(self, client, setup_identities):
+        """Cannot subscribe to a room you're not a member of."""
+        data = setup_identities
+
+        # Alice creates a room (only Alice is a member)
+        room = client.post(
+            f"/{data['ns']}/rooms",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+            json={"display_name": "Private Room"},
+        ).json()
+
+        # Bob tries to subscribe
+        response = client.post(
+            f"/{data['ns']}/subscribe",
+            headers={"X-Inbox-Secret": data["bob"]["secret"]},
+            json={
+                "topics": {f"room:{room['room_id']}": None},
+                "timeout": 1,
+            },
+        )
+        assert response.status_code == 403
+        assert "Not a member" in response.json()["detail"]
+
+    def test_subscribe_invalid_topic_format(self, client, setup_identities):
+        """Malformed topic key returns 400."""
+        data = setup_identities
+        response = client.post(
+            f"/{data['ns']}/subscribe",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+            json={
+                "topics": {"bad-topic-no-colon": None},
+                "timeout": 1,
+            },
+        )
+        assert response.status_code == 400
+        assert "Invalid topic format" in response.json()["detail"]
+
+    def test_subscribe_unknown_topic_type(self, client, setup_identities):
+        """Unknown topic type returns 400."""
+        data = setup_identities
+        response = client.post(
+            f"/{data['ns']}/subscribe",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+            json={
+                "topics": {"channel:abc": None},
+                "timeout": 1,
+            },
+        )
+        assert response.status_code == 400
+        assert "Unknown topic type" in response.json()["detail"]
+
+    def test_subscribe_empty_topics(self, client, setup_identities):
+        """Empty topics dict returns 400."""
+        data = setup_identities
+        response = client.post(
+            f"/{data['ns']}/subscribe",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+            json={"topics": {}, "timeout": 1},
+        )
+        assert response.status_code == 400
+
+    def test_subscribe_room_wrong_namespace(self, client, admin_headers, setup_identities):
+        """Cannot subscribe to a room from a different namespace."""
+        data = setup_identities
+
+        # Create room in ns1
+        room = client.post(
+            f"/{data['ns']}/rooms",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+            json={"display_name": "Room in NS1"},
+        ).json()
+
+        # Create ns2 with new identity
+        ns2 = client.post("/admin/namespaces", headers=admin_headers).json()
+        charlie = client.post(
+            f"/{ns2['ns']}/identities",
+            headers={"X-Namespace-Secret": ns2["secret"]},
+            json={"metadata": {"display_name": "Charlie"}},
+        ).json()
+
+        # Charlie in ns2 tries to subscribe to room in ns1
+        response = client.post(
+            f"/{ns2['ns']}/subscribe",
+            headers={"X-Inbox-Secret": charlie["secret"]},
+            json={
+                "topics": {f"room:{room['room_id']}": None},
+                "timeout": 1,
+            },
+        )
+        assert response.status_code in (403, 404)
+
+
+class TestSubscribePollMode:
+    """Tests for poll mode subscribe behavior."""
+
+    def test_subscribe_poll_timeout(self, client, setup_identities):
+        """Subscribe with no activity returns timeout."""
+        data = setup_identities
+        response = client.post(
+            f"/{data['ns']}/subscribe",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+            json={
+                "topics": {f"inbox:{data['alice']['id']}": None},
+                "timeout": 1,
+            },
+        )
+        assert response.status_code == 200
+        result = response.json()
+        assert result["events"] == {}
+        assert result["timeout"] is True
+
+    def test_subscribe_poll_immediate_return(self, client, setup_with_room):
+        """If topic already has changes, return immediately."""
+        data = setup_with_room
+        event_bus = get_event_bus()
+
+        # Pre-publish an event
+        asyncio.run(
+            event_bus.publish(
+                data["ns"],
+                f"room:{data['room']['room_id']}",
+                "01961234-0000-7000-8000-000000000001",
+            )
+        )
+
+        response = client.post(
+            f"/{data['ns']}/subscribe",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+            json={
+                "topics": {f"room:{data['room']['room_id']}": None},
+                "timeout": 5,
+            },
+        )
+        assert response.status_code == 200
+        result = response.json()
+        assert f"room:{data['room']['room_id']}" in result["events"]
+        assert result["timeout"] is False
+
+    def test_subscribe_poll_receives_event(self, client, setup_with_room):
+        """Subscribe blocks and receives event when published."""
+        data = setup_with_room
+        event_bus = get_event_bus()
+
+        mid = "01961234-0000-7000-8000-000000000001"
+
+        # Publish from a background thread after a small delay
+        def delayed_publish():
+            import time
+
+            time.sleep(0.2)
+            loop = asyncio.new_event_loop()
+            loop.run_until_complete(
+                event_bus.publish(data["ns"], f"room:{data['room']['room_id']}", mid)
+            )
+            loop.close()
+
+        thread = threading.Thread(target=delayed_publish)
+        thread.start()
+
+        response = client.post(
+            f"/{data['ns']}/subscribe",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+            json={
+                "topics": {f"room:{data['room']['room_id']}": None},
+                "timeout": 5,
+            },
+        )
+        thread.join()
+
+        assert response.status_code == 200
+        result = response.json()
+        assert result["events"] == {f"room:{data['room']['room_id']}": mid}
+        assert result["timeout"] is False
+
+    def test_subscribe_multiple_topics_mixed(self, client, setup_with_room):
+        """Subscribe to inbox + room; only changed topic returned."""
+        data = setup_with_room
+        event_bus = get_event_bus()
+
+        mid = "01961234-0000-7000-8000-000000000001"
+
+        # Pre-publish only to the room
+        asyncio.run(event_bus.publish(data["ns"], f"room:{data['room']['room_id']}", mid))
+
+        response = client.post(
+            f"/{data['ns']}/subscribe",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+            json={
+                "topics": {
+                    f"inbox:{data['alice']['id']}": None,
+                    f"room:{data['room']['room_id']}": None,
+                },
+                "timeout": 1,
+            },
+        )
+        assert response.status_code == 200
+        result = response.json()
+        assert f"room:{data['room']['room_id']}" in result["events"]
+        assert f"inbox:{data['alice']['id']}" not in result["events"]
+
+    def test_subscribe_with_cursor_no_new_messages(self, client, setup_with_room):
+        """Subscribe with cursor matching latest returns timeout."""
+        data = setup_with_room
+        event_bus = get_event_bus()
+
+        mid = "01961234-0000-7000-8000-000000000001"
+
+        asyncio.run(event_bus.publish(data["ns"], f"room:{data['room']['room_id']}", mid))
+
+        # Subscribe with cursor AT the latest — no new messages
+        response = client.post(
+            f"/{data['ns']}/subscribe",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+            json={
+                "topics": {f"room:{data['room']['room_id']}": mid},
+                "timeout": 1,
+            },
+        )
+        assert response.status_code == 200
+        result = response.json()
+        assert result["events"] == {}
+        assert result["timeout"] is True
+
+
+class TestEventPublishIntegration:
+    """Tests that sending messages triggers subscription events."""
+
+    def test_send_dm_triggers_inbox_event(self, client, setup_identities):
+        """Sending a DM publishes an event on the recipient's inbox topic."""
+        data = setup_identities
+        event_bus = get_event_bus()
+
+        # Alice sends a message to Bob
+        send_resp = client.post(
+            f"/{data['ns']}/send",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+            json={"to": data["bob"]["id"], "body": "Hello Bob!"},
+        )
+        assert send_resp.status_code == 200
+        sent_mid = send_resp.json()["mid"]
+
+        # The event bus should now have the inbox topic updated
+        latest = event_bus.get_latest(data["ns"], f"inbox:{data['bob']['id']}")
+        assert latest == sent_mid
+
+    def test_send_room_message_triggers_room_event(self, client, setup_with_room):
+        """Sending a room message publishes an event on the room topic."""
+        data = setup_with_room
+        event_bus = get_event_bus()
+
+        # Alice sends a room message
+        send_resp = client.post(
+            f"/{data['ns']}/rooms/{data['room']['room_id']}/messages",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+            json={"body": "Hello room!"},
+        )
+        assert send_resp.status_code == 200
+        sent_mid = send_resp.json()["mid"]
+
+        # The event bus should now have the room topic updated
+        latest = event_bus.get_latest(data["ns"], f"room:{data['room']['room_id']}")
+        assert latest == sent_mid
+
+    def test_subscribe_then_send_dm_receives_event(self, client, setup_identities):
+        """Subscribe to inbox, then send a DM — subscriber gets the event."""
+        data = setup_identities
+
+        sent_mid = None
+
+        def send_dm_after_delay():
+            """Send a DM from Alice to Bob after a small delay."""
+            nonlocal sent_mid
+            import time
+
+            time.sleep(0.3)
+            resp = client.post(
+                f"/{data['ns']}/send",
+                headers={"X-Inbox-Secret": data["alice"]["secret"]},
+                json={"to": data["bob"]["id"], "body": "Hello!"},
+            )
+            sent_mid = resp.json()["mid"]
+
+        thread = threading.Thread(target=send_dm_after_delay)
+        thread.start()
+
+        # Bob subscribes to his inbox
+        response = client.post(
+            f"/{data['ns']}/subscribe",
+            headers={"X-Inbox-Secret": data["bob"]["secret"]},
+            json={
+                "topics": {f"inbox:{data['bob']['id']}": None},
+                "timeout": 5,
+            },
+        )
+        thread.join()
+
+        assert response.status_code == 200
+        result = response.json()
+        assert result["timeout"] is False
+        assert f"inbox:{data['bob']['id']}" in result["events"]
+        assert result["events"][f"inbox:{data['bob']['id']}"] == sent_mid
+
+    def test_subscribe_then_send_room_message_receives_event(self, client, setup_with_room):
+        """Subscribe to room, then send a message — subscriber gets the event."""
+        data = setup_with_room
+        room_id = data["room"]["room_id"]
+
+        sent_mid = None
+
+        def send_room_msg_after_delay():
+            nonlocal sent_mid
+            import time
+
+            time.sleep(0.3)
+            resp = client.post(
+                f"/{data['ns']}/rooms/{room_id}/messages",
+                headers={"X-Inbox-Secret": data["alice"]["secret"]},
+                json={"body": "Hello room!"},
+            )
+            sent_mid = resp.json()["mid"]
+
+        thread = threading.Thread(target=send_room_msg_after_delay)
+        thread.start()
+
+        # Bob subscribes to the room
+        response = client.post(
+            f"/{data['ns']}/subscribe",
+            headers={"X-Inbox-Secret": data["bob"]["secret"]},
+            json={
+                "topics": {f"room:{room_id}": None},
+                "timeout": 5,
+            },
+        )
+        thread.join()
+
+        assert response.status_code == 200
+        result = response.json()
+        assert result["timeout"] is False
+        assert f"room:{room_id}" in result["events"]
+        assert result["events"][f"room:{room_id}"] == sent_mid
+
+    def test_subscribe_multi_topic_one_fires(self, client, setup_with_room):
+        """Subscribe to inbox + room, only room gets a message."""
+        data = setup_with_room
+        room_id = data["room"]["room_id"]
+
+        sent_mid = None
+
+        def send_room_msg_after_delay():
+            nonlocal sent_mid
+            import time
+
+            time.sleep(0.3)
+            resp = client.post(
+                f"/{data['ns']}/rooms/{room_id}/messages",
+                headers={"X-Inbox-Secret": data["alice"]["secret"]},
+                json={"body": "Room only"},
+            )
+            sent_mid = resp.json()["mid"]
+
+        thread = threading.Thread(target=send_room_msg_after_delay)
+        thread.start()
+
+        # Bob subscribes to both inbox and room
+        response = client.post(
+            f"/{data['ns']}/subscribe",
+            headers={"X-Inbox-Secret": data["bob"]["secret"]},
+            json={
+                "topics": {
+                    f"inbox:{data['bob']['id']}": None,
+                    f"room:{room_id}": None,
+                },
+                "timeout": 5,
+            },
+        )
+        thread.join()
+
+        assert response.status_code == 200
+        result = response.json()
+        assert result["timeout"] is False
+        # Only room should have an event
+        assert f"room:{room_id}" in result["events"]
+        assert f"inbox:{data['bob']['id']}" not in result["events"]

--- a/tests/test_subscribe_client.py
+++ b/tests/test_subscribe_client.py
@@ -1,0 +1,170 @@
+"""Tests for subscribe methods on the Python client."""
+
+import pytest
+
+from deadrop.client import Deaddrop
+from deadrop.events import reset_event_bus
+
+
+@pytest.fixture(autouse=True)
+def _reset_events():
+    """Reset event bus between tests."""
+    reset_event_bus()
+    yield
+    reset_event_bus()
+
+
+@pytest.fixture
+def client():
+    """Fresh in-memory client."""
+    c = Deaddrop.in_memory()
+    yield c
+    c.close()
+
+
+@pytest.fixture
+def setup(client):
+    """Create namespace with Alice and Bob + a room."""
+    result = client.quick_setup("Test", ["Alice", "Bob"])
+    ns = result["namespace"]["ns"]
+    ns_secret = result["namespace"]["secret"]
+    alice = result["identities"]["Alice"]
+    bob = result["identities"]["Bob"]
+
+    room = client.create_room(ns, alice["secret"], display_name="Test Room")
+    client.add_room_member(ns, room["room_id"], bob["id"], alice["secret"])
+
+    return {
+        "ns": ns,
+        "ns_secret": ns_secret,
+        "alice": alice,
+        "bob": bob,
+        "room": room,
+    }
+
+
+class TestSubscribePoll:
+    """Tests for poll-mode subscribe on the client."""
+
+    def test_subscribe_timeout_no_events(self, client, setup):
+        """Subscribe with no activity returns timeout."""
+        data = setup
+        result = client.subscribe(
+            data["ns"],
+            data["alice"]["secret"],
+            {f"inbox:{data['alice']['id']}": None},
+            timeout=1,
+        )
+        assert result["timeout"] is True
+        assert result["events"] == {}
+
+    def test_subscribe_returns_existing_changes(self, client, setup):
+        """Subscribe returns events for topics that already have messages."""
+        data = setup
+
+        # Send a message first
+        msg = client.send_message(
+            data["ns"],
+            data["alice"]["secret"],
+            data["bob"]["id"],
+            "Hello Bob!",
+        )
+
+        # Now Bob subscribes — should see the inbox event immediately
+        # Note: for local backend, send_message doesn't go through the API
+        # so the event bus won't have the event. We need to publish manually.
+        import asyncio
+
+        from deadrop.events import get_event_bus
+
+        bus = get_event_bus()
+        asyncio.run(bus.publish(data["ns"], f"inbox:{data['bob']['id']}", msg["mid"]))
+
+        result = client.subscribe(
+            data["ns"],
+            data["bob"]["secret"],
+            {f"inbox:{data['bob']['id']}": None},
+            timeout=1,
+        )
+        assert result["timeout"] is False
+        assert f"inbox:{data['bob']['id']}" in result["events"]
+
+    def test_subscribe_validates_inbox_ownership(self, client, setup):
+        """Cannot subscribe to another identity's inbox."""
+        data = setup
+        with pytest.raises(ValueError, match="another identity's inbox"):
+            client.subscribe(
+                data["ns"],
+                data["alice"]["secret"],
+                {f"inbox:{data['bob']['id']}": None},
+                timeout=1,
+            )
+
+    def test_subscribe_validates_room_membership(self, client, setup):
+        """Cannot subscribe to a room you're not a member of."""
+        data = setup
+
+        # Create a room that only Alice is in
+        private_room = client.create_room(
+            data["ns"], data["alice"]["secret"], display_name="Private"
+        )
+
+        # Remove bob from the original room for this test, use the private room
+        with pytest.raises(ValueError, match="Not a member"):
+            client.subscribe(
+                data["ns"],
+                data["bob"]["secret"],
+                {f"room:{private_room['room_id']}": None},
+                timeout=1,
+            )
+
+    def test_subscribe_invalid_secret(self, client, setup):
+        """Subscribe with bad secret raises error."""
+        data = setup
+        with pytest.raises(ValueError, match="Invalid"):
+            client.subscribe(
+                data["ns"],
+                "bad-secret-value",
+                {"inbox:fakeid": None},
+                timeout=1,
+            )
+
+
+class TestListenAll:
+    """Tests for the listen_all generator."""
+
+    def test_listen_all_yields_events(self, client, setup):
+        """listen_all yields events as they arrive."""
+        data = setup
+
+        import asyncio
+        import threading
+
+        from deadrop.events import get_event_bus
+
+        bus = get_event_bus()
+        mid = "01961234-0000-7000-8000-000000000001"
+
+        def publish_after_delay():
+            import time
+
+            time.sleep(0.2)
+            loop = asyncio.new_event_loop()
+            loop.run_until_complete(bus.publish(data["ns"], f"room:{data['room']['room_id']}", mid))
+            loop.close()
+
+        thread = threading.Thread(target=publish_after_delay)
+        thread.start()
+
+        gen = client.listen_all(
+            data["ns"],
+            data["alice"]["secret"],
+            {f"room:{data['room']['room_id']}": None},
+            timeout=3,
+        )
+
+        topic, latest_mid = next(gen)
+        thread.join()
+
+        assert topic == f"room:{data['room']['room_id']}"
+        assert latest_mid == mid

--- a/uv.lock
+++ b/uv.lock
@@ -344,6 +344,7 @@ turso = [
 dev = [
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "ty" },
@@ -368,6 +369,7 @@ provides-extras = ["turso"]
 dev = [
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.9.0" },
     { name = "ty", specifier = ">=0.0.11" },
@@ -845,6 +847,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements a subscription/notification system that lets clients efficiently monitor multiple topics (inboxes and rooms) for new messages through a single connection, replacing the need for N separate long-poll connections.

### Architecture

**Event Bus** (`src/deadrop/events.py`):
- `EventBus` ABC with `publish/subscribe/stream/get_latest` methods
- `InMemoryEventBus` implementation using `asyncio.Condition` for efficient waiter notification
- Clean interface designed for future Redis backing (swap in without changing callers)
- Topic key format: `inbox:{identity_id}` and `room:{room_id}`

**Subscribe API** (`POST /{ns}/subscribe`):
- Auth via `X-Inbox-Secret` — validates caller is a valid identity in the namespace
- Topic validation: own inbox only, room membership required for room topics
- **Poll mode**: blocks until any topic has changes or timeout, returns changed topics with latest mids
- **Stream mode**: returns `text/event-stream` SSE response with `change` events
- Vector clock design: client sends cursor map, server reports what's newer

**Event Publishing Integration**:
- `send_message` → publishes to `inbox:{to_id}`
- `send_room_message` → publishes to `room:{room_id}`
- Fire-and-forget: publish failures don't break message sends

### Client Support

**Web Client** (`api.js` + `app.html`):
- `SubscriptionManager` class with SSE streaming, poll fallback, automatic reconnection with exponential backoff
- Cursor tracking in `localStorage`
- Integrated into namespace lifecycle (starts on open, stops on back)

**Python Client** (`backends.py` + `client.py`):
- `subscribe()` — poll mode across all backends (Local, Remote, InMemory)
- `subscribe_stream()` — SSE streaming for Remote, async wrapper for Local
- `listen_all()` — convenience generator for continuous multi-topic monitoring

**CLI** (`cli.py`):
- `deadrop listen <ns>` with `--inbox`, `--rooms`, `--all`, `--json-output`
- Auto-discovers rooms, builds topic map, enters poll loop
- Fetches and displays actual message content for each event

### Documentation

- New `docs/SUBSCRIPTIONS.md`: concepts, API reference, client usage, architecture
- Updated `docs/ROOMS.md`: subscription cross-reference
- Updated `docs/GETTING_STARTED.md`: subscription examples
- Updated `README.md`: subscription concept and API reference

### Testing

- 49 new tests (23 event bus + 20 subscribe API + 6 client subscribe)
- Full suite: 392 tests passing
- Covers: auth, topic validation, poll/stream modes, event publishing integration, concurrent subscribers, namespace isolation, cursor management

### Key Design Decisions

- **Events, not payloads**: subscription is a notification channel; clients fetch content via existing endpoints
- **Vector clock = client-owned cursor map**: no server-side per-client state
- **Fully backward-compatible**: existing long-poll endpoints unchanged
- **No DB schema changes**: event bus is purely in-memory
- **Added pytest-asyncio** dev dependency for async event bus tests