### PR TITLE
feat: add sender_id to subscription events

### DIFF
--- a/src/deadrop/api.py
+++ b/src/deadrop/api.py
@@ -753,7 +753,7 @@ async def send_message(
 
     # Notify subscribers that the recipient's inbox has a new message
     try:
-        await get_event_bus().publish(ns, f"inbox:{request.to}", result["mid"])
+        await get_event_bus().publish(ns, f"inbox:{request.to}", result["mid"], sender_id=from_id)
     except Exception:
         logger.warning("Failed to publish inbox event", exc_info=True)
 
@@ -1407,7 +1407,7 @@ async def send_room_message(
 
     # Notify subscribers that this room has a new message
     try:
-        await get_event_bus().publish(ns, f"room:{room_id}", message["mid"])
+        await get_event_bus().publish(ns, f"room:{room_id}", message["mid"], sender_id=from_id)
     except Exception:
         logger.warning("Failed to publish room event", exc_info=True)
 
@@ -1578,8 +1578,17 @@ async def subscribe(
     # Poll mode — block until event or timeout
     changes = await event_bus.subscribe(ns, request.topics, timeout=request.timeout)
 
+    # Build response: "events" maps topic -> latest_mid (backward compatible),
+    # "details" maps topic -> {latest_mid, sender_id} (new rich info)
+    events = {topic: info["latest_mid"] for topic, info in changes.items()}
+    details = {
+        topic: {"latest_mid": info["latest_mid"], "sender_id": info["sender_id"]}
+        for topic, info in changes.items()
+    }
+
     return {
-        "events": changes,
+        "events": events,
+        "details": details,
         "timeout": len(changes) == 0,
     }
 

--- a/src/deadrop/backends.py
+++ b/src/deadrop/backends.py
@@ -1157,7 +1157,14 @@ class LocalBackend(Backend):
         else:
             changes = loop.run_until_complete(event_bus.subscribe(ns, topics, timeout=timeout))
 
-        return {"events": changes, "timeout": len(changes) == 0}
+        # Flatten to {topic: mid} for backward compatibility with clients;
+        # include rich details alongside.
+        events = {topic: info["latest_mid"] for topic, info in changes.items()}
+        details = {
+            topic: {"latest_mid": info["latest_mid"], "sender_id": info["sender_id"]}
+            for topic, info in changes.items()
+        }
+        return {"events": events, "details": details, "timeout": len(changes) == 0}
 
     def subscribe_stream(
         self,

--- a/src/deadrop/events.py
+++ b/src/deadrop/events.py
@@ -34,13 +34,21 @@ class EventBus(ABC):
     """
 
     @abstractmethod
-    async def publish(self, namespace: str, topic: str, mid: str) -> None:
+    async def publish(
+        self,
+        namespace: str,
+        topic: str,
+        mid: str,
+        sender_id: str | None = None,
+    ) -> None:
         """Publish that a topic has a new message.
 
         Args:
             namespace: Namespace ID
             topic: Topic key (e.g., "inbox:abc123" or "room:def456")
             mid: The new message ID (UUIDv7, lexicographically sortable)
+            sender_id: Identity ID of the sender (allows clients to ignore
+                       their own events)
         """
 
     @abstractmethod
@@ -49,7 +57,7 @@ class EventBus(ABC):
         namespace: str,
         topics: dict[str, str | None],
         timeout: float = 30.0,
-    ) -> dict[str, str]:
+    ) -> dict[str, dict[str, str | None]]:
         """Block until any subscribed topic has changes, or timeout.
 
         Compares the caller's last_seen_mid for each topic against the
@@ -62,8 +70,8 @@ class EventBus(ABC):
             timeout: Max seconds to wait (0 = check and return immediately)
 
         Returns:
-            Map of topic_key -> latest_mid for topics that have changes.
-            Empty dict if timeout reached with no changes.
+            Map of topic_key -> {"latest_mid": mid, "sender_id": id_or_none}
+            for topics that have changes. Empty dict if timeout reached.
         """
 
     @abstractmethod
@@ -112,8 +120,8 @@ class InMemoryEventBus(EventBus):
     """
 
     def __init__(self) -> None:
-        # latest_mid per (namespace, topic)
-        self._latest: dict[str, dict[str, str]] = defaultdict(dict)
+        # Latest event per (namespace, topic): maps to (mid, sender_id)
+        self._latest: dict[str, dict[str, tuple[str, str | None]]] = defaultdict(dict)
         # One condition per namespace for waiter notification
         self._conditions: dict[str, asyncio.Condition] = {}
 
@@ -123,37 +131,47 @@ class InMemoryEventBus(EventBus):
             self._conditions[namespace] = asyncio.Condition()
         return self._conditions[namespace]
 
-    async def publish(self, namespace: str, topic: str, mid: str) -> None:
+    async def publish(
+        self,
+        namespace: str,
+        topic: str,
+        mid: str,
+        sender_id: str | None = None,
+    ) -> None:
         """Publish a new message event for a topic."""
         condition = self._get_condition(namespace)
         async with condition:
-            self._latest[namespace][topic] = mid
+            self._latest[namespace][topic] = (mid, sender_id)
             condition.notify_all()
 
     def _check_changes(
         self,
         namespace: str,
         topics: dict[str, str | None],
-    ) -> dict[str, str]:
+    ) -> dict[str, dict[str, str | None]]:
         """Check which topics have changes beyond the caller's cursors.
 
         UUIDv7 message IDs are lexicographically sortable, so string
         comparison is valid for determining "newer than".
+
+        Returns:
+            Map of topic_key -> {"latest_mid": mid, "sender_id": id_or_none}
         """
-        changes: dict[str, str] = {}
+        changes: dict[str, dict[str, str | None]] = {}
         ns_latest = self._latest.get(namespace, {})
 
         for topic, last_seen in topics.items():
-            latest = ns_latest.get(topic)
-            if latest is None:
+            entry = ns_latest.get(topic)
+            if entry is None:
                 # No messages published for this topic yet
                 continue
+            mid, sender_id = entry
             if last_seen is None:
                 # Caller has never seen this topic — any message is new
-                changes[topic] = latest
-            elif latest > last_seen:
+                changes[topic] = {"latest_mid": mid, "sender_id": sender_id}
+            elif mid > last_seen:
                 # There are messages newer than what the caller has seen
-                changes[topic] = latest
+                changes[topic] = {"latest_mid": mid, "sender_id": sender_id}
 
         return changes
 
@@ -162,7 +180,7 @@ class InMemoryEventBus(EventBus):
         namespace: str,
         topics: dict[str, str | None],
         timeout: float = 30.0,
-    ) -> dict[str, str]:
+    ) -> dict[str, dict[str, str | None]]:
         """Block until any topic has changes, or timeout."""
         # Immediate check — avoid acquiring condition if possible
         changes = self._check_changes(namespace, topics)
@@ -195,16 +213,16 @@ class InMemoryEventBus(EventBus):
         self,
         namespace: str,
         topics: dict[str, str | None],
-    ) -> AsyncIterator[dict[str, str]]:
+    ) -> AsyncIterator[dict[str, str | None]]:
         """Stream events as they occur."""
         # Track our own cursor so we don't re-yield the same change
         cursors = dict(topics)
 
         # First, yield any immediately-available changes
         changes = self._check_changes(namespace, cursors)
