### PR TITLE
feat: exponential backoff for subscribe errors + implicit message deduplication

### DIFF
--- a/src/deadrop/__init__.py
+++ b/src/deadrop/__init__.py
@@ -24,13 +24,16 @@ Usage:
 """
 
 from deadrop._version import __version__
+from deadrop.backends import AuthenticationError, DeaddropAPIError
 from deadrop.client import Deaddrop
 from deadrop.discovery import DeaddropNotFound
 from deadrop.options import DeaddropConfigError, DeaddropOptions
 
 __all__ = [
     "__version__",
+    "AuthenticationError",
     "Deaddrop",
+    "DeaddropAPIError",
     "DeaddropOptions",
     "DeaddropNotFound",
     "DeaddropConfigError",

--- a/src/deadrop/api.py
+++ b/src/deadrop/api.py
@@ -866,8 +866,14 @@ async def send_message(
 
     Messages are delivered instantly. Optionally set ttl_hours for ephemeral
     messages that expire from creation time (instead of read time).
+
+    Implicit idempotency: if the same sender sends an identical message to
+    the same recipient within a short window (network retry), the original
+    message is returned with a ``Dedup-Status: deduplicated`` header.
     """
     import functools
+
+    from fastapi.responses import JSONResponse
 
     from .events import get_event_bus
 
@@ -889,13 +895,22 @@ async def send_message(
     except ValueError as e:
         raise HTTPException(404, str(e))
 
-    # Notify subscribers that the recipient's inbox has a new message
-    try:
-        await get_event_bus().publish(ns, f"inbox:{request.to}", result["mid"], sender_id=from_id)
-    except Exception:
-        logger.warning("Failed to publish inbox event", exc_info=True)
+    deduplicated = result.pop("deduplicated", False)
 
-    return result
+    # Only publish events for genuinely new messages
+    if not deduplicated:
+        try:
+            await get_event_bus().publish(
+                ns, f"inbox:{request.to}", result["mid"], sender_id=from_id
+            )
+        except Exception:
+            logger.warning("Failed to publish inbox event", exc_info=True)
+
+    headers = {}
+    if deduplicated:
+        headers["Dedup-Status"] = "deduplicated"
+
+    return JSONResponse(content=result, headers=headers)
 
 
 @app.get("/{ns}/inbox/{identity_id}")
@@ -1520,15 +1535,22 @@ async def get_room_messages(
     }
 
 
-@app.post("/{ns}/rooms/{room_id}/messages", response_model=RoomMessageInfo)
+@app.post("/{ns}/rooms/{room_id}/messages")
 async def send_room_message(
     ns: str,
     room_id: str,
     request: SendRoomMessageRequest,
     x_inbox_secret: Annotated[str | None, Header()] = None,
 ):
-    """Send a message to a room. Requires membership."""
+    """Send a message to a room. Requires membership.
+
+    Implicit idempotency: if the same sender sends an identical message to
+    the same room within a short window (network retry), the original
+    message is returned with a ``Dedup-Status: deduplicated`` header.
+    """
     import functools
+
+    from fastapi.responses import JSONResponse
 
     from .events import get_event_bus
 
@@ -1551,13 +1573,24 @@ async def send_room_message(
     except ValueError as e:
         raise HTTPException(400, str(e))
 
-    # Notify subscribers that this room has a new message
-    try:
-        await get_event_bus().publish(ns, f"room:{room_id}", message["mid"], sender_id=from_id)
-    except Exception:
-        logger.warning("Failed to publish room event", exc_info=True)
+    deduplicated = message.pop("deduplicated", False)
 
-    return RoomMessageInfo.from_db(message)
+    # Only publish events for genuinely new messages
+    if not deduplicated:
+        try:
+            await get_event_bus().publish(
+                ns, f"room:{room_id}", message["mid"], sender_id=from_id
+            )
+        except Exception:
+            logger.warning("Failed to publish room event", exc_info=True)
+
+    response_data = RoomMessageInfo.from_db(message).model_dump()
+
+    headers = {}
+    if deduplicated:
+        headers["Dedup-Status"] = "deduplicated"
+
+    return JSONResponse(content=response_data, headers=headers)
 
 
 @app.post("/{ns}/rooms/{room_id}/read")

--- a/src/deadrop/api.py
+++ b/src/deadrop/api.py
@@ -1578,9 +1578,7 @@ async def send_room_message(
     # Only publish events for genuinely new messages
     if not deduplicated:
         try:
-            await get_event_bus().publish(
-                ns, f"room:{room_id}", message["mid"], sender_id=from_id
-            )
+            await get_event_bus().publish(ns, f"room:{room_id}", message["mid"], sender_id=from_id)
         except Exception:
             logger.warning("Failed to publish room event", exc_info=True)
 

--- a/src/deadrop/backends.py
+++ b/src/deadrop/backends.py
@@ -22,6 +22,25 @@ from .auth import derive_id
 from .discovery import ensure_gitignore, get_deaddrop_init_path
 
 
+class DeaddropAPIError(Exception):
+    """Base exception for Deaddrop API errors."""
+
+    def __init__(self, message: str, status_code: int | None = None):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class AuthenticationError(DeaddropAPIError):
+    """Raised when authentication fails (401/403).
+
+    Callers should implement exponential backoff when receiving this
+    error in a polling loop, as retrying immediately will not help
+    and wastes server resources.
+    """
+
+    pass
+
+
 @dataclass
 class BackendInfo:
     """Information about a backend instance."""
@@ -1241,7 +1260,12 @@ class RemoteBackend(Backend):
         headers: dict[str, str] | None = None,
         timeout: float | None = None,
     ) -> Any:
-        """Make an HTTP request."""
+        """Make an HTTP request.
+
+        Raises:
+            AuthenticationError: For 401/403 responses.
+            DeaddropAPIError: For other 4xx/5xx responses.
+        """
         url = f"{self._url}{path}"
         request_headers = headers or {}
 
@@ -1253,8 +1277,17 @@ class RemoteBackend(Backend):
             timeout=timeout,
         )
 
+        if response.status_code in (401, 403):
+            raise AuthenticationError(
+                f"Authentication failed ({response.status_code}): {response.text}",
+                status_code=response.status_code,
+            )
+
         if response.status_code >= 400:
-            raise RuntimeError(f"API error {response.status_code}: {response.text}")
+            raise DeaddropAPIError(
+                f"API error {response.status_code}: {response.text}",
+                status_code=response.status_code,
+            )
 
         if response.status_code == 204 or not response.content:
             return None
@@ -1312,8 +1345,8 @@ class RemoteBackend(Backend):
                 f"/admin/namespaces/{ns}",
                 headers=self._admin_headers(),
             )
-        except RuntimeError as e:
-            if "404" in str(e):
+        except DeaddropAPIError as e:
+            if e.status_code == 404:
                 return None
             raise
 
@@ -1325,7 +1358,7 @@ class RemoteBackend(Backend):
                 headers=self._admin_headers(),
             )
             return True
-        except RuntimeError:
+        except DeaddropAPIError:
             return False
 
     def archive_namespace(self, ns: str, secret: str) -> bool:
@@ -1336,7 +1369,7 @@ class RemoteBackend(Backend):
                 headers=self._ns_headers(secret),
             )
             return True
