### PR TITLE
feat: flat threading for rooms (Slack-style)

### DIFF
--- a/docs/THREADS.md
+++ b/docs/THREADS.md
@@ -55,7 +55,7 @@ GET /{ns}/rooms/{room_id}/threads/{root_mid}
 
 ### Room messages (main timeline)
 
-By default, `GET /{ns}/rooms/{room_id}/messages` returns **only top-level messages** — replies and reactions are excluded. Top-level messages include thread metadata:
+By default, `GET /{ns}/rooms/{room_id}/messages` returns all messages including replies (for backward compatibility). Pass `?include_replies=false` to get only top-level messages with thread metadata:
 
 ```json
 {
@@ -68,7 +68,7 @@ By default, `GET /{ns}/rooms/{room_id}/messages` returns **only top-level messag
 }
 ```
 
-To get all messages including replies (useful for agents wanting full context), pass `?include_replies=true`.
+To get only top-level messages with thread metadata, pass `?include_replies=false`. The web UI uses this by default to show a clean timeline.
 
 ### Response fields
 
@@ -86,11 +86,11 @@ client.send_room_message(ns, room_id, secret, body, reference_mid=root_mid)
 # Get a thread
 client.get_thread(ns, room_id, secret, root_mid)
 
-# Get room messages (top-level only, with thread metadata)
+# Get all room messages (default, backward-compatible)
 client.get_room_messages(ns, room_id, secret)
 