-        for topic, mid in changes.items():
-            cursors[topic] = mid
-            yield {"topic": topic, "latest_mid": mid}
+        for topic, info in changes.items():
+            cursors[topic] = info["latest_mid"]
+            yield {"topic": topic, "latest_mid": info["latest_mid"], "sender_id": info["sender_id"]}
 
         # Then wait for new events
         condition = self._get_condition(namespace)
@@ -214,13 +232,21 @@ class InMemoryEventBus(EventBus):
 
             # Check what changed
             changes = self._check_changes(namespace, cursors)
-            for topic, mid in changes.items():
-                cursors[topic] = mid
-                yield {"topic": topic, "latest_mid": mid}
+            for topic, info in changes.items():
+                cursors[topic] = info["latest_mid"]
+                yield {
+                    "topic": topic,
+                    "latest_mid": info["latest_mid"],
+                    "sender_id": info["sender_id"],
+                }
 
     def get_latest(self, namespace: str, topic: str) -> str | None:
         """Get the latest known mid for a topic."""
-        return self._latest.get(namespace, {}).get(topic)
+        entry = self._latest.get(namespace, {}).get(topic)
+        if entry is None:
+            return None
+        mid, _sender_id = entry
+        return mid
 
 
 # --- Global singleton ---

--- a/src/deadrop/static/js/api.js
+++ b/src/deadrop/static/js/api.js
@@ -387,7 +387,8 @@ class SubscriptionManager {
                             const data = JSON.parse(event.data);
                             if (data.topic && data.latest_mid) {
                                 this.updateCursor(data.topic, data.latest_mid);
-                                if (this.onEvent) this.onEvent(data.topic, data.latest_mid);
+                                const senderId = data.sender_id || null;
+                                if (this.onEvent) this.onEvent(data.topic, data.latest_mid, senderId);
                             }
                         } catch (e) {
                             console.warn('Failed to parse SSE event data:', e);
@@ -442,9 +443,11 @@ class SubscriptionManager {
                 if (!this.running) break;
 
                 if (result.events && !result.timeout) {
+                    const details = result.details || {};
                     for (const [topic, mid] of Object.entries(result.events)) {
                         this.updateCursor(topic, mid);
-                        if (this.onEvent) this.onEvent(topic, mid);
+                        const senderId = details[topic]?.sender_id || null;
+                        if (this.onEvent) this.onEvent(topic, mid, senderId);
                     }
                 }
             } catch (e) {

--- a/src/deadrop/templates/app.html
+++ b/src/deadrop/templates/app.html
@@ -893,8 +893,14 @@
         
         subscriptionManager = new SubscriptionManager(credentials);
         
-        subscriptionManager.onEvent = async (topic, latestMid) => {
-            console.log(`[subscription] event on ${topic}: ${latestMid}`);
+        subscriptionManager.onEvent = async (topic, latestMid, senderId) => {
+            console.log(`[subscription] event on ${topic}: ${latestMid} from ${senderId || 'unknown'}`);
+            
+            // Skip events from ourselves — we already have optimistic updates
+            if (senderId === credentials.id) {
+                console.log(`[subscription] ignoring self-event on ${topic}`);
+                return;
+            }
             
             if (topic === `inbox:${credentials.id}`) {
                 // Inbox has new messages — refresh if viewing unified inbox

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -35,7 +35,9 @@ class TestPublishAndSubscribe:
             timeout=5.0,
         )
 
-        assert result == {"room:abc": "01961234-0000-7000-8000-000000000001"}
+        assert result == {
+            "room:abc": {"latest_mid": "01961234-0000-7000-8000-000000000001", "sender_id": None}
+        }
 
     @pytest.mark.asyncio
     async def test_subscribe_with_current_cursor_blocks_then_receives(self, bus):
@@ -57,7 +59,7 @@ class TestPublishAndSubscribe:
         )
         await task
 
-        assert result == {"room:abc": mid2}
+        assert result == {"room:abc": {"latest_mid": mid2, "sender_id": None}}
 
     @pytest.mark.asyncio
     async def test_subscribe_timeout_returns_empty(self, bus):
@@ -90,7 +92,9 @@ class TestPublishAndSubscribe:
             {"room:abc": None},
             timeout=0,
         )
-        assert result == {"room:abc": "01961234-0000-7000-8000-000000000001"}
+        assert result == {
+            "room:abc": {"latest_mid": "01961234-0000-7000-8000-000000000001", "sender_id": None}
+        }
 
     @pytest.mark.asyncio
     async def test_subscribe_multiple_topics_one_changed(self, bus):
@@ -109,7 +113,7 @@ class TestPublishAndSubscribe:
             timeout=0,
         )
 
-        assert result == {"room:abc": mid1}
+        assert result == {"room:abc": {"latest_mid": mid1, "sender_id": None}}
 
     @pytest.mark.asyncio
     async def test_subscribe_multiple_topics_multiple_changed(self, bus):
@@ -130,7 +134,10 @@ class TestPublishAndSubscribe:
             timeout=0,
         )
 