-        except RuntimeError:
+        except DeaddropAPIError:
             return False
 
     # --- Identity Operations ---
@@ -1375,7 +1408,7 @@ class RemoteBackend(Backend):
         headers = {"X-Namespace-Secret": secret}
         try:
             return self._request("GET", f"/{ns}/identities", headers=headers)
-        except RuntimeError:
+        except DeaddropAPIError:
             headers = {"X-Inbox-Secret": secret}
             return self._request("GET", f"/{ns}/identities", headers=headers)
 
@@ -1400,7 +1433,7 @@ class RemoteBackend(Backend):
                 headers=self._ns_headers(ns_secret),
             )
             return True
-        except RuntimeError:
+        except DeaddropAPIError:
             return False
 
     # --- Message Operations ---
@@ -1470,7 +1503,7 @@ class RemoteBackend(Backend):
                 headers=self._inbox_headers(secret),
             )
             return True
-        except RuntimeError:
+        except DeaddropAPIError:
             return False
 
     def archive_message(
@@ -1487,7 +1520,7 @@ class RemoteBackend(Backend):
                 headers=self._inbox_headers(secret),
             )
             return True
-        except RuntimeError:
+        except DeaddropAPIError:
             return False
 
     def get_archived_messages(
@@ -1545,8 +1578,8 @@ class RemoteBackend(Backend):
                 f"/{ns}/rooms/{room_id}",
                 headers=self._inbox_headers(secret),
             )
-        except RuntimeError as e:
-            if "404" in str(e) or "403" in str(e):
+        except DeaddropAPIError as e:
+            if e.status_code in (403, 404):
                 return None
             raise
 
@@ -1563,7 +1596,7 @@ class RemoteBackend(Backend):
                 headers=self._ns_headers(ns_secret),
             )
             return True
-        except RuntimeError:
+        except DeaddropAPIError:
             return False
 
     def add_room_member(
@@ -1594,7 +1627,7 @@ class RemoteBackend(Backend):
                 headers=self._inbox_headers(secret),
             )
             return True
-        except RuntimeError:
+        except DeaddropAPIError:
             return False
 
     def list_room_members(
@@ -1671,7 +1704,7 @@ class RemoteBackend(Backend):
                 headers=self._inbox_headers(secret),
             )
             return True
-        except RuntimeError:
+        except DeaddropAPIError:
             return False
 
     def get_room_unread_count(
@@ -1766,7 +1799,14 @@ class RemoteBackend(Backend):
         topics: dict[str, str | None],
         timeout: int = 30,
     ) -> dict[str, Any]:
-        """Subscribe to topic changes via the HTTP API (poll mode)."""
+        """Subscribe to topic changes via the HTTP API (poll mode).
+
+        Raises:
+            AuthenticationError: For 401/403 responses. Callers should
+                implement exponential backoff rather than retrying immediately.
+            DeaddropAPIError: For other server errors.
+            ValueError: For client-side validation errors (400 responses).
+        """
         response = self._client.post(
             f"{self._url}/{ns}/subscribe",
             headers={"X-Inbox-Secret": secret},
@@ -1774,9 +1814,21 @@ class RemoteBackend(Backend):
             timeout=max(30.0, timeout + 5),
         )
 
-        if response.status_code != 200:
+        if response.status_code in (401, 403):
             error = response.json().get("detail", response.text)
-            raise ValueError(f"Subscribe failed: {error}")
+            raise AuthenticationError(
+                f"Subscribe authentication failed ({response.status_code}): {error}",
+                status_code=response.status_code,
+            )
+
+        if response.status_code >= 400:
+            error = response.json().get("detail", response.text)
+            if response.status_code < 500:
+                raise ValueError(f"Subscribe failed: {error}")
+            raise DeaddropAPIError(
+                f"Subscribe server error ({response.status_code}): {error}",
+                status_code=response.status_code,
+            )
 
         return response.json()
 

--- a/src/deadrop/client.py
+++ b/src/deadrop/client.py
@@ -22,12 +22,23 @@ Usage:
 
 from __future__ import annotations
 
+import logging
+import time
 from pathlib import Path
 from typing import Any
 
-from .backends import Backend, InMemoryBackend, LocalBackend, RemoteBackend
+from .backends import (
+    AuthenticationError,
+    Backend,
+    DeaddropAPIError,
+    InMemoryBackend,
+    LocalBackend,
+    RemoteBackend,
+)
 from .discovery import DeaddropNotFound, discover_backend, get_deaddrop_init_path
 from .options import DeaddropOptions
+
+logger = logging.getLogger(__name__)
 
 
 class Deaddrop:
@@ -777,11 +788,18 @@ class Deaddrop:
         secret: str,
         topics: dict[str, str | None],
         timeout: int = 30,
+        max_retries: int = 0,
+        on_error: str = "raise",
     ):
         """Generator that yields topic change events across multiple topics.
 
         Uses poll-mode subscribe in a loop, yielding (topic, latest_mid) tuples.
         Automatically updates cursors to avoid re-reporting the same change.
+
+        Implements exponential backoff for transient errors. Authentication
+        errors (401/403) are retried with backoff up to ``max_retries`` times
+        before being raised, since they typically indicate revoked credentials
+        that won't recover.
 
         This is the recommended way to monitor multiple topics (inbox + rooms)
         simultaneously.
@@ -791,9 +809,18 @@ class Deaddrop:
             secret: Caller's inbox secret.
             topics: Map of topic_key -> last_seen_mid (None = never seen).
             timeout: Long-poll timeout per iteration (1-60 seconds).
+            max_retries: Max consecutive errors before giving up (0 = fail fast
+                on auth errors, retry transient errors indefinitely).
+            on_error: Error handling strategy:
+                - ``"raise"``: Re-raise after max_retries (default).
+                - ``"log"``: Log errors and continue retrying forever.
 
         Yields:
             Tuples of (topic_key, latest_mid).
+
+        Raises:
+            AuthenticationError: When auth fails and max_retries is exceeded.
+            DeaddropAPIError: When server errors exhaust retries.
 
         Example:
             topics = {
@@ -810,9 +837,47 @@ class Deaddrop:
                     messages = client.get_room_messages(ns, room_id, secret, after_mid=mid)
         """
         cursors = dict(topics)
+        consecutive_errors = 0
+        # Backoff params: start at 1s, double each time, cap at 5 minutes
+        base_delay = 1.0
+        max_delay = 300.0
 
         while True:
-            result = self.subscribe(ns, secret, cursors, timeout)
+            try:
+                result = self.subscribe(ns, secret, cursors, timeout)
+                # Success — reset error counter
+                consecutive_errors = 0
+            except AuthenticationError as e:
+                consecutive_errors += 1
+                delay = min(base_delay * (2 ** (consecutive_errors - 1)), max_delay)
+                logger.warning(
+                    "subscribe auth error (%d/%s), backing off %.1fs: %s",
+                    consecutive_errors,
+                    max_retries or "∞",
+                    delay,
+                    e,
+                )
+                if max_retries and consecutive_errors >= max_retries:
+                    if on_error == "raise":
+                        raise
+                    # on_error == "log": continue with backoff
+                time.sleep(delay)
+                continue
+            except (DeaddropAPIError, OSError) as e:
+                # Transient server/network errors — always retry with backoff
+                consecutive_errors += 1
+                delay = min(base_delay * (2 ** (consecutive_errors - 1)), max_delay)
+                logger.warning(
+                    "subscribe error (%d), backing off %.1fs: %s",
+                    consecutive_errors,
+                    delay,
+                    e,
+                )
+                if max_retries and consecutive_errors >= max_retries:
+                    if on_error == "raise":
+                        raise
+                time.sleep(delay)
+                continue
 
             for topic, mid in result.get("events", {}).items():
                 cursors[topic] = mid

