### PR TITLE
feat: reverse-chronological room loading with scroll-up pagination

### DIFF
--- a/src/deadrop/api.py
+++ b/src/deadrop/api.py
@@ -1346,14 +1346,19 @@ async def get_room_messages(
     ns: str,
     room_id: str,
     after: Annotated[str | None, Query()] = None,
+    before: Annotated[str | None, Query()] = None,
     limit: Annotated[int, Query(ge=1, le=1000)] = 100,
     x_inbox_secret: Annotated[str | None, Header()] = None,
 ):
     """Get messages from a room.
 
     Query parameters:
-    - after: Only return messages after this message ID (for pagination/polling)
+    - after: Only return messages after this message ID (forward pagination / polling)
+    - before: Only return messages before this message ID (backward pagination / scroll-up)
     - limit: Maximum number of messages to return (default: 100, max: 1000)
+
+    Messages are always returned in chronological order regardless of
+    pagination direction.
 
     For real-time updates, use the POST /{ns}/subscribe endpoint instead.
     """
@@ -1365,7 +1370,13 @@ async def get_room_messages(
         raise HTTPException(404, "Room not found in this namespace")
 
     messages = await _run_sync(
-        functools.partial(db.get_room_messages, room_id, after_mid=after, limit=limit)
+        functools.partial(
+            db.get_room_messages,
+            room_id,
+            after_mid=after,
+            before_mid=before,
+            limit=limit,
+        )
     )
 
     return {

--- a/src/deadrop/api.py
+++ b/src/deadrop/api.py
@@ -112,6 +112,10 @@ if STATIC_DIR.exists():
 # Initialize templates if directory exists
 templates = Jinja2Templates(directory=TEMPLATES_DIR) if TEMPLATES_DIR.exists() else None
 
+# Expose server-side configuration to templates as Jinja globals
+if templates:
+    templates.env.globals["ROOM_PAGE_SIZE"] = int(os.environ.get("DEADROP_ROOM_PAGE_SIZE", "20"))
+
 
 # --- Request/Response Models ---
 

--- a/src/deadrop/backends.py
+++ b/src/deadrop/backends.py
@@ -392,6 +392,7 @@ class Backend(ABC):
         room_id: str,
         secret: str,
         after_mid: str | None = None,
+        before_mid: str | None = None,
         limit: int = 100,
     ) -> list[dict[str, Any]]:
         """Get messages from a room.
@@ -400,11 +401,12 @@ class Backend(ABC):
             ns: Namespace ID
             room_id: Room ID
             secret: Caller's inbox secret (must be a member)
-            after_mid: Only get messages after this ID
+            after_mid: Only get messages after this ID (forward pagination)
+            before_mid: Only get messages before this ID (backward pagination)
             limit: Maximum messages to return
 
         Returns:
-            List of message dicts
+            List of message dicts in chronological order
         """
         ...
 
@@ -970,6 +972,7 @@ class LocalBackend(Backend):
         room_id: str,
         secret: str,
         after_mid: str | None = None,
+        before_mid: str | None = None,
         limit: int = 100,
     ) -> list[dict[str, Any]]:
         identity_id = derive_id(secret)
@@ -980,7 +983,9 @@ class LocalBackend(Backend):
         if not room or room.get("ns") != ns:
             raise ValueError("Room not found in this namespace")
 
-        return db.get_room_messages(room_id, after_mid=after_mid, limit=limit, conn=self._conn)
+        return db.get_room_messages(
+            room_id, after_mid=after_mid, before_mid=before_mid, limit=limit, conn=self._conn
+        )
 
     def update_room_read_cursor(
         self,
@@ -1629,11 +1634,14 @@ class RemoteBackend(Backend):
         room_id: str,
         secret: str,
         after_mid: str | None = None,
+        before_mid: str | None = None,
         limit: int = 100,
     ) -> list[dict[str, Any]]:
         params = []
         if after_mid:
             params.append(f"after={after_mid}")