-        assert result == {"room:abc": mid1, "inbox:xyz": mid2}
+        assert result == {
+            "room:abc": {"latest_mid": mid1, "sender_id": None},
+            "inbox:xyz": {"latest_mid": mid2, "sender_id": None},
+        }
 
     @pytest.mark.asyncio
     async def test_subscribe_no_change_when_cursor_matches(self, bus):
@@ -185,7 +192,7 @@ class TestNamespaceIsolation:
 
         await asyncio.gather(subscribe_ns1(), subscribe_ns2(), publish_ns1())
 
-        assert ns1_result == {"room:abc": mid}
+        assert ns1_result == {"room:abc": {"latest_mid": mid, "sender_id": None}}
         assert ns2_result == {}
 
 
@@ -216,7 +223,9 @@ class TestConcurrentSubscribers:
 
         assert len(results) == 3
         for idx, result in results:
-            assert result == {"room:abc": mid}, f"Subscriber {idx} got wrong result"
+            assert result == {"room:abc": {"latest_mid": mid, "sender_id": None}}, (
+                f"Subscriber {idx} got wrong result"
+            )
 
     @pytest.mark.asyncio
     async def test_subscribers_different_topics_in_same_namespace(self, bus):
@@ -240,7 +249,7 @@ class TestConcurrentSubscribers:
 
         await asyncio.gather(room_subscriber(), inbox_subscriber(), publisher())
 
