### PR TITLE
feat: pause subscriptions on tab blur, auto-focus chat input

### DIFF
--- a/src/deadrop/api.py
+++ b/src/deadrop/api.py
@@ -333,27 +333,11 @@ def require_active_namespace(ns: str) -> None:
 def _get_db_executor():
     """Get the appropriate executor for DB operations.
 
-    Returns a single-threaded executor when using libsql/Turso (which uses
-    a single shared connection that isn't thread-safe), or None to use the
-    default threadpool for local SQLite (which uses thread-local connections).
+    Delegates to db.get_db_executor() to ensure ALL database operations
+    (API handlers, cache warming, background tasks) share the same
+    single-threaded executor when using libsql/Turso.
     """
-    global _db_executor
-    if _db_executor is not None:
-        return _db_executor
-
-    if db.is_using_libsql():
-        from concurrent.futures import ThreadPoolExecutor
-
-        _db_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="db")
-        logger.info("Using serialized DB executor for libsql/Turso")
-    else:
-        _db_executor = None  # Use default threadpool for local SQLite
-        logger.info("Using default threadpool for local SQLite")
-
-    return _db_executor
-
-
-_db_executor = None  # Initialized lazily
+    return db.get_db_executor()
 
 
 async def _run_sync(fn, *args):

--- a/src/deadrop/cache.py
+++ b/src/deadrop/cache.py
@@ -287,13 +287,18 @@ async def warm_caches(conn: sqlite3.Connection | None = None) -> dict[str, int]:
     from . import db
 
     if conn is None:
-        # IMPORTANT: Get the connection in a thread pool to avoid blocking
-        # the event loop.  For libsql/Turso, get_connection() acquires a
+        # IMPORTANT: Get the connection via the shared DB executor to avoid
+        # both blocking the event loop AND concurrent access to the shared
+        # libsql connection.  For libsql/Turso, get_connection() acquires a
         # threading lock and runs a network health check — both blocking
         # operations that would freeze the entire server if executed on
-        # the event loop thread.
+        # the event loop thread.  Using the DB executor (instead of the
+        # default threadpool) ensures cache warming is serialized with API
+        # handler DB operations, preventing thread-safety violations on the
+        # shared libsql connection.
         loop = asyncio.get_event_loop()
-        conn = await loop.run_in_executor(None, db.get_connection)
+        executor = db.get_db_executor()
+        conn = await loop.run_in_executor(executor, db.get_connection)
 
     start_time = time.perf_counter()
     results = {"rooms": 0, "memberships": 0, "identities": 0}
@@ -333,13 +338,16 @@ async def _warm_room_cache(conn: sqlite3.Connection) -> int:
     """Load all rooms into cache."""
     from . import db
 
-    # Run DB query in thread pool to not block event loop
+    # Run DB query via the shared DB executor to serialize with API operations.
+    # Using the default threadpool here would cause concurrent access to the
+    # shared libsql connection, which is not thread-safe.
     loop = asyncio.get_event_loop()
+    executor = db.get_db_executor()
     cursor = await loop.run_in_executor(
-        None,
+        executor,
         lambda: conn.execute("SELECT room_id, ns, display_name, created_by, created_at FROM rooms"),
     )
-    rows = await loop.run_in_executor(None, cursor.fetchall)
+    rows = await loop.run_in_executor(executor, cursor.fetchall)
 
     # Build cache entries
     items = {}
@@ -354,13 +362,16 @@ async def _warm_room_cache(conn: sqlite3.Connection) -> int:
 
 async def _warm_membership_cache(conn: sqlite3.Connection) -> int:
     """Load all room memberships into cache."""
-    # Run DB query in thread pool
+    from . import db
+
+    # Run DB query via the shared DB executor to serialize with API operations
     loop = asyncio.get_event_loop()
+    executor = db.get_db_executor()
     cursor = await loop.run_in_executor(
-        None,
+        executor,
         lambda: conn.execute("SELECT room_id, identity_id FROM room_members"),
     )
-    rows = await loop.run_in_executor(None, cursor.fetchall)
+    rows = await loop.run_in_executor(executor, cursor.fetchall)
 
     # Build cache entries (membership is just a boolean - True if member)
     items = {}
@@ -374,13 +385,16 @@ async def _warm_membership_cache(conn: sqlite3.Connection) -> int:
 
 async def _warm_identity_cache(conn: sqlite3.Connection) -> int:
     """Load all identity secret hashes into cache."""
-    # Run DB query in thread pool
+    from . import db
+
+    # Run DB query via the shared DB executor to serialize with API operations
     loop = asyncio.get_event_loop()