+        if before_mid:
+            params.append(f"before={before_mid}")
         if limit != 100:
             params.append(f"limit={limit}")
 

--- a/src/deadrop/client.py
+++ b/src/deadrop/client.py
@@ -560,6 +560,7 @@ class Deaddrop:
         room_id: str,
         secret: str,
         after_mid: str | None = None,
+        before_mid: str | None = None,
         limit: int = 100,
     ) -> list[dict[str, Any]]:
         """Get messages from a room.
@@ -568,14 +569,15 @@ class Deaddrop:
             ns: Namespace ID.
             room_id: Room ID.
             secret: Caller's inbox secret (must be a member).
-            after_mid: Only get messages after this ID.
+            after_mid: Only get messages after this ID (forward pagination).
+            before_mid: Only get messages before this ID (backward pagination).
             limit: Maximum messages to return.
 
         Returns:
-            List of message dicts.
+            List of message dicts in chronological order.
         """
         return self._backend.get_room_messages(
-            ns, room_id, secret, after_mid=after_mid, limit=limit
+            ns, room_id, secret, after_mid=after_mid, before_mid=before_mid, limit=limit
         )
 
     def update_room_read_cursor(

--- a/src/deadrop/db.py
+++ b/src/deadrop/db.py
@@ -136,9 +136,13 @@ def _reset_libsql_connection() -> None:
     try:
         if _conn is not None:
             try:
-                _conn.close()
+                _run_with_timeout(
+                    lambda: _conn.close(),  # type: ignore[union-attr]
+                    timeout=2.0,
+                    description="conn.close()",
+                )
             except Exception:
-                pass  # Ignore close errors on stale connection
+                pass  # Abandon the stale connection
             _conn = None
             _is_libsql = False
     finally:
@@ -160,6 +164,46 @@ def _is_hrana_stream_error(error: Exception) -> bool:
     )
 
 
+def _run_with_timeout(fn, timeout: float, description: str = "operation"):
+    """Run a blocking function in a daemon thread with a timeout.
+
+    This is used to wrap operations that may hang indefinitely on network
+    I/O (e.g. ``libsql.connect()``, ``conn.execute("SELECT 1")``).
+
+    Args:
+        fn: A zero-argument callable to run.
+        timeout: Maximum seconds to wait.
+        description: Human-readable label for error messages.
+
+    Returns:
+        The return value of ``fn()``.
+
+    Raises:
+        TimeoutError: If the function does not complete in time.
+        Exception: Any exception raised by ``fn``.
+    """
+    result: list[Any] = [None]
+    error: list[BaseException | None] = [None]
+
+    def _wrapper():
+        try:
+            result[0] = fn()
+        except BaseException as e:
+            error[0] = e
+
+    t = threading.Thread(target=_wrapper, daemon=True)
+    t.start()
+    t.join(timeout=timeout)
+
+    if t.is_alive():
+        raise TimeoutError(f"{description} timed out after {timeout}s")
+
+    if error[0] is not None:
+        raise error[0]
+
+    return result[0]
+
+
 def _health_check_conn(
     conn: sqlite3.Connection, timeout: float = LIBSQL_HEALTH_CHECK_TIMEOUT
 ) -> None:
@@ -177,25 +221,7 @@ def _health_check_conn(
         TimeoutError: If the health check does not complete in time.
         Exception: Any exception raised by the underlying ``execute``.
     """
-    error: list[BaseException | None] = [None]
-
-    def _probe():
-        try:
-            conn.execute("SELECT 1")
-        except BaseException as e:
-            error[0] = e
-
-    t = threading.Thread(target=_probe, daemon=True)
-    t.start()
-    t.join(timeout=timeout)
-
-    if t.is_alive():
-        raise TimeoutError(
-            f"Database health check timed out after {timeout}s. The connection is likely stale."
-        )
-
-    if error[0] is not None:
-        raise error[0]
+    _run_with_timeout(lambda: conn.execute("SELECT 1"), timeout, "Database health check")
 
 
 # --- Connection Management ---
@@ -255,10 +281,19 @@ def get_connection(db_path: str | Path | None = None) -> sqlite3.Connection:
 
                 logging.info(f"Creating new libsql connection to {db_url[:50]}...")
                 try:
-                    _conn = libsql.connect(
-                        db_url, auth_token=os.environ.get("TURSO_AUTH_TOKEN", "")
+                    _conn = _run_with_timeout(
+                        lambda: libsql.connect(
+                            db_url, auth_token=os.environ.get("TURSO_AUTH_TOKEN", "")
+                        ),
+                        timeout=LIBSQL_CONNECT_TIMEOUT,
+                        description="libsql.connect()",
                     )
                     _is_libsql = True
+                except TimeoutError:
+                    logging.error(f"libsql.connect() timed out after {LIBSQL_CONNECT_TIMEOUT}s")
+                    raise RuntimeError(
+                        f"Timed out connecting to Turso database after {LIBSQL_CONNECT_TIMEOUT}s"
+                    )
                 except Exception as e:
                     logging.error(f"Failed to connect to libsql: {e}")
                     raise RuntimeError(f"Failed to connect to Turso database: {e}") from e
@@ -279,10 +314,16 @@ def get_connection(db_path: str | Path | None = None) -> sqlite3.Connection:
 
                     reason = "timed out" if is_timeout else "stale"
                     logging.warning(f"Libsql connection {reason}, reconnecting: {e}")
+                    # Close the stale connection with a timeout — close() itself
+                    # can hang on a dead TCP socket.
                     try:
-                        _conn.close()
+                        _run_with_timeout(
+                            lambda: _conn.close(),  # type: ignore[union-attr]
+                            timeout=2.0,
+                            description="conn.close()",
+                        )
                     except Exception:
-                        pass
+                        pass  # Abandon the stale connection
                     _conn = None
                     _is_libsql = False
                     # Release lock before recursive call to avoid deadlock

--- a/src/deadrop/db.py
+++ b/src/deadrop/db.py
@@ -2068,19 +2068,32 @@ def has_new_room_messages(
 def get_room_messages(
     room_id: str,
     after_mid: str | None = None,
+    before_mid: str | None = None,
     limit: int = 100,
     conn: sqlite3.Connection | None = None,
 ) -> list[dict]:
     """Get messages from a room.
 
+    Supports both forward and backward pagination:
+    - ``after_mid``: messages newer than this ID (forward / polling)
+    - ``before_mid``: messages older than this ID (backward / scroll-up)
+
+    When ``before_mid`` is provided the query fetches the *newest* messages
+    that are still older than the cursor, so the caller receives the page
+    immediately preceding the cursor in chronological order.
+
+    Results are always returned in chronological (ascending mid) order
+    regardless of pagination direction.
+
     Args:
         room_id: Room ID
-        after_mid: Only get messages after this message ID (for pagination/polling)
+        after_mid: Only get messages after this message ID (forward pagination)
+        before_mid: Only get messages before this message ID (backward pagination)
         limit: Maximum number of messages to return
         conn: Optional database connection
 
     Returns:
-        List of message dicts ordered by creation time
+        List of message dicts ordered by creation time (ascending)
     """
     conn = _get_conn(conn)
 
@@ -2095,13 +2108,26 @@ def get_room_messages(
         query += " AND mid > ?"
         params.append(after_mid)
 
-    query += " ORDER BY mid LIMIT ?"
+    if before_mid:
+        query += " AND mid < ?"
+        params.append(before_mid)
+
+    # Determine sort direction:
+    # - after_mid only: forward scan (ASC) — polling for new messages
+    # - before_mid (with or without after_mid): backward scan (DESC) — scroll-up
+    # - neither cursor: backward scan (DESC) — initial load gets newest page
+    use_desc = not after_mid or (before_mid and not after_mid)
+
+    if use_desc:
+        query += " ORDER BY mid DESC LIMIT ?"
+    else:
+        query += " ORDER BY mid LIMIT ?"
     params.append(limit)
 
     cursor = conn.execute(query, tuple(params))
     rows = _rows_to_dicts(cursor.description, cursor.fetchall())
 
-    return [
+    messages = [
         {
             "mid": row["mid"],
             "room_id": row["room_id"],
@@ -2113,6 +2139,12 @@ def get_room_messages(
         }
         for row in rows
     ]
+
+    # DESC rows need reversing so callers always get chronological order.
+    if use_desc:
+        messages.reverse()
+
+    return messages
 
 
 def get_room_message(

--- a/src/deadrop/static/js/api.js
+++ b/src/deadrop/static/js/api.js
@@ -130,13 +130,15 @@ const DeadropAPI = {
      * @param {object} credentials - User credentials
      * @param {string} roomId - Room ID
      * @param {object} options - Optional parameters
-     * @param {string} options.afterMid - Get messages after this message ID
+     * @param {string} options.afterMid - Get messages after this message ID (forward)
+     * @param {string} options.beforeMid - Get messages before this message ID (backward)
      * @param {number} options.limit - Max messages to return
      */
-    async getRoomMessages(credentials, roomId, { afterMid = null, limit = null } = {}) {
+    async getRoomMessages(credentials, roomId, { afterMid = null, beforeMid = null, limit = null } = {}) {
         let path = `/${credentials.ns}/rooms/${roomId}/messages`;
         const params = new URLSearchParams();
         if (afterMid) params.set('after', afterMid);
+        if (beforeMid) params.set('before', beforeMid);
         if (limit) params.set('limit', limit.toString());
         if (params.toString()) path += '?' + params.toString();
         

--- a/src/deadrop/templates/app.html
+++ b/src/deadrop/templates/app.html
@@ -182,6 +182,8 @@
     let roomMessages = [];
     let roomMembers = {};
     let roomMessagesLoading = false;  // Guard against concurrent fetches
+    let roomHasOlderMessages = true;  // Whether there are more messages to load on scroll-up
+    let roomLoadingOlder = false;     // Guard against concurrent scroll-up fetches
     // Legacy long-poll removed — subscriptions are the sole update mechanism
     let subscriptionManager = null;  // Unified subscription manager
     
@@ -633,9 +635,12 @@
         }
     }
     
+    const ROOM_PAGE_SIZE = 100;
+
     async function loadRoomMessages() {
         const list = document.getElementById('room-message-list');
         roomMessagesLoading = true;
+        roomHasOlderMessages = true;
         
         // Try loading from cache first for instant display
         const cacheKey = `room_messages_${currentRoomId}`;
@@ -655,30 +660,23 @@
         try {
             const startTime = performance.now();
             
-            // Paginate to fetch ALL messages (server default limit is 100)
-            const PAGE_SIZE = 500;
-            let allMessages = [];
-            let afterMid = null;
-            
-            while (true) {
-                const result = await DeadropAPI.getRoomMessages(
-                    credentials, currentRoomId, { afterMid, limit: PAGE_SIZE });
-                const page = result?.messages || [];
-                allMessages = [...allMessages, ...page];
-                
-                if (page.length < PAGE_SIZE) break;  // Last page
-                afterMid = page[page.length - 1].mid;
-            }
+            // Load only the newest page — no cursor means "latest N messages"
+            // The server returns results in chronological order (ASC) even
+            // when fetching backward, so the last element is the newest.
+            const result = await DeadropAPI.getRoomMessages(
+                credentials, currentRoomId, { limit: ROOM_PAGE_SIZE });
+            const page = result?.messages || [];
             
             const elapsed = Math.round(performance.now() - startTime);
-            console.log(`Room messages loaded in ${elapsed}ms (${allMessages.length} msgs)`);
+            console.log(`Room messages loaded in ${elapsed}ms (${page.length} msgs)`);
             
-            roomMessages = allMessages;
+            roomMessages = page;
+            roomHasOlderMessages = page.length >= ROOM_PAGE_SIZE;
             
             // Save to cache
             localStorage.setItem(cacheKey, JSON.stringify(roomMessages));
             
-            // Update subscription cursor
+            // Update subscription cursor for the newest message
             if (subscriptionManager && roomMessages.length > 0) {
                 const lastMid = roomMessages[roomMessages.length - 1].mid;
                 subscriptionManager.updateCursor(`room:${currentRoomId}`, lastMid);
@@ -691,6 +689,59 @@
             }
         } finally {
             roomMessagesLoading = false;
+        }
+    }
+    
+    /**
+     * Load older messages when the user scrolls to the top.
+     * Uses the `before` cursor to fetch the page preceding the oldest
+     * message currently loaded.
+     */
+    async function loadOlderRoomMessages() {
+        if (roomLoadingOlder || !roomHasOlderMessages || roomMessages.length === 0) return;
+        roomLoadingOlder = true;
+        
+        const list = document.getElementById('room-message-list');
+        
+        try {
+            // The oldest message we have is the first element (chronological order)
+            const oldestMid = roomMessages[0].mid;
+            
+            const result = await DeadropAPI.getRoomMessages(
+                credentials, currentRoomId, { beforeMid: oldestMid, limit: ROOM_PAGE_SIZE });
+            const olderPage = result?.messages || [];
+            
+            if (olderPage.length === 0) {
+                roomHasOlderMessages = false;
+                return;
+            }
+            
+            roomHasOlderMessages = olderPage.length >= ROOM_PAGE_SIZE;
+            
+            // Prepend older messages (they come in chronological order)
+            roomMessages = [...olderPage, ...roomMessages];
+            
+            // Save to cache
+            const cacheKey = `room_messages_${currentRoomId}`;
+            localStorage.setItem(cacheKey, JSON.stringify(roomMessages));
+            
+            // Re-render preserving scroll position.
+            // With column-reverse, the "top" in visual terms is the bottom of
+            // the DOM scroll.  We record scrollHeight before, render, then
+            // adjust scrollTop by the delta so the viewport stays on the same
+            // messages.
+            const prevScrollHeight = list.scrollHeight;
+            renderRoomMessages({skipReadCursor: true});
+            const newScrollHeight = list.scrollHeight;
+            // column-reverse: scrollTop is negative (or 0 at bottom).
+            // Adding the height delta keeps the same content in view.
+            list.scrollTop -= (newScrollHeight - prevScrollHeight);
+            
+            console.log(`Loaded ${olderPage.length} older messages (total: ${roomMessages.length})`);
+        } catch (e) {
+            console.error('Failed to load older messages:', e);
+        } finally {
+            roomLoadingOlder = false;
         }
     }
     
@@ -723,7 +774,7 @@
         return `<div class="reaction-badges">${badges}<button class="reaction-badge add-reaction" onclick="showReactionPicker(event, '${mid}')" title="Add reaction">+</button></div>`;
     }
     
-    function renderRoomMessages() {
+    function renderRoomMessages({skipReadCursor = false} = {}) {
         const list = document.getElementById('room-message-list');
         
         // Build reaction map from all messages
@@ -734,6 +785,12 @@
         
         // Reverse for column-reverse display (newest at bottom visually)
         const reversed = [...displayMessages].reverse();
+
+        // Show a "load more" sentinel at the visual top (DOM bottom in
+        // column-reverse) when there are older messages to fetch.
+        const loadMoreHtml = roomHasOlderMessages
+            ? '<div id="room-load-more" class="load-more-sentinel" style="text-align:center;padding:12px;color:var(--text-muted);font-size:13px;">Loading older messages…</div>'
+            : '';
         
         list.innerHTML = reversed.map(msg => {
             const isMe = msg.from_id === credentials.id;
@@ -747,19 +804,33 @@
                     <div class="message-time">${isPending ? 'Sending...' : formatTime(msg.created_at)}</div>
                 </div>
             `;
-        }).join('');
+        }).join('') + loadMoreHtml;
         
         // No need to scroll - column-reverse keeps us at bottom
         
         // Apply syntax highlighting to code blocks
         highlightCodeBlocks(list);
         
-        // Update read cursor (skip pending messages)
-        const realMessages = roomMessages.filter(m => !m.pending);
-        if (realMessages.length > 0) {
-            const lastMid = realMessages[realMessages.length - 1].mid;
-            DeadropAPI.updateRoomReadCursor(credentials, currentRoomId, lastMid).catch(() => {});
+        // Only update read cursor if the newest message is actually visible
+        // (i.e. the user hasn't scrolled up away from the bottom).
+        // In column-reverse, scrollTop ≈ 0 means we're at the bottom (newest).
+        if (!skipReadCursor && isAtBottom(list)) {
+            const realMessages = roomMessages.filter(m => !m.pending);
+            if (realMessages.length > 0) {
+                const lastMid = realMessages[realMessages.length - 1].mid;
+                DeadropAPI.updateRoomReadCursor(credentials, currentRoomId, lastMid).catch(() => {});
+            }
         }
+    }
+    
+    /**
+     * Check whether the message list is scrolled to the bottom (newest).
+     * In a column-reverse container, scrollTop = 0 means "at the bottom"
+     * (newest content visible). Negative values mean scrolled up.
+     */
+    function isAtBottom(listEl) {
+        // Allow a small tolerance for fractional pixels
+        return listEl.scrollTop >= -50;
     }
     
     async function sendRoomMessage() {
@@ -965,7 +1036,10 @@
                     roomMessages = [...roomMessages, ...newMsgs];
                     const cacheKey = `room_messages_${roomId}`;
                     localStorage.setItem(cacheKey, JSON.stringify(roomMessages));
-                    renderRoomMessages();
+                    
+                    // Only auto-update read cursor if user is at the bottom
+                    const list = document.getElementById('room-message-list');
+                    renderRoomMessages({skipReadCursor: !isAtBottom(list)});
                 }
                 
                 // Update subscription cursor (always, even if deduplicated)
@@ -1043,6 +1117,8 @@
         currentRoomId = null;
         roomMessages = [];
         roomMembers = {};
+        roomHasOlderMessages = true;
+        roomLoadingOlder = false;
         history.pushState({}, '', `/app/${currentSlug}`);
         showView('inbox');
     });
@@ -1057,6 +1133,31 @@
         if (e.key === 'Enter' && !e.shiftKey) {
             e.preventDefault();
             sendMessage();
+        }
+    });
+    
+    // Scroll-up to load older messages + scroll-to-bottom to mark as read
+    document.getElementById('room-message-list').addEventListener('scroll', () => {
+        const list = document.getElementById('room-message-list');
+        
+        // column-reverse: scrollTop is 0 at bottom, negative when scrolled up.
+        // When the user scrolls near the "top" (oldest, most negative scrollTop),
+        // load more history.
+        if (roomHasOlderMessages && !roomLoadingOlder) {
+            const scrolledUp = -list.scrollTop;
+            const threshold = list.scrollHeight - list.clientHeight - 200;
+            if (scrolledUp >= threshold) {
+                loadOlderRoomMessages();
+            }
+        }
+        
+        // When the user scrolls back to the bottom (newest), update read cursor
+        if (isAtBottom(list)) {
+            const realMessages = roomMessages.filter(m => !m.pending);
+            if (realMessages.length > 0) {
+                const lastMid = realMessages[realMessages.length - 1].mid;
+                DeadropAPI.updateRoomReadCursor(credentials, currentRoomId, lastMid).catch(() => {});
+            }
         }
     });
     

--- a/src/deadrop/templates/app.html
+++ b/src/deadrop/templates/app.html
@@ -635,7 +635,7 @@
         }
     }
     
-    const ROOM_PAGE_SIZE = 100;
+    const ROOM_PAGE_SIZE = {{ ROOM_PAGE_SIZE }};
 
     async function loadRoomMessages() {
         const list = document.getElementById('room-message-list');

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -378,6 +378,44 @@ class TestRoomMessages:
         messages = db.get_room_messages(room["room_id"], limit=3)
 
         assert len(messages) == 3
+        # No cursor = newest page; results are still chronological (ASC)
+        assert messages[0]["body"] == "Message 2"
+        assert messages[2]["body"] == "Message 4"
+
+    def test_get_room_messages_before_mid(self):
+        """Get older messages before a given mid (backward pagination)."""
+        ns = db.create_namespace()
+        alice = db.create_identity(ns["ns"])
+        room = db.create_room(ns["ns"], alice["id"])
+
+        mids = []
+        for i in range(5):
+            msg = db.send_room_message(room["room_id"], alice["id"], f"Message {i}")
+            mids.append(msg["mid"])
+
+        # Get messages before mid[3] (i.e., "Message 3"), limit 2
+        messages = db.get_room_messages(room["room_id"], before_mid=mids[3], limit=2)
+
+        assert len(messages) == 2
+        # Should get the 2 newest messages before mid[3]: "Message 1" and "Message 2"
+        assert messages[0]["body"] == "Message 1"
+        assert messages[1]["body"] == "Message 2"
+
+    def test_get_room_messages_before_mid_exhausted(self):
+        """Before-mid pagination returns fewer when history is exhausted."""
+        ns = db.create_namespace()
+        alice = db.create_identity(ns["ns"])
+        room = db.create_room(ns["ns"], alice["id"])
+
+        mids = []
+        for i in range(3):
+            msg = db.send_room_message(room["room_id"], alice["id"], f"Message {i}")
+            mids.append(msg["mid"])
+
+        # Ask for 10 before mid[1], only "Message 0" exists
+        messages = db.get_room_messages(room["room_id"], before_mid=mids[1], limit=10)
+
+        assert len(messages) == 1
         assert messages[0]["body"] == "Message 0"
 
     def test_get_room_message(self):


### PR DESCRIPTION
## Summary

Load the newest page of messages first for instant display of recent content, then lazy-load older messages as the user scrolls up. This dramatically improves initial load time for rooms with long history.

Closes #30

## Changes

### API / DB Layer
- `get_room_messages` now accepts a `before` cursor for backward pagination  
- **Default behavior change**: no-cursor requests now return the **newest** N messages (was oldest N)
- Results always returned in chronological (ASC) order regardless of pagination direction
- Fully backward compatible: `after` cursor still works for forward polling

### Web Client
- Initial load fetches only the latest page (100 msgs) instead of looping to fetch ALL messages
- Scroll-up triggers `loadOlderRoomMessages()` which loads older pages via `before` cursor
- "Load more" sentinel shown at visual top when older messages exist
- Read cursor (`last_read_mid`) only updates when the newest message is visible on screen — scrolling up to read history does NOT mark newer unseen messages as read
- Scrolling back to bottom resumes read cursor updates

### Backend / SDK
- `before_mid` parameter added to all backend `get_room_messages` methods
- Python `client.get_room_messages` accepts `before_mid`  
- JS `DeadropAPI.getRoomMessages` accepts `beforeMid` option

## Testing
- 395 tests pass (2 new tests for `before_mid` backward pagination)
- All linters/formatters pass
- Existing `after_mid` forward pagination tests unchanged