### PR TITLE
feat: reaction emoji support for room messages

### DIFF
--- a/src/deadrop/api.py
+++ b/src/deadrop/api.py
@@ -1118,6 +1118,7 @@ class RoomMemberInfo(BaseModel):
 class SendRoomMessageRequest(BaseModel):
     body: str
     content_type: str = "text/plain"
+    reference_mid: str | None = None
 
 
 class RoomMessageInfo(BaseModel):
@@ -1126,6 +1127,7 @@ class RoomMessageInfo(BaseModel):
     from_id: str  # The sender's identity ID
     body: str
     content_type: str
+    reference_mid: str | None = None
     created_at: str
 
     @classmethod
@@ -1137,6 +1139,7 @@ class RoomMessageInfo(BaseModel):
             from_id=data["from"],
             body=data["body"],
             content_type=data.get("content_type", "text/plain"),
+            reference_mid=data.get("reference_mid"),
             created_at=data["created_at"],
         )
 
@@ -1408,6 +1411,7 @@ async def send_room_message(
                 from_id=from_id,
                 body=request.body,
                 content_type=request.content_type,
+                reference_mid=request.reference_mid,
             )
         )
     except ValueError as e:

--- a/src/deadrop/db.py
+++ b/src/deadrop/db.py
@@ -485,12 +485,9 @@ def _migrate_002_add_rooms(conn: sqlite3.Connection) -> None:
 
 def _migrate_003_add_reference_mid(conn: sqlite3.Connection) -> None:
     """Migration 003: Add reference_mid column to room_messages for reactions."""
+    conn.execute("ALTER TABLE room_messages ADD COLUMN reference_mid TEXT")
     conn.execute(
-        "ALTER TABLE room_messages ADD COLUMN reference_mid TEXT"
-    )
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_room_messages_reference "
-        "ON room_messages(reference_mid)"
+        "CREATE INDEX IF NOT EXISTS idx_room_messages_reference ON room_messages(reference_mid)"
     )
     conn.commit()
 