-        assert room_result == {"room:abc": mid}
+        assert room_result == {"room:abc": {"latest_mid": mid, "sender_id": None}}
         assert inbox_result == {}
 
 
@@ -287,7 +296,7 @@ class TestStream:
         stream = bus.stream("ns1", {"room:abc": None})
         event = await asyncio.wait_for(stream.__anext__(), timeout=1.0)
 
-        assert event == {"topic": "room:abc", "latest_mid": mid1}
+        assert event == {"topic": "room:abc", "latest_mid": mid1, "sender_id": None}
 
     @pytest.mark.asyncio
     async def test_stream_waits_for_new_events(self, bus):
@@ -304,7 +313,7 @@ class TestStream:
         event = await asyncio.wait_for(stream.__anext__(), timeout=2.0)
         await publish_task
 
-        assert event == {"topic": "room:abc", "latest_mid": mid1}
+        assert event == {"topic": "room:abc", "latest_mid": mid1, "sender_id": None}
 
     @pytest.mark.asyncio
     async def test_stream_yields_multiple_events(self, bus):
@@ -356,6 +365,35 @@ class TestStream:
         assert event2["latest_mid"] == mid2
 
         await publish_task
+
+    @pytest.mark.asyncio
+    async def test_stream_includes_sender_id(self, bus):
+        """Stream yields sender_id when provided in publish."""
+        mid1 = "01961234-0000-7000-8000-000000000001"
+        await bus.publish("ns1", "room:abc", mid1, sender_id="user1")
+
+        stream = bus.stream("ns1", {"room:abc": None})
+        event = await asyncio.wait_for(stream.__anext__(), timeout=1.0)
+
+        assert event == {"topic": "room:abc", "latest_mid": mid1, "sender_id": "user1"}
+
+
+class TestSenderIdPropagation:
+    """Tests that sender_id is propagated through publish/subscribe/stream."""
+
+    @pytest.mark.asyncio
+    async def test_publish_with_sender_id_in_subscribe(self, bus):
+        """Publish with sender_id; subscribe returns sender_id in result."""
+        mid1 = "01961234-0000-7000-8000-000000000001"
+        await bus.publish("ns1", "room:abc", mid1, sender_id="user1")
+
+        result = await bus.subscribe(
+            "ns1",
+            {"room:abc": None},
+            timeout=5.0,
+        )
+
+        assert result == {"room:abc": {"latest_mid": mid1, "sender_id": "user1"}}
 
 
 class TestGlobalSingleton:


### PR DESCRIPTION
## Summary

Adds `sender_id` to subscription events so clients can identify who triggered each change and skip redundant fetches for their own actions.

## Motivation

When a user sends a room message, the web client already shows it optimistically. But the subscription event for that same message causes a redundant fetch. With `sender_id` in the event, the client can detect "this was me" and skip the fetch.

## Changes

### Event bus (`events.py`)
- `publish()` accepts optional `sender_id`, stored alongside `mid` in `_latest`
- `subscribe()` returns `{topic: {"latest_mid": mid, "sender_id": id}}` (was `{topic: mid}`)
- `stream()` includes `sender_id` in each yielded event dict

### API (`api.py`)
- Both publish call sites (DM send, room message send) now pass the sender's identity
- Subscribe poll response adds a `details` field with the rich format alongside the backward-compatible `events` field:
  ```json
  {
    "events": {"room:abc": "069..."},
    "details": {"room:abc": {"latest_mid": "069...", "sender_id": "user123"}},
    "timeout": false
  }
  ```

### Clients
- JS `SubscriptionManager` passes `senderId` through the `onEvent` callback (both SSE and poll modes)
- Web app skips self-events to avoid redundant fetches after optimistic updates
- Python SDK `listen_all()` and existing callers are unaffected (`events` field is backward compatible)

### Backward Compatibility
- The `events` field in poll responses is unchanged: `{topic: mid}`
- SSE stream events add `sender_id` as a new field (existing parsers ignore unknown fields)
- Python SDK works without changes

## Testing
- 393 tests pass (2 new: sender_id propagation in subscribe + stream)
- Pre-commit clean (ruff, ruff format, ty)
- Deployed to production