-# Get everything including replies
-client.get_room_messages(ns, room_id, secret, include_replies=True)
+# Get top-level only, with thread metadata (reply_count, last_reply_at)
+client.get_room_messages(ns, room_id, secret, include_replies=False)
 ```
 
 ## Web UI

--- a/docs/THREADS.md
+++ b/docs/THREADS.md
@@ -1,0 +1,121 @@
+# Threads
+
+Deadrop rooms support Slack-style flat threads: any top-level message can become the root of a thread, and replies are a flat chronological list under that root.
+
+## Model
+
+A thread reply is a regular `room_messages` row with `reference_mid` pointing to the thread root. Replies always point to a top-level message — there is no nesting.
+
+```
+Main timeline:
+  msg-A: "Let's plan the release"        ← top-level (reference_mid = NULL)
+  msg-F: "Deploy schedule?"              ← top-level (reference_mid = NULL)
+
+Thread on msg-A:
+  msg-B: "I'll handle the API"           ← reply (reference_mid = msg-A)
+  msg-C: "What about migration?"         ← reply (reference_mid = msg-A)
+  msg-D: "Schema looks complex"          ← reply (reference_mid = msg-A)
+```
+
+Reactions continue to use `reference_mid` with `content_type="reaction"`. The distinction is:
+- **Reply**: `reference_mid` is set, `content_type` is NOT `"reaction"`
+- **Reaction**: `reference_mid` is set, `content_type` IS `"reaction"`
+- **Top-level message**: `reference_mid` is NULL
+
+## Schema
+
+No new columns. The existing `reference_mid` column (added in migration 003) and `reference_mid` index handle everything.
+
+Server-side validation ensures replies point to top-level messages only. If `reference_mid` targets a reply (a message that itself has `reference_mid` set and isn't a reaction), the server redirects it to the root — following Slack's behavior where all replies are flat under the root.
+
+## API
+
+### Sending a reply
+
+Same endpoint, set `reference_mid`:
+
+```
+POST /{ns}/rooms/{room_id}/messages
+{
+  "body": "I agree with this",
+  "reference_mid": "<root_mid>"
+}
+```
+
+### Getting a thread
+
+```
+GET /{ns}/rooms/{room_id}/threads/{root_mid}
+→ {
+    "root": { ...message... },
+    "replies": [ ...messages ordered by created_at... ],
+    "reply_count": 3
+  }
+```
+
+### Room messages (main timeline)
+
+By default, `GET /{ns}/rooms/{room_id}/messages` returns **only top-level messages** — replies and reactions are excluded. Top-level messages include thread metadata:
+
+```json
+{
+  "mid": "...",
+  "body": "Let's plan the release",
+  "reply_count": 3,
+  "last_reply_at": "2025-01-15T10:30:00Z",
+  "is_thread_reply": false,
+  ...
+}
+```
+
+To get all messages including replies (useful for agents wanting full context), pass `?include_replies=true`.
+
+### Response fields
+
+Messages include:
+- `is_thread_reply` (bool): true if this message is a reply in a thread
+- `reply_count` (int): number of replies (only on top-level messages, 0 if no thread)
+- `last_reply_at` (str | null): timestamp of most recent reply
+
+## Python client
+
+```python
+# Send a reply
+client.send_room_message(ns, room_id, secret, body, reference_mid=root_mid)
+
+# Get a thread
+client.get_thread(ns, room_id, secret, root_mid)
+
+# Get room messages (top-level only, with thread metadata)
+client.get_room_messages(ns, room_id, secret)
+
+# Get everything including replies
+client.get_room_messages(ns, room_id, secret, include_replies=True)
+```
+
+## Web UI
+
+**Main timeline**: Top-level messages only. Messages with replies show a thread indicator:
+
+```
+┌──────────────────────────────────────┐
+│ Alice                                │
+│ Let's plan the release               │
+│ 👍 2  +    ↩ Reply                   │
+│ 💬 3 replies                  2m ago │
+└──────────────────────────────────────┘
+```
+
+**Thread panel**: Clicking the thread indicator or reply button opens a panel showing the root message and all replies chronologically.
+
+## Design exploration notes
+
+We evaluated three approaches before settling on flat threads:
+
+1. **Materialized path (`thread_path`)** — stores full ancestry as a string column (e.g., `/root_mid/parent_mid/child_mid`). Enables elegant subtree queries and server-side tree-order sorting via `ORDER BY thread_path`. However: unbounded string growth (37 bytes per nesting level), larger index entries, and the client needs the full thread for the panel anyway — making server-side tree ordering redundant.
+
+2. **`thread_root_mid` + `depth`** — fixed-size denormalized columns. Handles arbitrary nesting with simple "get full thread" queries (`WHERE thread_root_mid = ?`). Client reconstructs the tree from `reference_mid` pointers in memory. Reasonable tradeoff, but the nesting UX gets unwieldy and the use case doesn't need it.
+
+3. **Flat threads (Slack-style)** — `reference_mid` only, no new columns. All queries are simple indexed lookups. No tree reconstruction needed. Covers the actual use case for both human chat and agent conversations.
+
+Flat threads win because zero schema changes are needed, all queries are trivial, and the UX is straightforward. If nesting is ever needed, `reference_mid` already supports it — we'd just relax the validation rule.

--- a/src/deadrop/api.py
+++ b/src/deadrop/api.py
@@ -1432,9 +1432,7 @@ async def get_thread(
     if room["ns"] != ns:
         raise HTTPException(404, "Room not found in this namespace")
 
-    thread = await _run_sync(
-        functools.partial(db.get_thread, room_id, root_mid)
-    )
+    thread = await _run_sync(functools.partial(db.get_thread, room_id, root_mid))
 
     if not thread:
         raise HTTPException(404, "Thread root message not found")

--- a/src/deadrop/api.py
+++ b/src/deadrop/api.py
@@ -1133,6 +1133,14 @@ class RoomMessageInfo(BaseModel):
     content_type: str
     reference_mid: str | None = None
     created_at: str
+    # Thread metadata (only present when requested via include_thread_meta)
+    reply_count: int = 0
+    last_reply_at: str | None = None
+
+    @property
+    def is_thread_reply(self) -> bool:
+        """True if this message is a reply in a thread (not a reaction)."""
+        return self.reference_mid is not None and self.content_type != "reaction"
 
     @classmethod
     def from_db(cls, data: dict) -> "RoomMessageInfo":
@@ -1145,6 +1153,8 @@ class RoomMessageInfo(BaseModel):
             content_type=data.get("content_type", "text/plain"),
             reference_mid=data.get("reference_mid"),
             created_at=data["created_at"],
+            reply_count=data.get("reply_count", 0),
+            last_reply_at=data.get("last_reply_at"),
         )
 
 
@@ -1363,6 +1373,7 @@ async def get_room_messages(
     room_id: str,
     after: Annotated[str | None, Query()] = None,
     limit: Annotated[int, Query(ge=1, le=1000)] = 100,
+    include_replies: Annotated[bool, Query()] = True,
     x_inbox_secret: Annotated[str | None, Header()] = None,
 ):
     """Get messages from a room.
@@ -1370,6 +1381,8 @@ async def get_room_messages(
     Query parameters:
     - after: Only return messages after this message ID (for pagination/polling)
     - limit: Maximum number of messages to return (default: 100, max: 1000)
+    - include_replies: If false, exclude thread replies (default: true for backward compat).
+        When false, top-level messages include reply_count and last_reply_at metadata.
 
     For real-time updates, use the POST /{ns}/subscribe endpoint instead.
     """
@@ -1380,13 +1393,56 @@ async def get_room_messages(
     if room["ns"] != ns:
         raise HTTPException(404, "Room not found in this namespace")
 
+    # When filtering replies, also include thread metadata
+    include_thread_meta = not include_replies
+
     messages = await _run_sync(
-        functools.partial(db.get_room_messages, room_id, after_mid=after, limit=limit)
+        functools.partial(
+            db.get_room_messages,
+            room_id,
+            after_mid=after,
+            limit=limit,
+            include_replies=include_replies,
+            include_thread_meta=include_thread_meta,
+        )
     )
 
     return {
         "messages": [RoomMessageInfo.from_db(m).model_dump() for m in messages],
         "room_id": room_id,
+    }
+
+
+@app.get("/{ns}/rooms/{room_id}/threads/{root_mid}")
+async def get_thread(
+    ns: str,
+    room_id: str,
+    root_mid: str,
+    x_inbox_secret: Annotated[str | None, Header()] = None,
+):
+    """Get a thread: the root message and all its replies.
+
+    Returns the root message, all thread replies (excluding reactions) in
+    chronological order, and the reply count.
+    """
+    import functools
+
+    room, identity_id = await _require_room_member(room_id, x_inbox_secret)
+
+    if room["ns"] != ns:
+        raise HTTPException(404, "Room not found in this namespace")
+
+    thread = await _run_sync(
+        functools.partial(db.get_thread, room_id, root_mid)
+    )
+
+    if not thread:
+        raise HTTPException(404, "Thread root message not found")
+
+    return {
+        "root": RoomMessageInfo.from_db(thread["root"]).model_dump(),
+        "replies": [RoomMessageInfo.from_db(r).model_dump() for r in thread["replies"]],
+        "reply_count": thread["reply_count"],
     }
 
 

--- a/src/deadrop/backends.py
+++ b/src/deadrop/backends.py
@@ -982,8 +982,12 @@ class LocalBackend(Backend):
             raise ValueError("Room not found in this namespace")
 
         return db.send_room_message(
-            room_id, from_id, body, content_type,
-            reference_mid=reference_mid, conn=self._conn,
+            room_id,
+            from_id,
+            body,
+            content_type,
+            reference_mid=reference_mid,
+            conn=self._conn,
         )
 
     def get_room_messages(
@@ -1005,7 +1009,9 @@ class LocalBackend(Backend):
 
         include_thread_meta = not include_replies
         return db.get_room_messages(
-            room_id, after_mid=after_mid, limit=limit,
+            room_id,
+            after_mid=after_mid,
+            limit=limit,
             include_replies=include_replies,
             include_thread_meta=include_thread_meta,
             conn=self._conn,

--- a/src/deadrop/backends.py
+++ b/src/deadrop/backends.py
@@ -366,6 +366,7 @@ class Backend(ABC):
         secret: str,
         body: str,
         content_type: str = "text/plain",
+        reference_mid: str | None = None,
     ) -> dict[str, Any]:
         """Send a message to a room.
 
@@ -375,6 +376,7 @@ class Backend(ABC):
             secret: Sender's inbox secret (must be a member)
             body: Message body
             content_type: MIME type
+            reference_mid: Optional message ID to reply to (thread root)
 
         Returns:
             Message dict
@@ -389,6 +391,7 @@ class Backend(ABC):
         secret: str,
         after_mid: str | None = None,
         limit: int = 100,
+        include_replies: bool = True,
     ) -> list[dict[str, Any]]:
         """Get messages from a room.
 
@@ -398,9 +401,31 @@ class Backend(ABC):
             secret: Caller's inbox secret (must be a member)
             after_mid: Only get messages after this ID
             limit: Maximum messages to return
+            include_replies: If False, exclude thread replies
 
         Returns:
             List of message dicts
+        """
+        ...
+
+    @abstractmethod
+    def get_thread(
+        self,
+        ns: str,
+        room_id: str,
+        secret: str,
+        root_mid: str,
+    ) -> dict[str, Any] | None:
+        """Get a thread: root message and all replies.
+
+        Args:
+            ns: Namespace ID
+            room_id: Room ID
+            secret: Caller's inbox secret (must be a member)
+            root_mid: Message ID of the thread root
+
+        Returns:
+            Dict with "root", "replies", "reply_count", or None if not found
         """
         ...
 
@@ -946,6 +971,7 @@ class LocalBackend(Backend):
         secret: str,
         body: str,
         content_type: str = "text/plain",
+        reference_mid: str | None = None,
     ) -> dict[str, Any]:
         from_id = derive_id(secret)
         if not db.is_room_member(room_id, from_id, conn=self._conn):
@@ -955,7 +981,10 @@ class LocalBackend(Backend):
         if not room or room.get("ns") != ns:
             raise ValueError("Room not found in this namespace")
 
-        return db.send_room_message(room_id, from_id, body, content_type, conn=self._conn)
+        return db.send_room_message(
+            room_id, from_id, body, content_type,
+            reference_mid=reference_mid, conn=self._conn,
+        )
 
     def get_room_messages(
         self,
@@ -964,6 +993,7 @@ class LocalBackend(Backend):
         secret: str,
         after_mid: str | None = None,
         limit: int = 100,
+        include_replies: bool = True,
     ) -> list[dict[str, Any]]:
         identity_id = derive_id(secret)
         if not db.is_room_member(room_id, identity_id, conn=self._conn):
@@ -973,7 +1003,30 @@ class LocalBackend(Backend):
         if not room or room.get("ns") != ns:
             raise ValueError("Room not found in this namespace")
 
-        return db.get_room_messages(room_id, after_mid=after_mid, limit=limit, conn=self._conn)
+        include_thread_meta = not include_replies
+        return db.get_room_messages(
+            room_id, after_mid=after_mid, limit=limit,
+            include_replies=include_replies,
+            include_thread_meta=include_thread_meta,
+            conn=self._conn,
+        )
+
+    def get_thread(
+        self,
+        ns: str,
+        room_id: str,
+        secret: str,
+        root_mid: str,
+    ) -> dict[str, Any] | None:
+        identity_id = derive_id(secret)
+        if not db.is_room_member(room_id, identity_id, conn=self._conn):
+            raise PermissionError("Not a member of this room")
+
+        room = db.get_room(room_id, conn=self._conn)
+        if not room or room.get("ns") != ns:
+            raise ValueError("Room not found in this namespace")
+
+        return db.get_thread(room_id, root_mid, conn=self._conn)
 
     def update_room_read_cursor(
         self,
@@ -1597,11 +1650,15 @@ class RemoteBackend(Backend):
         secret: str,
         body: str,
         content_type: str = "text/plain",
+        reference_mid: str | None = None,
     ) -> dict[str, Any]:
+        payload: dict[str, Any] = {"body": body, "content_type": content_type}
+        if reference_mid is not None:
+            payload["reference_mid"] = reference_mid
         return self._request(
             "POST",
             f"/{ns}/rooms/{room_id}/messages",
-            json={"body": body, "content_type": content_type},
+            json=payload,
             headers=self._inbox_headers(secret),
         )
 
@@ -1612,12 +1669,15 @@ class RemoteBackend(Backend):
         secret: str,
         after_mid: str | None = None,
         limit: int = 100,
+        include_replies: bool = True,
     ) -> list[dict[str, Any]]:
         params = []
         if after_mid:
             params.append(f"after={after_mid}")
         if limit != 100:
             params.append(f"limit={limit}")
+        if not include_replies:
+            params.append("include_replies=false")
 
         path = f"/{ns}/rooms/{room_id}/messages"
         if params:
@@ -1629,6 +1689,22 @@ class RemoteBackend(Backend):
             headers=self._inbox_headers(secret),
         )
         return result.get("messages", [])
+
+    def get_thread(
+        self,
+        ns: str,
+        room_id: str,
+        secret: str,
+        root_mid: str,
+    ) -> dict[str, Any] | None:
+        try:
+            return self._request(
+                "GET",
+                f"/{ns}/rooms/{room_id}/threads/{root_mid}",
+                headers=self._inbox_headers(secret),
+            )
+        except Exception:
+            return None
 
     def update_room_read_cursor(
         self,

--- a/src/deadrop/client.py
+++ b/src/deadrop/client.py
@@ -519,6 +519,7 @@ class Deaddrop:
         secret: str,
         body: str,
         content_type: str = "text/plain",
+        reference_mid: str | None = None,
     ) -> dict[str, Any]:
         """Send a message to a room.
 
@@ -528,11 +529,15 @@ class Deaddrop:
             secret: Sender's inbox secret (must be a member).
             body: Message body.
             content_type: MIME type.
+            reference_mid: Optional message ID to reply to (creates a thread reply).
 
         Returns:
             Message dict.
         """
-        return self._backend.send_room_message(ns, room_id, secret, body, content_type)
+        return self._backend.send_room_message(
+            ns, room_id, secret, body, content_type,
+            reference_mid=reference_mid,
+        )
 
     def get_room_messages(
         self,
@@ -541,6 +546,7 @@ class Deaddrop:
         secret: str,
         after_mid: str | None = None,
         limit: int = 100,
+        include_replies: bool = True,
     ) -> list[dict[str, Any]]:
         """Get messages from a room.
 
@@ -550,13 +556,36 @@ class Deaddrop:
             secret: Caller's inbox secret (must be a member).
             after_mid: Only get messages after this ID.
             limit: Maximum messages to return.
+            include_replies: If False, exclude thread replies and include
+                thread metadata (reply_count, last_reply_at) on root messages.
 
         Returns:
             List of message dicts.
         """
         return self._backend.get_room_messages(
-            ns, room_id, secret, after_mid=after_mid, limit=limit
+            ns, room_id, secret, after_mid=after_mid, limit=limit,
+            include_replies=include_replies,
         )
+
+    def get_thread(
+        self,
+        ns: str,
+        room_id: str,
+        secret: str,
+        root_mid: str,
+    ) -> dict[str, Any] | None:
+        """Get a thread: root message and all replies.
+
+        Args:
+            ns: Namespace ID.
+            room_id: Room ID.
+            secret: Caller's inbox secret (must be a member).
+            root_mid: Message ID of the thread root.
+
+        Returns:
+            Dict with "root", "replies", "reply_count", or None if not found.
+        """
+        return self._backend.get_thread(ns, room_id, secret, root_mid)
 
     def update_room_read_cursor(
         self,

--- a/src/deadrop/client.py
+++ b/src/deadrop/client.py
@@ -535,7 +535,11 @@ class Deaddrop:
             Message dict.
         """
         return self._backend.send_room_message(
-            ns, room_id, secret, body, content_type,
+            ns,
+            room_id,
+            secret,
+            body,
+            content_type,
             reference_mid=reference_mid,
         )
 
@@ -563,7 +567,11 @@ class Deaddrop:
             List of message dicts.
         """
         return self._backend.get_room_messages(
-            ns, room_id, secret, after_mid=after_mid, limit=limit,
+            ns,
+            room_id,
+            secret,
+            after_mid=after_mid,
+            limit=limit,
             include_replies=include_replies,
         )
 

--- a/src/deadrop/db.py
+++ b/src/deadrop/db.py
@@ -1905,19 +1905,26 @@ def send_room_message(
 ) -> dict:
     """Send a message to a room.
 
+    For thread replies (non-reaction messages with reference_mid set),
+    the reference_mid must point to a top-level message. If it points to
+    another reply, it is silently redirected to the thread root (Slack-style
+    flat threading).
+
     Args:
         room_id: Room ID
         from_id: Sender identity ID (must be a member)
         body: Message body
         content_type: Content type (default: text/plain)
-        reference_mid: Optional message ID this message references (e.g. for reactions)
+        reference_mid: Optional message ID this references.
+            For reactions (content_type="reaction"): the message being reacted to.
+            For thread replies: the thread root message.
         conn: Optional database connection
 
     Returns:
         Message info dict
 
     Raises:
-        ValueError: If room not found or sender not a member
+        ValueError: If room not found, sender not a member, or reference_mid invalid
     """
     conn = _get_conn(conn)
 
@@ -1929,6 +1936,15 @@ def send_room_message(
     # Verify sender is a member
     if not is_room_member(room_id, from_id, conn=conn):
         raise ValueError(f"Identity {from_id} is not a member of room {room_id}")
+
+    # Validate and resolve reference_mid for thread replies
+    if reference_mid is not None and content_type != "reaction":
+        ref_msg = get_room_message(room_id, reference_mid, conn=conn)
+        if not ref_msg:
+            raise ValueError(f"Referenced message {reference_mid} not found in room {room_id}")
+        # If the target is itself a reply (not a reaction), redirect to the root
+        if ref_msg.get("reference_mid") and ref_msg.get("content_type") != "reaction":
+            reference_mid = ref_msg["reference_mid"]
 
     mid = str(make_uuid7())
     now = datetime.now(timezone.utc).isoformat()
@@ -1987,6 +2003,8 @@ def get_room_messages(
     room_id: str,
     after_mid: str | None = None,
     limit: int = 100,
+    include_replies: bool = True,
+    include_thread_meta: bool = False,
     conn: sqlite3.Connection | None = None,
 ) -> list[dict]:
     """Get messages from a room.
@@ -1995,6 +2013,11 @@ def get_room_messages(
         room_id: Room ID
         after_mid: Only get messages after this message ID (for pagination/polling)
         limit: Maximum number of messages to return
+        include_replies: If False, exclude thread replies (messages with reference_mid
+            set and content_type != 'reaction'). Reactions are always included.
+            Default True for backward compatibility.
+        include_thread_meta: If True, include reply_count and last_reply_at fields
+            on top-level messages that have thread replies.
         conn: Optional database connection
 
     Returns:
@@ -2009,6 +2032,10 @@ def get_room_messages(
     """
     params: list[Any] = [room_id]
 
+    if not include_replies:
+        # Exclude thread replies but keep reactions and top-level messages
+        query += " AND (reference_mid IS NULL OR content_type = 'reaction')"
+
     if after_mid:
         query += " AND mid > ?"
         params.append(after_mid)
@@ -2019,7 +2046,7 @@ def get_room_messages(
     cursor = conn.execute(query, tuple(params))
     rows = _rows_to_dicts(cursor.description, cursor.fetchall())
 
-    return [
+    messages = [
         {
             "mid": row["mid"],
             "room_id": row["room_id"],
@@ -2031,6 +2058,119 @@ def get_room_messages(
         }
         for row in rows
     ]
+
+    # Add thread metadata if requested
+    if include_thread_meta:
+        # Collect mids of top-level messages to look up thread info
+        top_level_mids = [
+            m["mid"] for m in messages
+            if not m.get("reference_mid") or m.get("content_type") == "reaction"
+        ]
+        if top_level_mids:
+            thread_meta = _get_thread_metadata(room_id, top_level_mids, conn=conn)
+            for msg in messages:
+                meta = thread_meta.get(msg["mid"])
+                if meta:
+                    msg["reply_count"] = meta["reply_count"]
+                    msg["last_reply_at"] = meta["last_reply_at"]
+                else:
+                    msg["reply_count"] = 0
+                    msg["last_reply_at"] = None
+
+    return messages
+
+
+def _get_thread_metadata(
+    room_id: str,
+    root_mids: list[str],
+    conn: sqlite3.Connection | None = None,
+) -> dict[str, dict]:
+    """Get thread reply counts and last reply timestamps for root messages.
+
+    Args:
+        room_id: Room ID
+        root_mids: List of root message IDs to get metadata for
+        conn: Optional database connection
+
+    Returns:
+        Dict mapping root_mid → {"reply_count": int, "last_reply_at": str | None}
+    """
+    conn = _get_conn(conn)
+
+    if not root_mids:
+        return {}
+
+    placeholders = ",".join("?" * len(root_mids))
+    cursor = conn.execute(
+        f"""SELECT reference_mid, COUNT(*) as reply_count, MAX(created_at) as last_reply_at
+            FROM room_messages
+            WHERE room_id = ? AND reference_mid IN ({placeholders})
+            AND content_type != 'reaction'
+            GROUP BY reference_mid""",
+        tuple([room_id] + root_mids),
+    )
+    rows = _rows_to_dicts(cursor.description, cursor.fetchall())
+
+    return {
+        row["reference_mid"]: {
+            "reply_count": row["reply_count"],
+            "last_reply_at": row["last_reply_at"],
+        }
+        for row in rows
+    }
+
+
+def get_thread(
+    room_id: str,
+    root_mid: str,
+    conn: sqlite3.Connection | None = None,
+) -> dict | None:
+    """Get a thread: the root message and all its replies.
+
+    Args:
+        room_id: Room ID
+        root_mid: Message ID of the thread root
+        conn: Optional database connection
+
+    Returns:
+        Dict with "root" (message dict), "replies" (list of message dicts),
+        and "reply_count" (int). Returns None if root message not found.
+    """
+    conn = _get_conn(conn)
+
+    # Get the root message
+    root = get_room_message(room_id, root_mid, conn=conn)
+    if not root:
+        return None
+
+    # Get all replies (non-reaction messages referencing this root)
+    cursor = conn.execute(
+        """SELECT mid, room_id, from_id, body, content_type, reference_mid, created_at
+           FROM room_messages
+           WHERE room_id = ? AND reference_mid = ? AND content_type != 'reaction'
+           ORDER BY mid""",
+        (room_id, root_mid),
+    )
+    rows = _rows_to_dicts(cursor.description, cursor.fetchall())
+
+    replies = [
+        {
+            "mid": row["mid"],
+            "room_id": row["room_id"],
+            "from": row["from_id"],
+            "body": row["body"],
+            "content_type": row.get("content_type") or "text/plain",
+            "reference_mid": row.get("reference_mid"),
+            "created_at": row["created_at"],
+        }
+        for row in rows
+    ]
+
+    return {
+        "root": root,
+        "replies": replies,
+        "reply_count": len(replies),
+    }
 
 
 def get_room_message(

--- a/src/deadrop/static/css/style.css
+++ b/src/deadrop/static/css/style.css
@@ -870,3 +870,124 @@ button:disabled {
 .view > .compose-area {
     flex-shrink: 0;
 }
+
+/* ==================== THREAD PANEL ==================== */
+
+.thread-panel {
+    width: 380px;
+    max-width: 50vw;
+    border-left: 1px solid var(--border-color);
+    background: var(--card-bg);
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 0;
+}
+
+.thread-panel.hidden {
+    display: none !important;
+}
+
+.thread-panel-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border-color);
+    flex-shrink: 0;
+}
+
+.thread-panel-header h2 {
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+.thread-message-list {
+    flex: 1;
+    overflow-y: auto;
+    min-height: 0;
+    padding: 12px;
+}
+
+.thread-compose {
+    flex-shrink: 0;
+    border-top: 1px solid var(--border-color);
+    padding: 12px;
+}
+
+/* Thread root in panel — slightly highlighted */
+.thread-root-msg {
+    padding-bottom: 12px;
+    margin-bottom: 12px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.thread-reply-divider {
+    font-size: 12px;
+    color: var(--text-muted);
+    padding: 4px 0 8px;
+}
+
+/* Thread indicator on main message list */
+.thread-indicator {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 8px;
+    margin-top: 4px;
+    font-size: 12px;
+    color: var(--primary-color);
+    cursor: pointer;
+    border-radius: 4px;
+    transition: background 0.15s;
+}
+
+.thread-indicator:hover {
+    background: rgba(37, 99, 235, 0.08);
+    text-decoration: underline;
+}
+
+.thread-indicator .thread-icon {
+    font-size: 14px;
+}
+
+/* Reply button on hover */
+.room-message .reply-btn {
+    display: none;
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    padding: 2px 6px;
+    font-size: 12px;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    cursor: pointer;
+    color: var(--text-muted);
+}
+
+.room-message {
+    position: relative;
+}
+
+.room-message:hover .reply-btn {
+    display: block;
+}
+
+.room-message:hover .reply-btn:hover {
+    background: var(--bg-color);
+    color: var(--primary-color);
+}
+
+/* Responsive: hide thread panel on small screens, show as overlay */
+@media (max-width: 640px) {
+    .thread-panel {
+        position: fixed;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        width: 100vw;
+        max-width: 100vw;
+        z-index: 200;
+        box-shadow: -4px 0 16px rgba(0, 0, 0, 0.15);
+    }
+}

--- a/src/deadrop/static/js/api.js
+++ b/src/deadrop/static/js/api.js
@@ -144,6 +144,27 @@ const DeadropAPI = {
     },
 
     /**
+     * Get room messages (top-level only, with thread metadata).
+     */
+    async getRoomMessagesTopLevel(credentials, roomId, { afterMid = null, limit = null } = {}) {
+        let path = `/${credentials.ns}/rooms/${roomId}/messages`;
+        const params = new URLSearchParams();
+        params.set('include_replies', 'false');
+        if (afterMid) params.set('after', afterMid);
+        if (limit) params.set('limit', limit.toString());
+        path += '?' + params.toString();
+        
+        return this.request('GET', path, { credentials });
+    },
+
+    /**
+     * Get a thread (root message + all replies).
+     */
+    async getThread(credentials, roomId, rootMid) {
+        return this.request('GET', `/${credentials.ns}/rooms/${roomId}/threads/${rootMid}`, { credentials });
+    },
+
+    /**
      * Send a message to a room.
      */
     async sendRoomMessage(credentials, roomId, body, contentType = 'text/plain', referenceMid = null) {

--- a/src/deadrop/templates/app.html
+++ b/src/deadrop/templates/app.html
@@ -794,6 +794,16 @@
     }
     
     /**
+     * Safely add a message to roomMessages, preventing duplicates.
+     * Returns true if the message was added, false if already present.
+     */
+    function addRoomMessage(msg) {
+        if (roomMessages.some(m => m.mid === msg.mid)) return false;
+        roomMessages.push(msg);
+        return true;
+    }
+    
+    /**
      * Check if a message is a thread reply (non-reaction with reference_mid set).
      */
     function isThreadReply(msg) {
@@ -976,10 +986,7 @@
             renderThread();
             
             // Add to main room messages list (deduplicated — subscription may also deliver it)
-            const existingMids = new Set(roomMessages.map(m => m.mid));
-            if (!existingMids.has(result.mid)) {
-                roomMessages.push(result);
-            }
+            addRoomMessage(result);
             renderRoomMessages();
         } catch (e) {
             alert('Failed to send reply: ' + e.message);
@@ -1005,7 +1012,7 @@
         try {
             const result = await DeadropAPI.sendRoomMessage(
                 credentials, currentRoomId, emoji, 'reaction', targetMid);
-            roomMessages.push(result);
+            addRoomMessage(result);
             renderRoomMessages();
         } catch (e) {
             console.error('Failed to send reaction:', e);
@@ -1135,8 +1142,12 @@
             if (result?.messages?.length > 0) {
                 // Filter out any messages we already have (including pending/optimistic)
                 const newMsgs = result.messages.filter(m => !existingMids.has(m.mid));
-                if (newMsgs.length > 0) {
-                    roomMessages = [...roomMessages, ...newMsgs];
+                // Double-check dedup with addRoomMessage (guards against races)
+                let addedAny = false;
+                for (const msg of newMsgs) {
+                    if (addRoomMessage(msg)) addedAny = true;
+                }
+                if (addedAny) {
                     const cacheKey = `room_messages_${roomId}`;
                     localStorage.setItem(cacheKey, JSON.stringify(roomMessages));
                     renderRoomMessages();

--- a/src/deadrop/templates/app.html
+++ b/src/deadrop/templates/app.html
@@ -1154,16 +1154,25 @@
                     
                     // If thread panel is open, check if any new messages belong to it
                     if (currentThreadRootMid) {
-                        const threadReplies = newMsgs.filter(m => 
-                            m.reference_mid === currentThreadRootMid && m.content_type !== 'reaction'
-                        );
-                        if (threadReplies.length > 0) {
-                            const existingThreadMids = new Set(threadMessages.map(m => m.mid));
-                            for (const reply of threadReplies) {
-                                if (!existingThreadMids.has(reply.mid)) {
-                                    threadMessages.push(reply);
+                        const threadMids = new Set(threadMessages.map(m => m.mid));
+                        let threadChanged = false;
+                        
+                        for (const msg of newMsgs) {
+                            // New reply to this thread
+                            if (msg.reference_mid === currentThreadRootMid && msg.content_type !== 'reaction') {
+                                if (!threadMids.has(msg.mid)) {
+                                    threadMessages.push(msg);
+                                    threadMids.add(msg.mid);
+                                    threadChanged = true;
                                 }
                             }
+                            // New reaction targeting any message in this thread — re-render
+                            if (msg.content_type === 'reaction' && threadMids.has(msg.reference_mid)) {
+                                threadChanged = true;
+                            }
+                        }
+                        
+                        if (threadChanged) {
                             renderThread();
                         }
                     }

--- a/src/deadrop/templates/app.html
+++ b/src/deadrop/templates/app.html
@@ -847,9 +847,13 @@
             const elapsed = Math.round(performance.now() - startTime);
             console.log(`Room message sent in ${elapsed}ms`);
             
-            // Replace optimistic message with real one
+            // Replace optimistic message with real one (or remove it if subscription already added the real one)
             const idx = roomMessages.findIndex(m => m.mid === optimisticMsg.mid);
-            if (idx >= 0) {
+            const realIdx = roomMessages.findIndex(m => m.mid === result.mid);
+            if (realIdx >= 0 && idx >= 0) {
+                // Subscription already delivered the real message; just remove optimistic
+                roomMessages.splice(idx, 1);
+            } else if (idx >= 0) {
                 roomMessages[idx] = result;
             }
             renderRoomMessages();
@@ -971,8 +975,11 @@
             threadMessages.push(result);
             renderThread();
             
-            // Add to main room messages list (so thread meta updates)
-            roomMessages.push(result);
+            // Add to main room messages list (deduplicated — subscription may also deliver it)
+            const existingMids = new Set(roomMessages.map(m => m.mid));
+            if (!existingMids.has(result.mid)) {
+                roomMessages.push(result);
+            }
             renderRoomMessages();
         } catch (e) {
             alert('Failed to send reply: ' + e.message);

--- a/src/deadrop/templates/app.html
+++ b/src/deadrop/templates/app.html
@@ -95,9 +95,25 @@
             </div>
         </div>
         
-        <div id="room-message-list" class="message-list"></div>
+        <div style="display: flex; flex: 1; overflow: hidden;">
+            <div id="room-message-list" class="message-list" style="flex: 1;"></div>
+            
+            <!-- Thread Panel (slides in from right) -->
+            <div id="thread-panel" class="thread-panel hidden">
+                <div class="thread-panel-header">
+                    <h2>Thread</h2>
+                    <button id="thread-panel-close" class="btn btn-icon" title="Close thread">✕</button>
+                </div>
+                <div id="thread-messages" class="message-list thread-message-list"></div>
+                <div class="compose-area thread-compose">
+                    <textarea id="thread-message-input" class="compose-input" 
+                              placeholder="Reply in thread..." rows="1" enterkeyhint="send"></textarea>
+                    <button id="thread-send-btn" class="btn btn-primary">Reply ➤</button>
+                </div>
+            </div>
+        </div>
         
-        <div class="compose-area">
+        <div class="compose-area" id="room-compose-area">
             <textarea id="room-message-input" class="compose-input" 
                       placeholder="Type a message..." rows="1" enterkeyhint="send"></textarea>
             <button id="room-send-btn" class="btn btn-primary">Send ➤</button>
@@ -184,6 +200,10 @@
     let roomMessagesLoading = false;  // Guard against concurrent fetches
     // Legacy long-poll removed — subscriptions are the sole update mechanism
     let subscriptionManager = null;  // Unified subscription manager
+    
+    // Thread state
+    let currentThreadRootMid = null;
+    let threadMessages = [];  // [root, ...replies]
     
     // DOM elements
     const views = {
@@ -725,8 +745,13 @@
         // Build reaction map from all messages
         const reactionMap = buildReactionMap(roomMessages);
         
-        // Filter out reaction messages from the main list
-        const displayMessages = roomMessages.filter(m => m.content_type !== 'reaction');
+        // Build thread metadata map: root_mid → { reply_count, last_reply_at }
+        const threadMetaMap = buildThreadMetaMap(roomMessages);
+        
+        // Filter out reaction messages AND thread replies from the main list
+        const displayMessages = roomMessages.filter(m => 
+            m.content_type !== 'reaction' && !isThreadReply(m)
+        );
         
         // Reverse for column-reverse display (newest at bottom visually)
         const reversed = [...displayMessages].reverse();
@@ -734,12 +759,22 @@
         list.innerHTML = reversed.map(msg => {
             const isMe = msg.from_id === credentials.id;
             const isPending = msg.pending;
+            const threadMeta = threadMetaMap[msg.mid];
+            const threadIndicator = threadMeta 
+                ? `<div class="thread-indicator" onclick="openThread('${msg.mid}')">
+                     <span class="thread-icon">💬</span>
+                     ${threadMeta.reply_count} ${threadMeta.reply_count === 1 ? 'reply' : 'replies'}
+                     <span style="color: var(--text-muted); margin-left: 4px;">${formatTime(threadMeta.last_reply_at)}</span>
+                   </div>`
+                : '';
             
             return `
                 <div class="room-message ${isMe ? 'from-me' : ''} ${isPending ? 'pending' : ''}" data-mid="${msg.mid}">