--- a/src/deadrop/db.py
+++ b/src/deadrop/db.py
@@ -39,11 +39,16 @@ from uuid_extensions import uuid7 as make_uuid7
 
 from .auth import derive_id, generate_secret, hash_secret
 
+# Deduplication window in seconds — messages with the same sender,
+# destination, and content hash within this window are considered
+# duplicates and silently de-duplicated.
+DEDUP_WINDOW_SECONDS = 60
+
 # Default TTL in hours when messages are read
 DEFAULT_TTL_HOURS = 24
 
 # Current schema version (increment when adding migrations)
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 
 # Thread-local storage for per-thread connections
 # This ensures each thread gets its own SQLite connection, avoiding
@@ -641,12 +646,40 @@ def _migrate_004_add_mid_indexes(conn: sqlite3.Connection) -> None:
     conn.commit()
 
 
+def _migrate_005_add_content_hash(conn: sqlite3.Connection) -> None:
+    """Migration 005: Add content_hash for implicit message deduplication.
+
+    Network timeouts can cause clients to retry sends, producing duplicate
+    messages. We add a content_hash column to both messages and room_messages
+    and create indexes that support efficient duplicate lookups within a
+    time window based on (sender, destination, content_hash).
+    """
+    # Direct messages
+    if not _column_exists(conn, "messages", "content_hash"):
+        conn.execute("ALTER TABLE messages ADD COLUMN content_hash TEXT")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_messages_dedup "
+        "ON messages(ns, from_id, to_id, content_hash)"
+    )
+
+    # Room messages
+    if not _column_exists(conn, "room_messages", "content_hash"):
+        conn.execute("ALTER TABLE room_messages ADD COLUMN content_hash TEXT")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_room_messages_dedup "
+        "ON room_messages(room_id, from_id, content_hash)"
+    )
+
+    conn.commit()
+
+
 # Migration registry: (version, description, migration_function)
 MIGRATIONS: list[tuple[int, str, Callable[[sqlite3.Connection], None]]] = [
     (1, "Add content_type column to messages", _migrate_001_add_content_type),
     (2, "Add rooms tables for group communication", _migrate_002_add_rooms),
     (3, "Add reference_mid to room_messages for reactions", _migrate_003_add_reference_mid),
     (4, "Add mid-based indexes for room_messages and messages", _migrate_004_add_mid_indexes),
+    (5, "Add content_hash for implicit message deduplication", _migrate_005_add_content_hash),
 ]
 
 
@@ -704,6 +737,7 @@ SCHEMA_SQL = """
         from_id TEXT NOT NULL,
         body TEXT NOT NULL,
         content_type TEXT DEFAULT 'text/plain',
+        content_hash TEXT,
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         read_at TIMESTAMP,
         expires_at TIMESTAMP,
@@ -717,6 +751,8 @@ SCHEMA_SQL = """
         ON messages(expires_at) WHERE expires_at IS NOT NULL;
     CREATE INDEX IF NOT EXISTS idx_messages_archived
         ON messages(ns, to_id, archived_at) WHERE archived_at IS NOT NULL;
