### PR TITLE
fix: show reaction '+' button on all messages

### DIFF
--- a/src/deadrop/db.py
+++ b/src/deadrop/db.py
@@ -1715,9 +1715,11 @@ def list_rooms_for_identity(
                    WHERE rm2.room_id = r.room_id) AS last_activity_at,
                   (SELECT rm3.body FROM room_messages rm3
                    WHERE rm3.room_id = r.room_id
+                     AND rm3.content_type != 'reaction'
                    ORDER BY rm3.mid DESC LIMIT 1) AS last_message_body,
                   (SELECT rm4.from_id FROM room_messages rm4
                    WHERE rm4.room_id = r.room_id
+                     AND rm4.content_type != 'reaction'
                    ORDER BY rm4.mid DESC LIMIT 1) AS last_message_from
            FROM rooms r
            JOIN room_members m ON r.room_id = m.room_id

--- a/src/deadrop/templates/app.html
+++ b/src/deadrop/templates/app.html
@@ -707,18 +707,16 @@
     
     function renderReactionBadges(mid, reactionMap) {
         const reactions = reactionMap[mid];
-        if (!reactions) return '';
+        const badges = reactions ? Object.entries(reactions).map(([emoji, senders]) => {
+            const isMine = senders.has(credentials.id);
+            const names = [...senders].map(id => getMemberName(id)).join(', ');
+            return `<button class="reaction-badge ${isMine ? 'mine' : ''}"
+                title="${names}"
+                onclick="toggleReaction('${mid}', '${emoji}')"
+                >${emoji}<span class="reaction-count">${senders.size > 1 ? ' ' + senders.size : ''}</span></button>`;
+        }).join('') : '';
         
-        return `<div class="reaction-badges">${
-            Object.entries(reactions).map(([emoji, senders]) => {
-                const isMine = senders.has(credentials.id);
-                const names = [...senders].map(id => getMemberName(id)).join(', ');
-                return `<button class="reaction-badge ${isMine ? 'mine' : ''}"
-                    title="${names}"
-                    onclick="toggleReaction('${mid}', '${emoji}')"
-                    >${emoji}<span class="reaction-count">${senders.size > 1 ? ' ' + senders.size : ''}</span></button>`;
-            }).join('')
-        }<button class="reaction-badge add-reaction" onclick="showReactionPicker(event, '${mid}')" title="Add reaction">+</button></div>`;
+        return `<div class="reaction-badges">${badges}<button class="reaction-badge add-reaction" onclick="showReactionPicker(event, '${mid}')" title="Add reaction">+</button></div>`;
     }
     
     function renderRoomMessages() {


### PR DESCRIPTION
Two bugs found via browser testing:

1. **No way to add first reaction**: `renderReactionBadges()` returned empty string when a message had zero reactions, so the '+' button only appeared on messages already having reactions. Fixed by always rendering the reaction badges container with the '+' button.

2. **Reaction emoji in room preview**: The unified inbox `last_message_body`/`last_message_from` subqueries didn't filter `content_type='reaction'`, so a reaction could appear as the room preview. Added `AND rm.content_type != 'reaction'` filter.

378 tests pass, verified in browser.