+                    <button class="reply-btn" onclick="openThread('${msg.mid}')" title="Reply in thread">💬</button>
                     <div class="sender-name">${getMemberName(msg.from_id)}</div>
                     <div class="message-body markdown-body">${renderMessageBody(msg.body, msg.content_type)}</div>
                     ${renderReactionBadges(msg.mid, reactionMap)}
+                    ${threadIndicator}
                     <div class="message-time">${isPending ? 'Sending...' : formatTime(msg.created_at)}</div>
                 </div>
             `;
@@ -756,6 +791,31 @@
             const lastMid = realMessages[realMessages.length - 1].mid;
             DeadropAPI.updateRoomReadCursor(credentials, currentRoomId, lastMid).catch(() => {});
         }
+    }
+    
+    /**
+     * Check if a message is a thread reply (non-reaction with reference_mid set).
+     */
+    function isThreadReply(msg) {
+        return msg.reference_mid && msg.content_type !== 'reaction';
+    }
+    
+    /**
+     * Build thread metadata from messages: root_mid → { reply_count, last_reply_at }
+     */
+    function buildThreadMetaMap(messages) {
+        const map = {};
+        for (const msg of messages) {
+            if (!isThreadReply(msg)) continue;
+            if (!map[msg.reference_mid]) {
+                map[msg.reference_mid] = { reply_count: 0, last_reply_at: null };
+            }
+            map[msg.reference_mid].reply_count++;
+            if (!map[msg.reference_mid].last_reply_at || msg.created_at > map[msg.reference_mid].last_reply_at) {
+                map[msg.reference_mid].last_reply_at = msg.created_at;
+            }
+        }
+        return map;
     }
     
     async function sendRoomMessage() {
@@ -803,6 +863,123 @@
         } finally {
             sendBtn.disabled = false;
             sendBtn.textContent = 'Send ➤';
+        }
+    }
+    
+    // ==================== THREADS ====================
+    
+    async function openThread(rootMid) {
+        currentThreadRootMid = rootMid;
+        
+        const panel = document.getElementById('thread-panel');
+        const msgList = document.getElementById('thread-messages');
+        
+        panel.classList.remove('hidden');
+        msgList.innerHTML = '<div class="loading"><div class="spinner"></div></div>';
+        
+        try {
+            const thread = await DeadropAPI.getThread(credentials, currentRoomId, rootMid);
+            
+            // Build thread messages array: root + replies
+            threadMessages = [thread.root, ...thread.replies];
+            renderThread();
+        } catch (e) {
+            msgList.innerHTML = `<div class="error-message">Failed to load thread: ${e.message}</div>`;
+        }
+        
+        // Focus the thread input
+        document.getElementById('thread-message-input').focus();
+    }
+    
+    function closeThread() {
+        currentThreadRootMid = null;
+        threadMessages = [];
+        document.getElementById('thread-panel').classList.add('hidden');
+    }
+    
+    function renderThread() {
+        const list = document.getElementById('thread-messages');
+        
+        if (threadMessages.length === 0) {
+            list.innerHTML = '<div class="empty-state">No messages</div>';
+            return;
+        }
+        
+        // Build reaction map for thread messages
+        const allMids = new Set(threadMessages.map(m => m.mid));
+        const threadReactions = roomMessages.filter(m => 
+            m.content_type === 'reaction' && allMids.has(m.reference_mid)
+        );
+        const reactionMap = buildReactionMap([...threadMessages, ...threadReactions]);
+        
+        const root = threadMessages[0];
+        const replies = threadMessages.slice(1);
+        
+        // Reverse for column-reverse display
+        const items = [];
+        
+        // Replies (reversed for column-reverse)
+        for (let i = replies.length - 1; i >= 0; i--) {
+            const msg = replies[i];
+            const isMe = msg.from_id === credentials.id;
+            items.push(`
+                <div class="room-message ${isMe ? 'from-me' : ''}" data-mid="${msg.mid}">
+                    <div class="sender-name">${getMemberName(msg.from_id)}</div>
+                    <div class="message-body markdown-body">${renderMessageBody(msg.body, msg.content_type)}</div>
+                    ${renderReactionBadges(msg.mid, reactionMap)}
+                    <div class="message-time">${formatTime(msg.created_at)}</div>
+                </div>
+            `);
+        }
+        
+        // Reply count divider
+        if (replies.length > 0) {
+            items.push(`<div class="thread-reply-divider">${replies.length} ${replies.length === 1 ? 'reply' : 'replies'}</div>`);
+        }
+        
+        // Root message (at the "bottom" in reversed display = top visually)
+        const isRootMe = root.from_id === credentials.id;
+        items.push(`
+            <div class="room-message thread-root-msg ${isRootMe ? 'from-me' : ''}" data-mid="${root.mid}">
+                <div class="sender-name">${getMemberName(root.from_id)}</div>
+                <div class="message-body markdown-body">${renderMessageBody(root.body, root.content_type)}</div>
+                ${renderReactionBadges(root.mid, reactionMap)}
+                <div class="message-time">${formatTime(root.created_at)}</div>
+            </div>
+        `);
+        
+        list.innerHTML = items.join('');
+        highlightCodeBlocks(list);
+    }
+    
+    async function sendThreadReply() {
+        const input = document.getElementById('thread-message-input');
+        const sendBtn = document.getElementById('thread-send-btn');
+        const body = input.value.trim();
+        if (!body || !currentThreadRootMid) return;
+        
+        input.value = '';
+        sendBtn.disabled = true;
+        sendBtn.textContent = 'Sending...';
+        
+        try {
+            const result = await DeadropAPI.sendRoomMessage(
+                credentials, currentRoomId, body, 'text/plain', currentThreadRootMid
+            );
+            
+            // Add to thread view
+            threadMessages.push(result);
+            renderThread();
+            
+            // Add to main room messages list (so thread meta updates)
+            roomMessages.push(result);
+            renderRoomMessages();
+        } catch (e) {
+            alert('Failed to send reply: ' + e.message);
+            input.value = body;
+        } finally {
+            sendBtn.disabled = false;
+            sendBtn.textContent = 'Reply ➤';
         }
     }
     
@@ -956,6 +1133,22 @@
                     const cacheKey = `room_messages_${roomId}`;
                     localStorage.setItem(cacheKey, JSON.stringify(roomMessages));
                     renderRoomMessages();
+                    
+                    // If thread panel is open, check if any new messages belong to it
+                    if (currentThreadRootMid) {
+                        const threadReplies = newMsgs.filter(m => 
+                            m.reference_mid === currentThreadRootMid && m.content_type !== 'reaction'
+                        );
+                        if (threadReplies.length > 0) {
+                            const existingThreadMids = new Set(threadMessages.map(m => m.mid));
+                            for (const reply of threadReplies) {
+                                if (!existingThreadMids.has(reply.mid)) {
+                                    threadMessages.push(reply);
+                                }
+                            }
+                            renderThread();
+                        }
+                    }
                 }
                 
                 // Update subscription cursor (always, even if deduplicated)
@@ -1030,6 +1223,7 @@
     
     document.getElementById('room-chat-back').addEventListener('click', (e) => {
         e.preventDefault();
+        closeThread();
         currentRoomId = null;
         roomMessages = [];
         roomMembers = {};
@@ -1067,6 +1261,16 @@
         if (e.key === 'Enter' && !e.shiftKey) {
             e.preventDefault();
             sendRoomMessage();
+        }
+    });
+    
+    // Thread panel events
+    document.getElementById('thread-panel-close').addEventListener('click', closeThread);
+    document.getElementById('thread-send-btn').addEventListener('click', sendThreadReply);
+    document.getElementById('thread-message-input').addEventListener('keypress', (e) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            sendThreadReply();
         }
     });
     

--- a/tests/test_rooms_api.py
+++ b/tests/test_rooms_api.py
@@ -560,6 +560,154 @@ class TestRoomReadTracking:
         assert response.json()["unread_count"] == 2
 
 
+class TestRoomThreading:
+    """Tests for thread API endpoints."""
+
+    def _create_room(self, client, data):
+        """Helper to create a room."""
+        return client.post(
+            f"/{data['ns']}/rooms",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+            json={"display_name": "Test Room"},
+        ).json()
+
+    def _send_msg(self, client, data, room_id, body, reference_mid=None):
+        """Helper to send a message."""
+        payload = {"body": body}
+        if reference_mid:
+            payload["reference_mid"] = reference_mid
+        return client.post(
+            f"/{data['ns']}/rooms/{room_id}/messages",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+            json=payload,
+        ).json()
+
+    def test_send_thread_reply(self, client, setup_identities):
+        """Send a reply via API sets reference_mid."""
+        data = setup_identities
+        room = self._create_room(client, data)
+        root = self._send_msg(client, data, room["room_id"], "Root message")
+        reply = self._send_msg(client, data, room["room_id"], "Reply", reference_mid=root["mid"])
+
+        assert reply["reference_mid"] == root["mid"]
+
+    def test_send_reply_to_reply_redirects(self, client, setup_identities):
+        """Replying to a reply redirects to root (flat threading)."""
+        data = setup_identities
+        room = self._create_room(client, data)
+        root = self._send_msg(client, data, room["room_id"], "Root")
+        reply1 = self._send_msg(client, data, room["room_id"], "Reply 1", reference_mid=root["mid"])
+        reply2 = self._send_msg(client, data, room["room_id"], "Reply 2", reference_mid=reply1["mid"])
+
+        assert reply2["reference_mid"] == root["mid"]
+
+    def test_get_thread(self, client, setup_identities):
+        """GET thread endpoint returns root + replies."""
+        data = setup_identities
+        room = self._create_room(client, data)
+        root = self._send_msg(client, data, room["room_id"], "Root message")
+        self._send_msg(client, data, room["room_id"], "Reply 1", reference_mid=root["mid"])
+        self._send_msg(client, data, room["room_id"], "Reply 2", reference_mid=root["mid"])
+
+        response = client.get(
+            f"/{data['ns']}/rooms/{room['room_id']}/threads/{root['mid']}",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+        )
+
+        assert response.status_code == 200
+        thread = response.json()
+        assert thread["root"]["mid"] == root["mid"]
+        assert thread["reply_count"] == 2
+        assert len(thread["replies"]) == 2
+        assert thread["replies"][0]["body"] == "Reply 1"
+        assert thread["replies"][1]["body"] == "Reply 2"
+
+    def test_get_thread_not_found(self, client, setup_identities):
+        """GET thread for non-existent root returns 404."""
+        data = setup_identities
+        room = self._create_room(client, data)
+
+        response = client.get(
+            f"/{data['ns']}/rooms/{room['room_id']}/threads/nonexistent-mid",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+        )
+
+        assert response.status_code == 404
+
+    def test_get_thread_not_member(self, client, setup_identities):
+        """Non-member cannot get thread."""
+        data = setup_identities
+        room = self._create_room(client, data)
+        root = self._send_msg(client, data, room["room_id"], "Root")
+
+        response = client.get(
+            f"/{data['ns']}/rooms/{room['room_id']}/threads/{root['mid']}",
+            headers={"X-Inbox-Secret": data["bob"]["secret"]},
+        )
+
+        assert response.status_code == 403
+
+    def test_get_messages_exclude_replies(self, client, setup_identities):
+        """include_replies=false filters out thread replies."""
+        data = setup_identities
+        room = self._create_room(client, data)
+        self._send_msg(client, data, room["room_id"], "Top level 1")
+        root = self._send_msg(client, data, room["room_id"], "Thread root")
+        self._send_msg(client, data, room["room_id"], "Reply", reference_mid=root["mid"])
+        self._send_msg(client, data, room["room_id"], "Top level 2")
+
+        # With replies
+        all_resp = client.get(
+            f"/{data['ns']}/rooms/{room['room_id']}/messages",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+        )
+        assert len(all_resp.json()["messages"]) == 4
+
+        # Without replies
+        top_resp = client.get(
+            f"/{data['ns']}/rooms/{room['room_id']}/messages",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+            params={"include_replies": "false"},
+        )
+        messages = top_resp.json()["messages"]
+        assert len(messages) == 3
+        bodies = [m["body"] for m in messages]
+        assert "Reply" not in bodies
+
+    def test_get_messages_thread_metadata(self, client, setup_identities):
+        """include_replies=false includes reply_count and last_reply_at."""
+        data = setup_identities
+        room = self._create_room(client, data)
+        self._send_msg(client, data, room["room_id"], "No thread")
+        root = self._send_msg(client, data, room["room_id"], "Has thread")
+        self._send_msg(client, data, room["room_id"], "Reply 1", reference_mid=root["mid"])
+        self._send_msg(client, data, room["room_id"], "Reply 2", reference_mid=root["mid"])
+
+        resp = client.get(
+            f"/{data['ns']}/rooms/{room['room_id']}/messages",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+            params={"include_replies": "false"},
+        )
+        messages = resp.json()["messages"]
+
+        no_thread = next(m for m in messages if m["body"] == "No thread")
+        has_thread = next(m for m in messages if m["body"] == "Has thread")
+
+        assert no_thread["reply_count"] == 0
+        assert no_thread["last_reply_at"] is None
+        assert has_thread["reply_count"] == 2
+        assert has_thread["last_reply_at"] is not None
+
+    def test_message_response_has_reply_count_field(self, client, setup_identities):
+        """All message responses include reply_count field (default 0)."""
+        data = setup_identities
+        room = self._create_room(client, data)
+        msg = self._send_msg(client, data, room["room_id"], "Hello")
+
+        assert "reply_count" in msg
+        assert msg["reply_count"] == 0
+
+
 class TestRoomDeletion:
     """Tests for room deletion."""
 

--- a/tests/test_rooms_api.py
+++ b/tests/test_rooms_api.py
@@ -597,7 +597,9 @@ class TestRoomThreading:
         room = self._create_room(client, data)
         root = self._send_msg(client, data, room["room_id"], "Root")
         reply1 = self._send_msg(client, data, room["room_id"], "Reply 1", reference_mid=root["mid"])
-        reply2 = self._send_msg(client, data, room["room_id"], "Reply 2", reference_mid=reply1["mid"])
+        reply2 = self._send_msg(
+            client, data, room["room_id"], "Reply 2", reference_mid=reply1["mid"]
+        )
 
         assert reply2["reference_mid"] == root["mid"]
 

--- a/tests/test_rooms_backend.py
+++ b/tests/test_rooms_backend.py
@@ -239,11 +239,12 @@ class TestInMemoryBackendThreading:
     def test_send_reply(self, setup):
         """Send a thread reply via backend."""
         b = setup["backend"]
-        root = b.send_room_message(
-            setup["ns"], setup["room_id"], setup["alice"]["secret"], "Root"
-        )
+        root = b.send_room_message(setup["ns"], setup["room_id"], setup["alice"]["secret"], "Root")
         reply = b.send_room_message(
-            setup["ns"], setup["room_id"], setup["alice"]["secret"], "Reply",
+            setup["ns"],
+            setup["room_id"],
+            setup["alice"]["secret"],
+            "Reply",
             reference_mid=root["mid"],
         )
         assert reply["reference_mid"] == root["mid"]
@@ -251,15 +252,19 @@ class TestInMemoryBackendThreading:
     def test_get_thread(self, setup):
         """Get a thread via backend."""
         b = setup["backend"]
-        root = b.send_room_message(
-            setup["ns"], setup["room_id"], setup["alice"]["secret"], "Root"
-        )
+        root = b.send_room_message(setup["ns"], setup["room_id"], setup["alice"]["secret"], "Root")
         b.send_room_message(
-            setup["ns"], setup["room_id"], setup["alice"]["secret"], "Reply 1",
+            setup["ns"],
+            setup["room_id"],
+            setup["alice"]["secret"],
+            "Reply 1",
             reference_mid=root["mid"],
         )
         b.send_room_message(
-            setup["ns"], setup["room_id"], setup["alice"]["secret"], "Reply 2",
+            setup["ns"],
+            setup["room_id"],
+            setup["alice"]["secret"],
+            "Reply 2",
             reference_mid=root["mid"],
         )
 
@@ -280,24 +285,23 @@ class TestInMemoryBackendThreading:
     def test_get_messages_exclude_replies(self, setup):
         """Filter out replies from room messages."""
         b = setup["backend"]
+        b.send_room_message(setup["ns"], setup["room_id"], setup["alice"]["secret"], "Top level")
+        root = b.send_room_message(setup["ns"], setup["room_id"], setup["alice"]["secret"], "Root")
         b.send_room_message(
-            setup["ns"], setup["room_id"], setup["alice"]["secret"], "Top level"
-        )
-        root = b.send_room_message(
-            setup["ns"], setup["room_id"], setup["alice"]["secret"], "Root"
-        )
-        b.send_room_message(
-            setup["ns"], setup["room_id"], setup["alice"]["secret"], "Reply",
+            setup["ns"],
+            setup["room_id"],
+            setup["alice"]["secret"],
+            "Reply",
             reference_mid=root["mid"],
         )
 
-        all_msgs = b.get_room_messages(
-            setup["ns"], setup["room_id"], setup["alice"]["secret"]
-        )
+        all_msgs = b.get_room_messages(setup["ns"], setup["room_id"], setup["alice"]["secret"])
         assert len(all_msgs) == 3
 
         top_only = b.get_room_messages(
-            setup["ns"], setup["room_id"], setup["alice"]["secret"],
+            setup["ns"],
+            setup["room_id"],
+            setup["alice"]["secret"],
             include_replies=False,
         )
         assert len(top_only) == 2
@@ -307,16 +311,19 @@ class TestInMemoryBackendThreading:
     def test_get_messages_thread_metadata(self, setup):
         """Thread metadata included when filtering replies."""
         b = setup["backend"]
-        root = b.send_room_message(
-            setup["ns"], setup["room_id"], setup["alice"]["secret"], "Root"
-        )
+        root = b.send_room_message(setup["ns"], setup["room_id"], setup["alice"]["secret"], "Root")
         b.send_room_message(
-            setup["ns"], setup["room_id"], setup["alice"]["secret"], "Reply",
+            setup["ns"],
+            setup["room_id"],
+            setup["alice"]["secret"],
+            "Reply",
             reference_mid=root["mid"],
         )
 
         top_only = b.get_room_messages(
-            setup["ns"], setup["room_id"], setup["alice"]["secret"],
+            setup["ns"],
+            setup["room_id"],
+            setup["alice"]["secret"],
             include_replies=False,
         )
         root_msg = next(m for m in top_only if m["body"] == "Root")
@@ -464,11 +471,12 @@ class TestDeaddropClientRooms:
         """Send a thread reply via client."""
         c = setup["client"]
         room = c.create_room(setup["ns"], setup["alice"]["secret"])
-        root = c.send_room_message(
-            setup["ns"], room["room_id"], setup["alice"]["secret"], "Root"
-        )
+        root = c.send_room_message(setup["ns"], room["room_id"], setup["alice"]["secret"], "Root")
         reply = c.send_room_message(
-            setup["ns"], room["room_id"], setup["alice"]["secret"], "Reply",
+            setup["ns"],
+            room["room_id"],
+            setup["alice"]["secret"],
+            "Reply",
             reference_mid=root["mid"],
         )
         assert reply["reference_mid"] == root["mid"]
@@ -477,17 +485,16 @@ class TestDeaddropClientRooms:
         """Get a thread via client."""
         c = setup["client"]
         room = c.create_room(setup["ns"], setup["alice"]["secret"])
-        root = c.send_room_message(
-            setup["ns"], room["room_id"], setup["alice"]["secret"], "Root"
-        )
+        root = c.send_room_message(setup["ns"], room["room_id"], setup["alice"]["secret"], "Root")
         c.send_room_message(
-            setup["ns"], room["room_id"], setup["alice"]["secret"], "Reply",
+            setup["ns"],
+            room["room_id"],
+            setup["alice"]["secret"],
+            "Reply",
             reference_mid=root["mid"],
         )
 
-        thread = c.get_thread(
-            setup["ns"], room["room_id"], setup["alice"]["secret"], root["mid"]
-        )
+        thread = c.get_thread(setup["ns"], room["room_id"], setup["alice"]["secret"], root["mid"])
         assert thread is not None
         assert thread["root"]["mid"] == root["mid"]
         assert thread["reply_count"] == 1
@@ -496,24 +503,23 @@ class TestDeaddropClientRooms:
         """Filter replies from room messages via client."""
         c = setup["client"]
         room = c.create_room(setup["ns"], setup["alice"]["secret"])
+        c.send_room_message(setup["ns"], room["room_id"], setup["alice"]["secret"], "Top")
+        root = c.send_room_message(setup["ns"], room["room_id"], setup["alice"]["secret"], "Root")
         c.send_room_message(
-            setup["ns"], room["room_id"], setup["alice"]["secret"], "Top"
-        )
-        root = c.send_room_message(
-            setup["ns"], room["room_id"], setup["alice"]["secret"], "Root"
-        )
-        c.send_room_message(
-            setup["ns"], room["room_id"], setup["alice"]["secret"], "Reply",
+            setup["ns"],
+            room["room_id"],
+            setup["alice"]["secret"],
+            "Reply",
             reference_mid=root["mid"],
         )
 
-        all_msgs = c.get_room_messages(
-            setup["ns"], room["room_id"], setup["alice"]["secret"]
-        )
+        all_msgs = c.get_room_messages(setup["ns"], room["room_id"], setup["alice"]["secret"])
         assert len(all_msgs) == 3
 
         top_only = c.get_room_messages(
-            setup["ns"], room["room_id"], setup["alice"]["secret"],
+            setup["ns"],
+            room["room_id"],
+            setup["alice"]["secret"],
             include_replies=False,
         )
         assert len(top_only) == 2


### PR DESCRIPTION
## Summary

Adds Slack-style flat threading to rooms. Any top-level message can become a thread root, and all replies are flat under it — no nesting.

Closes #27

## Changes

### DB layer (`db.py`)
- `send_room_message`: validates `reference_mid` for thread replies — target must be top-level; replies-to-replies silently redirect to the thread root
- New `get_thread(room_id, root_mid)`: returns root + replies in chronological order
- `get_room_messages`: new `include_replies` param (filter thread replies), new `include_thread_meta` param (adds `reply_count`/`last_reply_at`)

### API layer (`api.py`)
- New endpoint: `GET /{ns}/rooms/{room_id}/threads/{root_mid}`
- `GET /{ns}/rooms/{room_id}/messages`: new `include_replies` query param; when false, includes thread metadata automatically
- `RoomMessageInfo`: gains `reply_count`, `last_reply_at` fields

### Backends & Client
- Abstract backend, LocalBackend, RemoteBackend all updated with `reference_mid`, `include_replies`, `get_thread`
- `Deaddrop` client exposes `reference_mid`, `include_replies`, `get_thread()`

### Web UI
- Thread panel (slides in from right, full-overlay on mobile)
- Main timeline hides replies, shows thread indicators (`💬 N replies`)
- Reply button on hover
- Real-time: new thread replies appear in open panel via subscription
- `api.js`: `getThread()`, `getRoomMessagesTopLevel()`

### Documentation
- `docs/THREADS.md`: model, API reference, Python examples, design rationale

## Design Decision
Flat threads (no nesting) — zero schema changes needed, reuses existing `reference_mid` column. Server validates that replies always point to top-level messages. See `docs/THREADS.md` for full design exploration notes.

## Testing
- **17 new DB tests**: reply validation, redirect-to-root, get_thread, exclude_replies, thread_meta, reactions not filtered
- **8 new API tests**: send reply, redirect, get thread, thread not found, auth, filter replies, thread metadata
- **8 new backend/client tests**: send reply, get_thread, filter, metadata across InMemoryBackend and Deaddrop client
- **405 total tests pass**, 0 regressions
- Linting clean (`ruff check`)