+    CREATE INDEX IF NOT EXISTS idx_messages_dedup
+        ON messages(ns, from_id, to_id, content_hash);
     
     CREATE TABLE IF NOT EXISTS invites (
         invite_id TEXT PRIMARY KEY,
@@ -772,10 +808,13 @@ SCHEMA_SQL = """
         from_id TEXT NOT NULL,
         body TEXT NOT NULL,
         content_type TEXT DEFAULT 'text/plain',
+        content_hash TEXT,
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     );
     
     CREATE INDEX IF NOT EXISTS idx_room_messages_room ON room_messages(room_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_room_messages_dedup
+        ON room_messages(room_id, from_id, content_hash);
 """
 
 
@@ -1259,6 +1298,25 @@ def update_identity_metadata(
     return cursor.rowcount > 0
 
 
+# --- Content Hash for Deduplication ---
+
+
+def _compute_content_hash(body: str, content_type: str, reference_mid: str | None = None) -> str:
+    """Compute a short hash of message content for deduplication.
+
+    Uses SHA-256 truncated to 16 hex chars (64 bits) — sufficient for
+    detecting retries within a narrow time window while keeping the index
+    compact.
+    """
+    import hashlib
+
+    parts = [body, content_type]
+    if reference_mid:
+        parts.append(reference_mid)
+    digest = hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()
+    return digest[:16]
+
+
 # --- Message Operations ---
 
 
@@ -1271,7 +1329,13 @@ def send_message(
     ttl_hours: int | None = None,
     conn: sqlite3.Connection | None = None,
 ) -> dict:
-    """Send a message. Returns message info."""
+    """Send a message. Returns message info.
+
+    Implements implicit idempotency: if the same sender sends an identical
+    message (same body, content_type) to the same recipient within
+    DEDUP_WINDOW_SECONDS, the original message is returned instead of
+    creating a duplicate.
+    """
     conn = _get_conn(conn)
 
     # Verify recipient exists
@@ -1281,17 +1345,41 @@ def send_message(
     if not row:
         raise ValueError(f"Recipient {to_id} not found in namespace {ns}")
 
+    now = datetime.now(timezone.utc)
+    now_iso = now.isoformat()
+    content_hash = _compute_content_hash(body, content_type)
+
+    # Check for recent duplicate within the dedup window
+    window_start = (now - timedelta(seconds=DEDUP_WINDOW_SECONDS)).isoformat()
+    cursor = conn.execute(
+        """SELECT mid, from_id, to_id, content_type, created_at
+           FROM messages
+           WHERE ns = ? AND from_id = ? AND to_id = ? AND content_hash = ?
+             AND created_at > ?
+           ORDER BY created_at DESC LIMIT 1""",
+        (ns, from_id, to_id, content_hash, window_start),
+    )
+    existing = _row_to_dict(cursor.description, cursor.fetchone())
+    if existing:
+        return {
+            "mid": existing["mid"],
+            "from": existing["from_id"],
+            "to": existing["to_id"],
+            "content_type": existing["content_type"],
+            "created_at": existing["created_at"],
+            "deduplicated": True,
+        }
+
     mid = str(make_uuid7())
-    now = datetime.now(timezone.utc).isoformat()
 
     expires_at = None
     if ttl_hours is not None and ttl_hours > 0:
-        expires_at = (datetime.now(timezone.utc) + timedelta(hours=ttl_hours)).isoformat()
+        expires_at = (now + timedelta(hours=ttl_hours)).isoformat()
 
     conn.execute(
-        """INSERT INTO messages (mid, ns, to_id, from_id, body, content_type, created_at, expires_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
-        (mid, ns, to_id, from_id, body, content_type, now, expires_at),
+        """INSERT INTO messages (mid, ns, to_id, from_id, body, content_type, content_hash, created_at, expires_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (mid, ns, to_id, from_id, body, content_type, content_hash, now_iso, expires_at),
     )
     conn.commit()
 
@@ -1300,7 +1388,7 @@ def send_message(
         "from": from_id,
         "to": to_id,
         "content_type": content_type,
-        "created_at": now,
+        "created_at": now_iso,
     }
 
 
@@ -2097,6 +2185,11 @@ def send_room_message(
 ) -> dict:
     """Send a message to a room.
 
+    Implements implicit idempotency: if the same sender sends an identical
+    message (same body, content_type, reference_mid) to the same room
+    within DEDUP_WINDOW_SECONDS, the original message is returned instead
+    of creating a duplicate.
+
     Args:
         room_id: Room ID
         from_id: Sender identity ID (must be a member)
@@ -2122,14 +2215,40 @@ def send_room_message(
     if not is_room_member(room_id, from_id, conn=conn):
         raise ValueError(f"Identity {from_id} is not a member of room {room_id}")
 
+    now = datetime.now(timezone.utc)
+    now_iso = now.isoformat()
+    content_hash = _compute_content_hash(body, content_type, reference_mid)
+
+    # Check for recent duplicate within the dedup window
+    window_start = (now - timedelta(seconds=DEDUP_WINDOW_SECONDS)).isoformat()
+    cursor = conn.execute(
+        """SELECT mid, room_id, from_id, body, content_type, reference_mid, created_at
+           FROM room_messages
+           WHERE room_id = ? AND from_id = ? AND content_hash = ?
+             AND created_at > ?
+           ORDER BY created_at DESC LIMIT 1""",
+        (room_id, from_id, content_hash, window_start),
+    )
+    existing = _row_to_dict(cursor.description, cursor.fetchone())
+    if existing:
+        return {
+            "mid": existing["mid"],
+            "room_id": existing["room_id"],
+            "from": existing["from_id"],
+            "body": existing["body"],
+            "content_type": existing.get("content_type") or "text/plain",
+            "reference_mid": existing.get("reference_mid"),
+            "created_at": existing["created_at"],
+            "deduplicated": True,
+        }
+
     mid = str(make_uuid7())
-    now = datetime.now(timezone.utc).isoformat()
 
     conn.execute(
         """INSERT INTO room_messages
-               (mid, room_id, from_id, body, content_type, reference_mid, created_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?)""",
-        (mid, room_id, from_id, body, content_type, reference_mid, now),
+               (mid, room_id, from_id, body, content_type, content_hash, reference_mid, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        (mid, room_id, from_id, body, content_type, content_hash, reference_mid, now_iso),
     )
     conn.commit()
 
@@ -2140,7 +2259,7 @@ def send_room_message(
         "body": body,
         "content_type": content_type,
         "reference_mid": reference_mid,
-        "created_at": now,
+        "created_at": now_iso,
     }
 
 

--- a/tests/test_backend_errors.py
+++ b/tests/test_backend_errors.py
@@ -1,0 +1,108 @@
+"""Tests for backend error handling and exception types."""
+
+import pytest
+
+from deadrop.backends import AuthenticationError, DeaddropAPIError
+
+
+class TestExceptionHierarchy:
+    """Verify exception class hierarchy."""
+
+    def test_auth_error_is_api_error(self):
+        """AuthenticationError is a subclass of DeaddropAPIError."""
+        assert issubclass(AuthenticationError, DeaddropAPIError)
+
+    def test_api_error_is_exception(self):
+        """DeaddropAPIError is a subclass of Exception."""
+        assert issubclass(DeaddropAPIError, Exception)
+
+    def test_auth_error_has_status_code(self):
+        """AuthenticationError carries the status code."""
+        err = AuthenticationError("Forbidden", status_code=403)
+        assert err.status_code == 403
+        assert "Forbidden" in str(err)
+
+    def test_api_error_has_status_code(self):
+        """DeaddropAPIError carries the status code."""
+        err = DeaddropAPIError("Server Error", status_code=500)
+        assert err.status_code == 500
+
+    def test_catching_api_error_catches_auth_error(self):
+        """Catching DeaddropAPIError also catches AuthenticationError."""
+        with pytest.raises(DeaddropAPIError):
+            raise AuthenticationError("Forbidden", status_code=403)
+
+
+class TestRemoteBackendRequest:
+    """Tests for RemoteBackend._request error handling."""
+
+    @pytest.fixture
+    def mock_backend(self):
+        """Create a RemoteBackend with a mocked HTTP client."""
+        from unittest.mock import MagicMock
+
+        from deadrop.backends import RemoteBackend
+
+        backend = RemoteBackend.__new__(RemoteBackend)
+        backend._url = "https://example.com"
+        backend._bearer_token = None
+        backend._client = MagicMock()
+        return backend
+
+    def test_request_401_raises_auth_error(self, mock_backend):
+        """401 response raises AuthenticationError."""
+        mock_backend._client.request.return_value = _mock_response(401, "Unauthorized")
+
+        with pytest.raises(AuthenticationError) as exc_info:
+            mock_backend._request("GET", "/test")
+
+        assert exc_info.value.status_code == 401
+
+    def test_request_403_raises_auth_error(self, mock_backend):
+        """403 response raises AuthenticationError."""
+        mock_backend._client.request.return_value = _mock_response(403, "Forbidden")
+
+        with pytest.raises(AuthenticationError) as exc_info:
+            mock_backend._request("GET", "/test")
+
+        assert exc_info.value.status_code == 403
+
+    def test_request_404_raises_api_error(self, mock_backend):
+        """404 response raises DeaddropAPIError (not AuthenticationError)."""
+        mock_backend._client.request.return_value = _mock_response(404, "Not Found")
+
+        with pytest.raises(DeaddropAPIError) as exc_info:
+            mock_backend._request("GET", "/test")
+
+        assert exc_info.value.status_code == 404
+        assert not isinstance(exc_info.value, AuthenticationError)
+
+    def test_request_500_raises_api_error(self, mock_backend):
+        """500 response raises DeaddropAPIError."""
+        mock_backend._client.request.return_value = _mock_response(500, "Internal Error")
+
+        with pytest.raises(DeaddropAPIError) as exc_info:
+            mock_backend._request("GET", "/test")
+
+        assert exc_info.value.status_code == 500
+
+    def test_request_200_returns_json(self, mock_backend):
+        """200 response returns parsed JSON."""
+        resp = _mock_response(200, '{"ok": true}')
+        resp.json.return_value = {"ok": True}
+        resp.content = b'{"ok": true}'
+        mock_backend._client.request.return_value = resp
+
+        result = mock_backend._request("GET", "/test")
+        assert result == {"ok": True}
+
+
+def _mock_response(status_code, text=""):
+    """Create a mock HTTP response."""
+    from unittest.mock import MagicMock
+
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text
+    resp.content = text.encode() if text else b""
+    return resp

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -1,0 +1,507 @@
+"""Tests for implicit message deduplication.
+
+Verifies that identical messages from the same sender to the same destination
+within a short time window are deduplicated, preventing network-retry
+duplicates while still allowing intentional repeated messages.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from deadrop import db
+from deadrop.api import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def setup():
+    """Create namespace with two identities for testing."""
+    ns = db.create_namespace(metadata={"display_name": "Test NS"})
+    alice = db.create_identity(ns["ns"], metadata={"display_name": "Alice"})
+    bob = db.create_identity(ns["ns"], metadata={"display_name": "Bob"})
+    return {"ns": ns, "alice": alice, "bob": bob}
+
+
+@pytest.fixture
+def room_setup(setup):
+    """Create a room with Alice and Bob as members."""
+    ns = setup["ns"]["ns"]
+    alice_id = setup["alice"]["id"]
+    bob_id = setup["bob"]["id"]
+    room = db.create_room(ns, alice_id, display_name="Test Room")
+    db.add_room_member(room["room_id"], bob_id)
+    return {**setup, "room": room}
+
+
+# --- Direct Message Dedup (db layer) ---
+
+
+class TestDirectMessageDedup:
+    """Deduplication for direct (inbox) messages at the db layer."""
+
+    def test_duplicate_message_returns_same_mid(self, setup):
+        """Sending the same message twice returns the same mid."""
+        ns = setup["ns"]["ns"]
+        alice_id = setup["alice"]["id"]
+        bob_id = setup["bob"]["id"]
+
+        msg1 = db.send_message(ns, alice_id, bob_id, "Hello!")
+        msg2 = db.send_message(ns, alice_id, bob_id, "Hello!")
+
+        assert msg1["mid"] == msg2["mid"]
+        assert msg2.get("deduplicated") is True
+        assert msg1.get("deduplicated") is None  # First send is not deduped
+
+    def test_duplicate_detected_by_content_hash(self, setup):
+        """Dedup matches on body + content_type, not just body."""
+        ns = setup["ns"]["ns"]
+        alice_id = setup["alice"]["id"]
+        bob_id = setup["bob"]["id"]
+
+        msg1 = db.send_message(ns, alice_id, bob_id, "Hello!", content_type="text/plain")
+        msg2 = db.send_message(ns, alice_id, bob_id, "Hello!", content_type="text/plain")
+
+        assert msg1["mid"] == msg2["mid"]
+
+    def test_different_content_type_not_deduped(self, setup):
+        """Same body but different content_type creates separate message."""
+        ns = setup["ns"]["ns"]
+        alice_id = setup["alice"]["id"]
+        bob_id = setup["bob"]["id"]
+
+        msg1 = db.send_message(ns, alice_id, bob_id, "Hello!", content_type="text/plain")
+        msg2 = db.send_message(ns, alice_id, bob_id, "Hello!", content_type="text/markdown")
+
+        assert msg1["mid"] != msg2["mid"]
+        assert msg2.get("deduplicated") is None
+
+    def test_different_body_not_deduped(self, setup):
+        """Different body is not considered a duplicate."""
+        ns = setup["ns"]["ns"]
+        alice_id = setup["alice"]["id"]
+        bob_id = setup["bob"]["id"]
+
+        msg1 = db.send_message(ns, alice_id, bob_id, "Hello!")
+        msg2 = db.send_message(ns, alice_id, bob_id, "Hi there!")
+
+        assert msg1["mid"] != msg2["mid"]
+
+    def test_different_sender_not_deduped(self, setup):
+        """Same message from different senders is not a duplicate."""
+        ns = setup["ns"]["ns"]
+        alice_id = setup["alice"]["id"]
+        bob_id = setup["bob"]["id"]
+
+        msg1 = db.send_message(ns, alice_id, bob_id, "Hello!")
+        msg2 = db.send_message(ns, bob_id, alice_id, "Hello!")
+
+        assert msg1["mid"] != msg2["mid"]
+
+    def test_different_recipient_not_deduped(self, setup):
+        """Same message to different recipients is not a duplicate."""
+        ns = setup["ns"]["ns"]
+        alice_id = setup["alice"]["id"]
+        bob_id = setup["bob"]["id"]
+        carol = db.create_identity(ns, metadata={"display_name": "Carol"})
+
+        msg1 = db.send_message(ns, alice_id, bob_id, "Hello!")
+        msg2 = db.send_message(ns, alice_id, carol["id"], "Hello!")
+
+        assert msg1["mid"] != msg2["mid"]
+
+    def test_dedup_window_expires(self, setup):
+        """After the dedup window, the same message creates a new entry."""
+        ns = setup["ns"]["ns"]
+        alice_id = setup["alice"]["id"]
+        bob_id = setup["bob"]["id"]
+
+        msg1 = db.send_message(ns, alice_id, bob_id, "Hello!")
+
+        # Simulate the dedup window expiring by backdating the first message
+        window = db.DEDUP_WINDOW_SECONDS
+        past = (datetime.now(timezone.utc) - timedelta(seconds=window + 10)).isoformat()
+        conn = db._get_conn(None)
+        conn.execute("UPDATE messages SET created_at = ? WHERE mid = ?", (past, msg1["mid"]))
+        conn.commit()
+
+        msg2 = db.send_message(ns, alice_id, bob_id, "Hello!")
+        assert msg1["mid"] != msg2["mid"]
+        assert msg2.get("deduplicated") is None
+
+    def test_only_one_row_in_db_on_dedup(self, setup):
+        """Deduplication does not insert a second row."""
+        ns = setup["ns"]["ns"]
+        alice_id = setup["alice"]["id"]
+        bob_id = setup["bob"]["id"]
+
+        db.send_message(ns, alice_id, bob_id, "Hello!")
+        db.send_message(ns, alice_id, bob_id, "Hello!")
+        db.send_message(ns, alice_id, bob_id, "Hello!")
+
+        messages = db.get_messages(ns, bob_id)
+        assert len(messages) == 1
+
+    def test_self_message_dedup(self, setup):
+        """Self-messages (notes to self) are also deduplicated."""
+        ns = setup["ns"]["ns"]
+        alice_id = setup["alice"]["id"]
+
+        msg1 = db.send_message(ns, alice_id, alice_id, "Reminder")
+        msg2 = db.send_message(ns, alice_id, alice_id, "Reminder")
+
+        assert msg1["mid"] == msg2["mid"]
+        assert msg2.get("deduplicated") is True
+
+    def test_dedup_preserves_ttl(self, setup):
+        """Dedup returns the original message; TTL from the first send is kept."""
+        ns = setup["ns"]["ns"]
+        alice_id = setup["alice"]["id"]
+        bob_id = setup["bob"]["id"]
+
+        msg1 = db.send_message(ns, alice_id, bob_id, "ephemeral", ttl_hours=1)
+        msg2 = db.send_message(ns, alice_id, bob_id, "ephemeral", ttl_hours=1)
+
+        assert msg1["mid"] == msg2["mid"]
+
+
+# --- Room Message Dedup (db layer) ---
+
+
+class TestRoomMessageDedup:
+    """Deduplication for room messages at the db layer."""
+
+    def test_duplicate_room_message_returns_same_mid(self, room_setup):
+        """Sending the same room message twice returns the same mid."""
+        room_id = room_setup["room"]["room_id"]
+        alice_id = room_setup["alice"]["id"]
+
+        msg1 = db.send_room_message(room_id, alice_id, "Hello room!")
+        msg2 = db.send_room_message(room_id, alice_id, "Hello room!")
+
+        assert msg1["mid"] == msg2["mid"]
+        assert msg2.get("deduplicated") is True
+
+    def test_different_body_in_room_not_deduped(self, room_setup):
+        """Different messages in the same room are not deduplicated."""
+        room_id = room_setup["room"]["room_id"]
+        alice_id = room_setup["alice"]["id"]
+
+        msg1 = db.send_room_message(room_id, alice_id, "Hello!")
+        msg2 = db.send_room_message(room_id, alice_id, "Goodbye!")
+
+        assert msg1["mid"] != msg2["mid"]
+
+    def test_different_sender_in_room_not_deduped(self, room_setup):
+        """Same message from different senders is not a duplicate."""
+        room_id = room_setup["room"]["room_id"]
+        alice_id = room_setup["alice"]["id"]
+        bob_id = room_setup["bob"]["id"]
+
+        msg1 = db.send_room_message(room_id, alice_id, "Hello!")
+        msg2 = db.send_room_message(room_id, bob_id, "Hello!")
+
+        assert msg1["mid"] != msg2["mid"]
+
+    def test_different_room_not_deduped(self, room_setup):
+        """Same message in different rooms is not deduplicated."""
+        ns = room_setup["ns"]["ns"]
+        alice_id = room_setup["alice"]["id"]
+        room1_id = room_setup["room"]["room_id"]
+
+        room2 = db.create_room(ns, alice_id, display_name="Room 2")
+        room2_id = room2["room_id"]
+
+        msg1 = db.send_room_message(room1_id, alice_id, "Hello!")
+        msg2 = db.send_room_message(room2_id, alice_id, "Hello!")
+
+        assert msg1["mid"] != msg2["mid"]
+
+    def test_reaction_dedup(self, room_setup):
+        """Duplicate reactions (same emoji, same reference_mid) are deduplicated."""
+        room_id = room_setup["room"]["room_id"]
+        alice_id = room_setup["alice"]["id"]
+        bob_id = room_setup["bob"]["id"]
+
+        # Alice sends a message, Bob reacts twice (network retry)
+        original = db.send_room_message(room_id, alice_id, "Check this out")
+        react1 = db.send_room_message(
+            room_id, bob_id, "👍", content_type="reaction", reference_mid=original["mid"]
+        )
+        react2 = db.send_room_message(
+            room_id, bob_id, "👍", content_type="reaction", reference_mid=original["mid"]
+        )
+
+        assert react1["mid"] == react2["mid"]
+        assert react2.get("deduplicated") is True
+
+    def test_different_reaction_not_deduped(self, room_setup):
+        """Different reaction emoji on the same message is not deduplicated."""
+        room_id = room_setup["room"]["room_id"]
+        alice_id = room_setup["alice"]["id"]
+        bob_id = room_setup["bob"]["id"]
+
+        original = db.send_room_message(room_id, alice_id, "Check this out")
+        react1 = db.send_room_message(
+            room_id, bob_id, "👍", content_type="reaction", reference_mid=original["mid"]
+        )
+        react2 = db.send_room_message(
+            room_id, bob_id, "❤️", content_type="reaction", reference_mid=original["mid"]
+        )
+
+        assert react1["mid"] != react2["mid"]
+
+    def test_room_dedup_window_expires(self, room_setup):
+        """After the dedup window, the same room message creates a new entry."""
+        room_id = room_setup["room"]["room_id"]
+        alice_id = room_setup["alice"]["id"]
+
+        msg1 = db.send_room_message(room_id, alice_id, "Hello!")
+
+        # Backdate the first message past the dedup window
+        window = db.DEDUP_WINDOW_SECONDS
+        past = (datetime.now(timezone.utc) - timedelta(seconds=window + 10)).isoformat()
+        conn = db._get_conn(None)
+        conn.execute("UPDATE room_messages SET created_at = ? WHERE mid = ?", (past, msg1["mid"]))
+        conn.commit()
+
+        msg2 = db.send_room_message(room_id, alice_id, "Hello!")
+        assert msg1["mid"] != msg2["mid"]
+
+    def test_only_one_row_in_room_on_dedup(self, room_setup):
+        """Deduplication does not insert extra rows into room_messages."""
+        room_id = room_setup["room"]["room_id"]
+        alice_id = room_setup["alice"]["id"]
+
+        db.send_room_message(room_id, alice_id, "Hello!")
+        db.send_room_message(room_id, alice_id, "Hello!")
+        db.send_room_message(room_id, alice_id, "Hello!")
+
+        messages = db.get_room_messages(room_id)
+        assert len(messages) == 1
+
+
+# --- API Layer Dedup ---
+
+
+class TestDirectMessageDedupAPI:
+    """Deduplication for direct messages via the API layer."""
+
+    def test_send_duplicate_returns_same_mid_with_header(self, client, setup):
+        """API returns Dedup-Status header when dedup fires."""
+        ns = setup["ns"]["ns"]
+        secret = setup["alice"]["secret"]
+        bob_id = setup["bob"]["id"]
+
+        resp1 = client.post(
+            f"/{ns}/send",
+            json={"to": bob_id, "body": "Hello!"},
+            headers={"X-Inbox-Secret": secret},
+        )
+        assert resp1.status_code == 200
+        assert "Dedup-Status" not in resp1.headers
+
+        resp2 = client.post(
+            f"/{ns}/send",
+            json={"to": bob_id, "body": "Hello!"},
+            headers={"X-Inbox-Secret": secret},
+        )
+        assert resp2.status_code == 200
+        assert resp2.headers.get("Dedup-Status") == "deduplicated"
+        assert resp1.json()["mid"] == resp2.json()["mid"]
+
+    def test_send_different_message_no_dedup_header(self, client, setup):
+        """Different messages do not trigger dedup header."""
+        ns = setup["ns"]["ns"]
+        secret = setup["alice"]["secret"]
+        bob_id = setup["bob"]["id"]
+
+        resp1 = client.post(
+            f"/{ns}/send",
+            json={"to": bob_id, "body": "Hello!"},
+            headers={"X-Inbox-Secret": secret},
+        )
+        resp2 = client.post(
+            f"/{ns}/send",
+            json={"to": bob_id, "body": "Different message"},
+            headers={"X-Inbox-Secret": secret},
+        )
+
+        assert "Dedup-Status" not in resp1.headers
+        assert "Dedup-Status" not in resp2.headers
+        assert resp1.json()["mid"] != resp2.json()["mid"]
+
+
+class TestRoomMessageDedupAPI:
+    """Deduplication for room messages via the API layer."""
+
+    def test_room_send_duplicate_returns_same_mid_with_header(self, client, room_setup):
+        """API returns Dedup-Status header for room message dedup."""
+        ns = room_setup["ns"]["ns"]
+        room_id = room_setup["room"]["room_id"]
+        secret = room_setup["alice"]["secret"]
+
+        resp1 = client.post(
+            f"/{ns}/rooms/{room_id}/messages",
+            json={"body": "Hello room!"},
+            headers={"X-Inbox-Secret": secret},
+        )
+        assert resp1.status_code == 200
+        assert "Dedup-Status" not in resp1.headers
+
+        resp2 = client.post(
+            f"/{ns}/rooms/{room_id}/messages",
+            json={"body": "Hello room!"},
+            headers={"X-Inbox-Secret": secret},
+        )
+        assert resp2.status_code == 200
+        assert resp2.headers.get("Dedup-Status") == "deduplicated"
+        assert resp1.json()["mid"] == resp2.json()["mid"]
+
+    def test_room_send_different_message_no_dedup_header(self, client, room_setup):
+        """Different room messages do not trigger dedup."""
+        ns = room_setup["ns"]["ns"]
+        room_id = room_setup["room"]["room_id"]
+        secret = room_setup["alice"]["secret"]
+
+        resp1 = client.post(
+            f"/{ns}/rooms/{room_id}/messages",
+            json={"body": "First message"},
+            headers={"X-Inbox-Secret": secret},
+        )
+        resp2 = client.post(
+            f"/{ns}/rooms/{room_id}/messages",
+            json={"body": "Second message"},
+            headers={"X-Inbox-Secret": secret},
+        )
+
+        assert "Dedup-Status" not in resp1.headers
+        assert "Dedup-Status" not in resp2.headers
+        assert resp1.json()["mid"] != resp2.json()["mid"]
+
+
+# --- Content Hash Tests ---
+
+
+class TestContentHash:
+    """Verify the content hash function properties."""
+
+    def test_same_inputs_same_hash(self):
+        """Identical inputs produce the same hash."""
+        h1 = db._compute_content_hash("hello", "text/plain")
+        h2 = db._compute_content_hash("hello", "text/plain")
+        assert h1 == h2
+
+    def test_different_body_different_hash(self):
+        """Different body produces different hash."""
+        h1 = db._compute_content_hash("hello", "text/plain")
+        h2 = db._compute_content_hash("world", "text/plain")
+        assert h1 != h2
+
+    def test_different_content_type_different_hash(self):
+        """Different content_type produces different hash."""
+        h1 = db._compute_content_hash("hello", "text/plain")
+        h2 = db._compute_content_hash("hello", "text/markdown")
+        assert h1 != h2
+
+    def test_reference_mid_affects_hash(self):
+        """reference_mid is included in the hash."""
+        h1 = db._compute_content_hash("👍", "reaction", reference_mid="abc")
+        h2 = db._compute_content_hash("👍", "reaction", reference_mid="def")
+        assert h1 != h2
+
+    def test_no_reference_mid_vs_with_reference_mid(self):
+        """Hash differs between no reference_mid and a specific reference_mid."""
+        h1 = db._compute_content_hash("👍", "reaction")
+        h2 = db._compute_content_hash("👍", "reaction", reference_mid="abc")
+        assert h1 != h2
+
+    def test_hash_length(self):
+        """Hash is 16 hex chars (64 bits)."""
+        h = db._compute_content_hash("test", "text/plain")
+        assert len(h) == 16
+        assert all(c in "0123456789abcdef" for c in h)
+
+
+# --- Migration Test ---
+
+
+class TestDedupMigration:
+    """Verify migration 005 adds the correct columns and indexes."""
+
+    def test_migration_adds_content_hash_to_messages(self):
+        """Messages table has content_hash column after migration."""
+        conn = db._get_conn(None)
+        assert db._column_exists(conn, "messages", "content_hash")
+
+    def test_migration_adds_content_hash_to_room_messages(self):
+        """Room messages table has content_hash column after migration."""
+        conn = db._get_conn(None)
+        assert db._column_exists(conn, "room_messages", "content_hash")
+
+    def test_migration_is_idempotent(self):
+        """Running migration 005 twice does not error."""
+        conn = db._get_conn(None)
+        # Should not raise
+        db._migrate_005_add_content_hash(conn)
+        db._migrate_005_add_content_hash(conn)
+
+
+# --- Client Layer Dedup ---
+
+
+class TestClientDedup:
+    """Dedup works through the Deaddrop client layer."""
+
+    def test_client_send_message_dedup(self):
+        """Deaddrop.send_message deduplicates on retry."""
+        from deadrop.client import Deaddrop
+
+        client = Deaddrop.in_memory()
+        setup = client.quick_setup("Test", ["Alice", "Bob"])
+        ns = setup["namespace"]["ns"]
+        alice_secret = setup["identities"]["Alice"]["secret"]
+        bob_id = setup["identities"]["Bob"]["id"]
+
+        msg1 = client.send_message(ns, alice_secret, bob_id, "Hello!")
+        msg2 = client.send_message(ns, alice_secret, bob_id, "Hello!")
+
+        assert msg1["mid"] == msg2["mid"]
+
+    def test_client_send_room_message_dedup(self):
+        """Deaddrop.send_room_message deduplicates on retry."""
+        from deadrop.client import Deaddrop
+
+        client = Deaddrop.in_memory()
+        setup = client.quick_setup("Test", ["Alice", "Bob"])
+        ns = setup["namespace"]["ns"]
+        alice_secret = setup["identities"]["Alice"]["secret"]
+        bob_id = setup["identities"]["Bob"]["id"]
+
+        room = client.create_room(ns, alice_secret, "Chat")
+        client.add_room_member(ns, room["room_id"], bob_id, alice_secret)
+
+        msg1 = client.send_room_message(ns, room["room_id"], alice_secret, "Hello room!")
+        msg2 = client.send_room_message(ns, room["room_id"], alice_secret, "Hello room!")
+
+        assert msg1["mid"] == msg2["mid"]
+
+    def test_client_different_messages_not_deduped(self):
+        """Different messages through client are not deduplicated."""
+        from deadrop.client import Deaddrop
+
+        client = Deaddrop.in_memory()
+        setup = client.quick_setup("Test", ["Alice", "Bob"])
+        ns = setup["namespace"]["ns"]
+        alice_secret = setup["identities"]["Alice"]["secret"]
+        bob_id = setup["identities"]["Bob"]["id"]
+
+        msg1 = client.send_message(ns, alice_secret, bob_id, "First")
+        msg2 = client.send_message(ns, alice_secret, bob_id, "Second")
+
+        assert msg1["mid"] != msg2["mid"]

--- a/tests/test_subscribe_client.py
+++ b/tests/test_subscribe_client.py
@@ -1,7 +1,10 @@
 """Tests for subscribe methods on the Python client."""
 
+from unittest.mock import patch
+
 import pytest
 
+from deadrop.backends import AuthenticationError, DeaddropAPIError
 from deadrop.client import Deaddrop
 from deadrop.events import reset_event_bus
 
@@ -168,3 +171,195 @@ class TestListenAll:
 
         assert topic == f"room:{data['room']['room_id']}"
         assert latest_mid == mid
+
+
+class TestListenAllBackoff:
+    """Tests for exponential backoff in listen_all."""
+
+    def test_auth_error_raises_immediately_by_default(self, client, setup):
+        """With default max_retries=0, auth errors cause immediate failure on first retry."""
+        data = setup
+        # max_retries=0 means: fail fast on auth errors (no retries)
+        # But we need at least 1 retry attempt to trigger the raise.
+        # Actually, max_retries=0 means the check `if max_retries and ...` is False
+        # so it will retry forever. Let's use max_retries=1 for fail-fast.
+
+        with patch.object(client, "subscribe") as mock_sub:
+            mock_sub.side_effect = AuthenticationError("Forbidden", status_code=403)
+
+            gen = client.listen_all(
+                data["ns"],
+                data["alice"]["secret"],
+                {f"room:{data['room']['room_id']}": None},
+                timeout=1,
+                max_retries=1,
+            )
+
+            with pytest.raises(AuthenticationError):
+                next(gen)
+
+    @patch("deadrop.client.time.sleep")
+    def test_auth_error_backoff_timing(self, mock_sleep, client, setup):
+        """Auth errors trigger exponential backoff before retries."""
+        data = setup
+
+        call_count = 0
+
+        def fail_then_succeed(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 3:
+                raise AuthenticationError("Forbidden", status_code=403)
+            # 4th call succeeds
+            return {
+                "events": {f"room:{data['room']['room_id']}": "mid-1"},
+                "timeout": False,
+            }
+
+        with patch.object(client, "subscribe", side_effect=fail_then_succeed):
+            gen = client.listen_all(
+                data["ns"],
+                data["alice"]["secret"],
+                {f"room:{data['room']['room_id']}": None},
+                timeout=1,
+                # max_retries=0 means retry indefinitely
+            )
+            topic, mid = next(gen)
+
+        assert topic == f"room:{data['room']['room_id']}"
+        assert mid == "mid-1"
+
+        # Should have slept 3 times with exponential backoff: 1s, 2s, 4s
+        assert mock_sleep.call_count == 3
+        delays = [call.args[0] for call in mock_sleep.call_args_list]
+        assert delays == [1.0, 2.0, 4.0]
+
+    @patch("deadrop.client.time.sleep")
+    def test_backoff_caps_at_max_delay(self, mock_sleep, client, setup):
+        """Backoff delay caps at 300 seconds."""
+        data = setup
+
+        call_count = 0
+
+        def fail_many_then_succeed(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 12:
+                raise DeaddropAPIError("Server Error", status_code=500)
+            return {
+                "events": {f"room:{data['room']['room_id']}": "mid-1"},
+                "timeout": False,
+            }
+
+        with patch.object(client, "subscribe", side_effect=fail_many_then_succeed):
+            gen = client.listen_all(
+                data["ns"],
+                data["alice"]["secret"],
+                {f"room:{data['room']['room_id']}": None},
+                timeout=1,
+            )
+            next(gen)
+
+        delays = [call.args[0] for call in mock_sleep.call_args_list]
+        # After 9 retries, 2^8 = 256s. After 10, min(512, 300) = 300
+        assert all(d <= 300.0 for d in delays)
+        # The last few should all be 300
+        assert delays[-1] == 300.0
+
+    @patch("deadrop.client.time.sleep")
+    def test_success_resets_error_counter(self, mock_sleep, client, setup):
+        """A successful subscribe resets the consecutive error counter."""
+        data = setup
+
+        call_count = 0
+
+        def alternating(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise DeaddropAPIError("Server Error", status_code=500)
+            if call_count == 2:
+                return {
+                    "events": {f"room:{data['room']['room_id']}": "mid-1"},
+                    "timeout": False,
+                }
+            if call_count == 3:
+                raise DeaddropAPIError("Server Error", status_code=500)
+            if call_count == 4:
+                return {
+                    "events": {f"room:{data['room']['room_id']}": "mid-2"},
+                    "timeout": False,
+                }
+            raise StopIteration  # shouldn't reach here
+
+        with patch.object(client, "subscribe", side_effect=alternating):
+            gen = client.listen_all(
+                data["ns"],
+                data["alice"]["secret"],
+                {f"room:{data['room']['room_id']}": None},
+                timeout=1,
+            )
+            topic1, mid1 = next(gen)
+            topic2, mid2 = next(gen)
+
+        assert mid1 == "mid-1"
+        assert mid2 == "mid-2"
+
+        # Both errors should have delay of 1.0 (reset after success)
+        delays = [call.args[0] for call in mock_sleep.call_args_list]
+        assert delays == [1.0, 1.0]
+
+    @patch("deadrop.client.time.sleep")
+    def test_max_retries_raises_after_limit(self, mock_sleep, client, setup):
+        """Raises after max_retries consecutive errors."""
+        data = setup
+
+        with patch.object(client, "subscribe") as mock_sub:
+            mock_sub.side_effect = AuthenticationError("Forbidden", status_code=403)
+
+            gen = client.listen_all(
+                data["ns"],
+                data["alice"]["secret"],
+                {f"room:{data['room']['room_id']}": None},
+                timeout=1,
+                max_retries=3,
+            )
+
+            with pytest.raises(AuthenticationError):
+                next(gen)
+
+            # Should have called subscribe 3 times
+            assert mock_sub.call_count == 3
+            # Sleeps happen between retries: after attempt 1, after attempt 2,
+            # but on attempt 3 we hit max_retries and raise before sleeping
+            assert mock_sleep.call_count == 2
+
+    @patch("deadrop.client.time.sleep")
+    def test_network_errors_trigger_backoff(self, mock_sleep, client, setup):
+        """OSError (network errors) also trigger backoff."""
+        data = setup
+
+        call_count = 0
+
+        def network_then_ok(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                raise OSError("Connection refused")
+            return {
+                "events": {f"room:{data['room']['room_id']}": "mid-1"},
+                "timeout": False,
+            }
+
+        with patch.object(client, "subscribe", side_effect=network_then_ok):
+            gen = client.listen_all(
+                data["ns"],
+                data["alice"]["secret"],
+                {f"room:{data['room']['room_id']}": None},
+                timeout=1,
+            )
+            next(gen)
+
+        assert mock_sleep.call_count == 2
+        delays = [call.args[0] for call in mock_sleep.call_args_list]
+        assert delays == [1.0, 2.0]


### PR DESCRIPTION
## Summary

Two related reliability improvements:

### 1. Exponential backoff for auth/server errors in subscribe loop (original)

When a client's credentials are revoked or a namespace is deleted, the subscribe endpoint returns 403. Without backoff, the client retries every ~3 seconds in a tight loop, wasting server resources.

**Changes:**
- `DeaddropAPIError` and `AuthenticationError` exception classes
- `RemoteBackend._request()` raises typed exceptions for 401/403
- `listen_all()` backoff: 1s → 2s → 4s → ... → 300s (cap), resets on success
- Configurable `max_retries` and `on_error` (`raise`/`log`)

### 2. Implicit message deduplication (new)

Network timeouts cause clients to retry sends, producing duplicate messages. This adds transparent deduplication based on `(sender, destination, content_hash)` within a 60-second window.

**Changes:**
- **Migration 005**: Add `content_hash` column to `messages` and `room_messages` tables with dedup indexes
- **`db.send_message()` / `db.send_room_message()`**: Compute SHA-256 hash of `(body, content_type, reference_mid)` and check for recent duplicates before inserting
- **API layer**: Return `Dedup-Status: deduplicated` response header when dedup fires; skip event bus notifications for deduped messages
- Works for direct messages, room messages, and reactions
- Dedup key is `(sender, destination, content_hash)` — different senders, recipients, rooms, or content always create new messages
- Window is 60 seconds — after that, the same content creates a new message (intentional repeated messages work fine)

### Tests

- 34 new dedup tests: db layer, API layer, client layer, content hash properties, migration idempotency, window expiration
- 16 subscribe backoff tests
- All **445 tests pass**, ruff clean

### Impact

1. Orphaned subscribe clients back off from ~28,800 req/day to ~288 req/day
2. Network retries no longer produce duplicate messages in inboxes or rooms