### PR TITLE
fix: reaction picker mobile support

### DIFF
--- a/src/deadrop/static/css/style.css
+++ b/src/deadrop/static/css/style.css
@@ -736,12 +736,19 @@ textarea.form-input {
     font-size: 12px;
     color: var(--text-muted);
     padding: 2px 6px;
-    opacity: 0;
+    opacity: 0.4;
     transition: opacity 0.15s ease;
 }
 
 .room-message:hover .reaction-badge.add-reaction {
     opacity: 1;
+}
+
+/* Touch devices: always show the add-reaction button since there's no hover */
+@media (hover: none) {
+    .reaction-badge.add-reaction {
+        opacity: 0.6;
+    }
 }
 
 /* From-me reactions: adjust for blue bubble context */

--- a/src/deadrop/templates/app.html
+++ b/src/deadrop/templates/app.html
@@ -844,14 +844,17 @@
             `<button class="reaction-picker-btn" onclick="pickReaction(event, '${targetMid}', '${emoji}')">${emoji}</button>`
         ).join('');
         
-        // Position near the click
-        const rect = event.target.getBoundingClientRect();
-        picker.style.position = 'fixed';
-        picker.style.left = Math.min(rect.left, window.innerWidth - 250) + 'px';
-        picker.style.top = (rect.top - 44) + 'px';
-        picker.style.zIndex = '1500';
-        
+        // Position near the click, clamped to viewport
         document.body.appendChild(picker);
+        const rect = event.target.getBoundingClientRect();
+        const pickerRect = picker.getBoundingClientRect();
+        const left = Math.max(8, Math.min(rect.left, window.innerWidth - pickerRect.width - 8));
+        let top = rect.top - pickerRect.height - 4;
+        if (top < 8) top = rect.bottom + 4;  // flip below if no room above
+        picker.style.position = 'fixed';
+        picker.style.left = left + 'px';
+        picker.style.top = top + 'px';
+        picker.style.zIndex = '1500';
         
         // Close on click outside
         const close = (e) => {


### PR DESCRIPTION
The add-reaction '+' button was `opacity: 0` with `:hover` to reveal — invisible and untappable on touch devices.

**Fixes:**
- Base opacity 0.4 (subtle but visible on desktop), brightens to 1.0 on hover
- `@media (hover: none)`: 0.6 opacity on touch devices since there's no hover
- Picker positioning: measure actual picker size after DOM append, clamp to viewport edges with 8px margin, flip below target message if no room above