--- a/src/deadrop/db.py
+++ b/src/deadrop/db.py
@@ -1988,7 +1988,7 @@ def get_room_messages(
     conn = _get_conn(conn)
 
     query = """
-        SELECT mid, room_id, from_id, body, content_type, created_at
+        SELECT mid, room_id, from_id, body, content_type, reference_mid, created_at
         FROM room_messages
         WHERE room_id = ?
     """
@@ -2011,6 +2011,7 @@ def get_room_messages(
             "from": row["from_id"],
             "body": row["body"],
             "content_type": row.get("content_type") or "text/plain",
+            "reference_mid": row.get("reference_mid"),
             "created_at": row["created_at"],
         }
         for row in rows
@@ -2034,7 +2035,7 @@ def get_room_message(
     """
     conn = _get_conn(conn)
     cursor = conn.execute(
-        """SELECT mid, room_id, from_id, body, content_type, created_at
+        """SELECT mid, room_id, from_id, body, content_type, reference_mid, created_at
            FROM room_messages WHERE room_id = ? AND mid = ?""",
         (room_id, mid),
     )
@@ -2047,6 +2048,7 @@ def get_room_message(
             "from": row["from_id"],
             "body": row["body"],
             "content_type": row.get("content_type") or "text/plain",
+            "reference_mid": row.get("reference_mid"),
             "created_at": row["created_at"],
         }
     return None

--- a/src/deadrop/db.py
+++ b/src/deadrop/db.py
@@ -43,7 +43,7 @@ from .auth import derive_id, generate_secret, hash_secret
 DEFAULT_TTL_HOURS = 24
 
 # Current schema version (increment when adding migrations)
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 # Thread-local storage for per-thread connections
 # This ensures each thread gets its own SQLite connection, avoiding
@@ -483,10 +483,23 @@ def _migrate_002_add_rooms(conn: sqlite3.Connection) -> None:
     conn.commit()
 
 
+def _migrate_003_add_reference_mid(conn: sqlite3.Connection) -> None:
+    """Migration 003: Add reference_mid column to room_messages for reactions."""
+    conn.execute(
+        "ALTER TABLE room_messages ADD COLUMN reference_mid TEXT"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_room_messages_reference "
+        "ON room_messages(reference_mid)"
+    )
+    conn.commit()
+
+
 # Migration registry: (version, description, migration_function)
 MIGRATIONS: list[tuple[int, str, Callable[[sqlite3.Connection], None]]] = [
     (1, "Add content_type column to messages", _migrate_001_add_content_type),
     (2, "Add rooms tables for group communication", _migrate_002_add_rooms),
+    (3, "Add reference_mid to room_messages for reactions", _migrate_003_add_reference_mid),
 ]
 
 
@@ -1872,6 +1885,7 @@ def send_room_message(
     from_id: str,
     body: str,
     content_type: str = "text/plain",
+    reference_mid: str | None = None,
     conn: sqlite3.Connection | None = None,
 ) -> dict:
     """Send a message to a room.
@@ -1881,6 +1895,7 @@ def send_room_message(
         from_id: Sender identity ID (must be a member)
         body: Message body
         content_type: Content type (default: text/plain)
+        reference_mid: Optional message ID this message references (e.g. for reactions)
         conn: Optional database connection
 
     Returns:
@@ -1904,9 +1919,10 @@ def send_room_message(
     now = datetime.now(timezone.utc).isoformat()
 
     conn.execute(
-        """INSERT INTO room_messages (mid, room_id, from_id, body, content_type, created_at)
-           VALUES (?, ?, ?, ?, ?, ?)""",
-        (mid, room_id, from_id, body, content_type, now),
+        """INSERT INTO room_messages
+               (mid, room_id, from_id, body, content_type, reference_mid, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+        (mid, room_id, from_id, body, content_type, reference_mid, now),
     )
     conn.commit()
 
@@ -1916,6 +1932,7 @@ def send_room_message(
         "from": from_id,
         "body": body,
         "content_type": content_type,
+        "reference_mid": reference_mid,
         "created_at": now,
     }
 

--- a/src/deadrop/static/css/style.css
+++ b/src/deadrop/static/css/style.css
@@ -792,6 +792,87 @@ textarea.form-input {
 
 /* From-me messages are plain text, no markdown overrides needed */
 
+/* ========== REACTION BADGES ========== */
+
+.reaction-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-top: 4px;
+}
+
+.reaction-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+    padding: 2px 8px;
+    border-radius: 12px;
+    border: 1px solid var(--border-color);
+    background: var(--bg-color);
+    font-size: 14px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    line-height: 1.4;
+}
+
+.reaction-badge:hover {
+    background: var(--hover-bg);
+    border-color: var(--primary-color);
+}
+
+.reaction-badge.mine {
+    background: rgba(37, 99, 235, 0.1);
+    border-color: var(--primary-color);
+}
+
+.reaction-badge .reaction-count {
+    font-size: 12px;
+    color: var(--text-muted);
+}
+
+.reaction-badge.add-reaction {
+    font-size: 12px;
+    color: var(--text-muted);
+    padding: 2px 6px;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+}
+
+.room-message:hover .reaction-badge.add-reaction {
+    opacity: 1;
+}
+
+/* From-me reactions: adjust for blue bubble context */
+.room-message.from-me .reaction-badges {
+    justify-content: flex-end;
+}
+
+/* Reaction picker popup */
+.reaction-picker {
+    display: flex;
+    gap: 2px;
+    padding: 6px 8px;
+    background: white;
+    border-radius: 24px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+    border: 1px solid var(--border-color);
+}
+
+.reaction-picker-btn {
+    font-size: 22px;
+    padding: 4px 6px;
+    background: none;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background 0.1s;
+    line-height: 1;
+}
+
+.reaction-picker-btn:hover {
+    background: var(--hover-bg);
+}
+
 .room-message .message-time {
     font-size: 11px;
     color: var(--text-muted);

--- a/src/deadrop/static/js/api.js
+++ b/src/deadrop/static/js/api.js
@@ -146,9 +146,11 @@ const DeadropAPI = {
     /**
      * Send a message to a room.
      */
-    async sendRoomMessage(credentials, roomId, body, contentType = 'text/plain') {
+    async sendRoomMessage(credentials, roomId, body, contentType = 'text/plain', referenceMid = null) {
+        const payload = { body, content_type: contentType };
+        if (referenceMid) payload.reference_mid = referenceMid;
         return this.request('POST', `/${credentials.ns}/rooms/${roomId}/messages`, {
-            body: { body, content_type: contentType },
+            body: payload,
             credentials,
         });
     },

--- a/src/deadrop/templates/app.html
+++ b/src/deadrop/templates/app.html
@@ -747,20 +747,58 @@
         }
     }
     
+    const REACTION_EMOJIS = ['👍', '❤️', '😂', '🎉', '👀', '🙏'];
+    
+    function buildReactionMap(messages) {
+        // Group reactions by reference_mid → { emoji → Set of sender IDs }
+        const map = {};
+        for (const msg of messages) {
+            if (msg.content_type !== 'reaction' || !msg.reference_mid) continue;
+            if (!map[msg.reference_mid]) map[msg.reference_mid] = {};
+            const byEmoji = map[msg.reference_mid];
+            if (!byEmoji[msg.body]) byEmoji[msg.body] = new Set();
+            byEmoji[msg.body].add(msg.from_id);
+        }
+        return map;
+    }
+    
+    function renderReactionBadges(mid, reactionMap) {
+        const reactions = reactionMap[mid];
+        if (!reactions) return '';
+        
+        return `<div class="reaction-badges">${
+            Object.entries(reactions).map(([emoji, senders]) => {
+                const isMine = senders.has(credentials.id);
+                const names = [...senders].map(id => getMemberName(id)).join(', ');
+                return `<button class="reaction-badge ${isMine ? 'mine' : ''}"
+                    title="${names}"
+                    onclick="toggleReaction('${mid}', '${emoji}')"
+                    >${emoji}<span class="reaction-count">${senders.size > 1 ? ' ' + senders.size : ''}</span></button>`;
+            }).join('')
+        }<button class="reaction-badge add-reaction" onclick="showReactionPicker(event, '${mid}')" title="Add reaction">+</button></div>`;
+    }
+    
     function renderRoomMessages() {
         const list = document.getElementById('room-message-list');
         
+        // Build reaction map from all messages
+        const reactionMap = buildReactionMap(roomMessages);
+        
+        // Filter out reaction messages from the main list
+        const displayMessages = roomMessages.filter(m => m.content_type !== 'reaction');
+        
         // Reverse for column-reverse display (newest at bottom visually)
-        const reversed = [...roomMessages].reverse();
+        const reversed = [...displayMessages].reverse();
         
         list.innerHTML = reversed.map(msg => {
             const isMe = msg.from_id === credentials.id;
             const isPending = msg.pending;
             
             return `
-                <div class="room-message ${isMe ? 'from-me' : ''} ${isPending ? 'pending' : ''}">
+                <div class="room-message ${isMe ? 'from-me' : ''} ${isPending ? 'pending' : ''}" data-mid="${msg.mid}">
                     <div class="sender-name">${getMemberName(msg.from_id)}</div>
                     <div class="message-body markdown-body">${renderMessageBody(msg.body, msg.content_type)}</div>
+                    ${renderReactionBadges(msg.mid, reactionMap)}
                     <div class="message-time">${isPending ? 'Sending...' : formatTime(msg.created_at)}</div>
                 </div>
             `;
@@ -825,6 +863,68 @@
             sendBtn.disabled = false;
             sendBtn.textContent = 'Send ➤';
         }
+    }
+    
+    // ==================== REACTIONS ====================
+    
+    async function toggleReaction(targetMid, emoji) {
+        // Check if we already reacted with this emoji
+        const existing = roomMessages.find(m =>
+            m.content_type === 'reaction' &&
+            m.reference_mid === targetMid &&
+            m.body === emoji &&
+            m.from_id === credentials.id
+        );
+        if (existing) return;  // Already reacted, reactions are permanent
+        
+        try {
+            const result = await DeadropAPI.sendRoomMessage(
+                credentials, currentRoomId, emoji, 'reaction', targetMid);
+            roomMessages.push(result);
+            renderRoomMessages();
+        } catch (e) {
+            console.error('Failed to send reaction:', e);
+        }
+    }
+    
+    function showReactionPicker(event, targetMid) {
+        event.stopPropagation();
+        
+        // Remove any existing picker
+        const old = document.getElementById('reaction-picker');
+        if (old) old.remove();
+        
+        const picker = document.createElement('div');
+        picker.id = 'reaction-picker';
+        picker.className = 'reaction-picker';
+        picker.innerHTML = REACTION_EMOJIS.map(emoji =>
+            `<button class="reaction-picker-btn" onclick="pickReaction(event, '${targetMid}', '${emoji}')">${emoji}</button>`
+        ).join('');
+        
+        // Position near the click
+        const rect = event.target.getBoundingClientRect();
+        picker.style.position = 'fixed';
+        picker.style.left = Math.min(rect.left, window.innerWidth - 250) + 'px';
+        picker.style.top = (rect.top - 44) + 'px';
+        picker.style.zIndex = '1500';
+        
+        document.body.appendChild(picker);
+        
+        // Close on click outside
+        const close = (e) => {
+            if (!picker.contains(e.target)) {
+                picker.remove();
+                document.removeEventListener('click', close);
+            }
+        };
+        setTimeout(() => document.addEventListener('click', close), 0);
+    }
+    
+    function pickReaction(event, targetMid, emoji) {
+        event.stopPropagation();
+        const picker = document.getElementById('reaction-picker');
+        if (picker) picker.remove();
+        toggleReaction(targetMid, emoji);
     }
     
     // startRoomPolling removed — subscriptions handle real-time updates


### PR DESCRIPTION
## Summary

Adds reaction emoji support to room messages. Reactions are implemented as regular room messages with `content_type="reaction"` and a `reference_mid` field that points to the target message.

### Backend
- **Migration 003**: Adds `reference_mid` column to `room_messages` table with index
- `send_room_message()` accepts optional `reference_mid` parameter
- API models (`SendRoomMessageRequest`, `RoomMessageInfo`) include `reference_mid`
- Schema version bumped to 3
- **Bug fix**: `get_room_messages()` and `get_room_message()` SELECT queries were missing `reference_mid` column — added to both queries and return dicts

### Web Client
- `buildReactionMap()` groups reaction messages by `reference_mid` → emoji → senders
- `renderReactionBadges()` displays emoji badges on target messages with count and "mine" highlighting
- `toggleReaction()` / `showReactionPicker()` provide a floating picker UI (👍❤️😂🎉👀🙏)
- Reaction messages filtered from main message list display
- `sendRoomMessage()` API call expanded to pass `contentType` and `referenceMid`
- CSS: `.reaction-badges`, `.reaction-badge`, `.reaction-picker` styles

### Docs
- Added Reactions section to `docs/ROOMS.md` covering message format, sending/reading reactions, and design notes

### Design Decisions
- No new tables or API endpoints — reuses existing room messages infrastructure
- Reactions are permanent (cannot be retracted)
- Clients are responsible for filtering and grouping reactions
- Real-time delivery via existing subscription system

### Testing
- All 378 existing tests pass
- Linter clean
- Visual browser testing confirms reaction badges, picker, and end-to-end flow work correctly

Closes #20