### PR TITLE
fix: show sender display name in room preview

### DIFF
--- a/src/deadrop/api.py
+++ b/src/deadrop/api.py
@@ -1103,6 +1103,7 @@ class RoomWithMemberInfo(BaseModel):
     last_activity_at: str | None = None
     last_message_body: str | None = None
     last_message_from: str | None = None
+    last_message_from_name: str | None = None
 
 
 class AddRoomMemberRequest(BaseModel):

--- a/src/deadrop/db.py
+++ b/src/deadrop/db.py
@@ -1720,7 +1720,15 @@ def list_rooms_for_identity(
                   (SELECT rm4.from_id FROM room_messages rm4
                    WHERE rm4.room_id = r.room_id
                      AND rm4.content_type != 'reaction'
-                   ORDER BY rm4.mid DESC LIMIT 1) AS last_message_from
+                   ORDER BY rm4.mid DESC LIMIT 1) AS last_message_from,
+                  (SELECT COALESCE(
+                       json_extract(i.metadata, '$.display_name'),
+                       rm5.from_id)
+                   FROM room_messages rm5
+                   LEFT JOIN identities i ON i.id = rm5.from_id AND i.ns = r.ns
+                   WHERE rm5.room_id = r.room_id
+                     AND rm5.content_type != 'reaction'
+                   ORDER BY rm5.mid DESC LIMIT 1) AS last_message_from_name
            FROM rooms r
            JOIN room_members m ON r.room_id = m.room_id
            WHERE r.ns = ? AND m.identity_id = ?

--- a/src/deadrop/templates/app.html
+++ b/src/deadrop/templates/app.html
@@ -459,7 +459,7 @@
                 let preview = `${room.member_count || '?'} members`;
                 if (room.last_message_body) {
                     const senderName = room.last_message_from === credentials.id
-                        ? 'You' : (room.last_message_from?.substring(0, 8) || '?');
+                        ? 'You' : (room.last_message_from_name || room.last_message_from?.substring(0, 8) || '?');
                     preview = `${senderName}: ${room.last_message_body}`;
                 }
                 threads.push({


### PR DESCRIPTION
The unified inbox room preview was showing raw identity IDs instead of display names (e.g. `d0ff5a7a: Looking good!` instead of `Bob: Looking good!`).

Added `last_message_from_name` subquery that joins to the identities table and extracts `display_name` from metadata JSON via `json_extract()`. Falls back to the raw ID if no display name is set.

Frontend fallback chain: `'You'` (if self) → `last_message_from_name` → truncated ID.

378 tests pass, verified in browser.