+    executor = db.get_db_executor()
     cursor = await loop.run_in_executor(
-        None,
+        executor,
         lambda: conn.execute("SELECT ns, id, secret_hash FROM identities"),
     )
-    rows = await loop.run_in_executor(None, cursor.fetchall)
+    rows = await loop.run_in_executor(executor, cursor.fetchall)
 
     # Build cache entries
     items = {}

--- a/src/deadrop/db.py
+++ b/src/deadrop/db.py
@@ -77,6 +77,43 @@ _libsql_lock = threading.Lock()
 LIBSQL_CONNECT_TIMEOUT = 10.0
 LIBSQL_HEALTH_CHECK_TIMEOUT = 5.0
 
+# Shared single-threaded executor for serializing libsql operations.
+# When using Turso/libsql, ALL database operations must go through this
+# executor because the shared connection is NOT thread-safe.
+_db_executor = None
+_db_executor_lock = threading.Lock()
+
+
+def get_db_executor():
+    """Get the shared executor for database operations.
+
+    Returns a single-threaded executor when using libsql/Turso (which uses
+    a single shared connection that isn't thread-safe), or None to use the
+    default threadpool for local SQLite (which uses thread-local connections).
+
+    This MUST be used by all async code that accesses the database, including
+    cache warming, API handlers, and any other background tasks.
+    """
+    global _db_executor
+
+    if _db_executor is not None:
+        return _db_executor
+
+    with _db_executor_lock:
+        # Double-check under lock
+        if _db_executor is not None:
+            return _db_executor
+
+        if is_using_libsql():
+            from concurrent.futures import ThreadPoolExecutor
+
+            import logging
+
+            _db_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="db")
+            logging.getLogger(__name__).info("Using serialized DB executor for libsql/Turso")
+
+    return _db_executor
+
 
 def _reset_libsql_connection() -> None:
     """Reset the global libsql connection.

--- a/src/deadrop/templates/app.html
+++ b/src/deadrop/templates/app.html
@@ -527,6 +527,8 @@
         document.getElementById('conversation-title').textContent = getPeerName(peerId);
         showView('conversation');
         renderConversation();
+        // Focus the input so the user can start typing immediately
+        document.getElementById('message-input').focus();
     }
     
     function renderConversation() {
@@ -623,6 +625,8 @@
             
             showView('roomChat');
             await loadRoomMessages();
+            // Focus the input so the user can start typing immediately
+            document.getElementById('room-message-input').focus();
             
         } catch (e) {
             alert('Failed to open room: ' + e.message);
@@ -1123,6 +1127,41 @@
         }
     }
     
+    // ==================== TAB VISIBILITY ====================
+    
+    /**
+     * Pause subscriptions and message fetching when the tab is not visible
+     * (backgrounded, another workspace, screen locked, etc.).
+     *
+     * This prevents messages from being marked as read while the user isn't
+     * actually looking at them.  When the tab regains focus the subscription
+     * is restarted and the current view is refreshed.
+     */
+    document.addEventListener('visibilitychange', () => {
+        if (document.hidden) {
+            // Tab hidden — stop subscription so we don't fetch (and mark-as-read)
+            stopSubscription();
+        } else {
+            // Tab visible again — restart subscription and refresh the active view
+            if (currentSlug && credentials) {
+                startSubscription();
+
+                // Refresh whichever view is currently shown
+                const inboxView = document.getElementById('view-inbox');
+                const roomView = document.getElementById('view-room-chat');
+                const convView = document.getElementById('view-conversation');
+
+                if (roomView && !roomView.classList.contains('hidden') && currentRoomId) {
+                    loadRoomMessages();
+                } else if (convView && !convView.classList.contains('hidden') && currentPeerId) {
+                    loadUnifiedInbox().then(() => renderConversation());
+                } else if (inboxView && !inboxView.classList.contains('hidden')) {
+                    loadUnifiedInbox();
+                }
+            }
+        }
+    });
+
     // ==================== BROWSER NAVIGATION ====================
     
     /**


### PR DESCRIPTION
## Changes

Two UX improvements to the web messaging client:

### 1. Tab visibility awareness

When the browser tab is hidden (backgrounded, another workspace, screen locked), the subscription loop is now **stopped**. This prevents the app from fetching messages and inadvertently marking them as read while the user isn't looking.

When the tab regains focus:
- Subscriptions restart automatically
- The current view (inbox, room, or conversation) is refreshed to pick up anything that arrived while away

Uses the standard `document.visibilitychange` API.

### 2. Auto-focus message input

When entering a 1:1 conversation or a room chat view, the message input textarea now receives focus automatically, so the user can start typing immediately.

## Testing

- 391 unit tests pass
- Pre-commit clean
- Deployed to production (`deaddrop.dokku.heare.io`)