### PR TITLE
feat: attachment support for room messages

### DIFF
--- a/src/deadrop/api.py
+++ b/src/deadrop/api.py
@@ -1256,6 +1256,20 @@ class RoomMemberInfo(BaseModel):
     metadata: dict[str, Any]
 
 
+# Allowed MIME types for attachments
+ALLOWED_ATTACHMENT_TYPES = frozenset({
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+    "application/pdf",
+})
+
+MAX_ATTACHMENT_SIZE = 10 * 1024 * 1024  # 10MB per attachment
+MAX_ATTACHMENTS_PER_MESSAGE = 10
+MAX_TOTAL_ATTACHMENT_SIZE = 25 * 1024 * 1024  # 25MB total per message
+
+
 class AttachmentRequest(BaseModel):
     filename: str | None = None
     content_type: str  # e.g. "image/png"
@@ -1566,17 +1580,20 @@ async def get_room_messages(
         )
     )
 
-    # Enrich messages with attachment metadata (without data)
-    enriched = []
-    for m in messages:
-        atts = await _run_sync(
-            functools.partial(
-                db.get_message_attachments,
-                m["mid"],
-                include_data=False,
-            )
+    # Batch-fetch attachment metadata for all messages (avoids N+1)
+    mids = [m["mid"] for m in messages]
+    attachments_by_mid = await _run_sync(
+        functools.partial(
+            db.get_batch_message_attachments,
+            mids,
+            include_data=False,
         )
-        enriched.append(RoomMessageInfo.from_db(m, atts or None).model_dump())
+    )
+
+    enriched = [
+        RoomMessageInfo.from_db(m, attachments_by_mid.get(m["mid"]) or None).model_dump()
+        for m in messages
+    ]
 
     return {
         "messages": enriched,
@@ -1608,21 +1625,43 @@ async def send_room_message(
     if room["ns"] != ns:
         raise HTTPException(404, "Room not found in this namespace")
 
-    # Validate attachment sizes
+    # Validate attachments: count, content-type allowlist, sizes
+    validated_attachments: list[tuple] = []  # (att, raw_size)
     if request.attachments:
         import base64
 
-        MAX_ATTACHMENT_SIZE = 10 * 1024 * 1024  # 10MB per attachment
+        if len(request.attachments) > MAX_ATTACHMENTS_PER_MESSAGE:
+            raise HTTPException(
+                400,
+                f"Too many attachments: {len(request.attachments)} (max {MAX_ATTACHMENTS_PER_MESSAGE})",
+            )
+
+        total_size = 0
         for att in request.attachments:
+            # Content-type allowlist
+            if att.content_type not in ALLOWED_ATTACHMENT_TYPES:
+                raise HTTPException(
+                    400,
+                    f"Unsupported attachment type: {att.content_type!r}. "
+                    f"Allowed: {', '.join(sorted(ALLOWED_ATTACHMENT_TYPES))}",
+                )
             try:
                 raw = base64.b64decode(att.data, validate=True)
             except Exception:
                 raise HTTPException(400, "Invalid base64 data in attachment")
-            if len(raw) > MAX_ATTACHMENT_SIZE:
+            raw_size = len(raw)
+            if raw_size > MAX_ATTACHMENT_SIZE:
                 raise HTTPException(
-                    400,
-                    f"Attachment too large: {len(raw)} bytes (max {MAX_ATTACHMENT_SIZE})",
+                    413,
+                    f"Attachment too large: {raw_size} bytes (max {MAX_ATTACHMENT_SIZE})",
                 )
+            total_size += raw_size
+            if total_size > MAX_TOTAL_ATTACHMENT_SIZE:
+                raise HTTPException(
+                    413,
+                    f"Total attachment size too large: {total_size} bytes (max {MAX_TOTAL_ATTACHMENT_SIZE})",
+                )
+            validated_attachments.append((att, raw_size))
 
     try:
         message = await _run_sync(
@@ -1640,13 +1679,10 @@ async def send_room_message(
 
     deduplicated = message.pop("deduplicated", False)
 
-    # Store attachments for genuinely new messages
+    # Store attachments for genuinely new messages (reuse validated sizes)
     attachment_records = []
-    if not deduplicated and request.attachments:
-        import base64
-
-        for att in request.attachments:
-            raw_size = len(base64.b64decode(att.data))
+    if not deduplicated and validated_attachments:
+        for att, raw_size in validated_attachments:
             record = await _run_sync(
                 functools.partial(
                     db.add_attachment,

--- a/src/deadrop/api.py
+++ b/src/deadrop/api.py
@@ -1257,13 +1257,15 @@ class RoomMemberInfo(BaseModel):
 
 
 # Allowed MIME types for attachments
-ALLOWED_ATTACHMENT_TYPES = frozenset({
-    "image/png",
-    "image/jpeg",
-    "image/gif",
-    "image/webp",
-    "application/pdf",
-})
+ALLOWED_ATTACHMENT_TYPES = frozenset(
+    {
+        "image/png",
+        "image/jpeg",
+        "image/gif",
+        "image/webp",
+        "application/pdf",
+    }
+)
 
 MAX_ATTACHMENT_SIZE = 10 * 1024 * 1024  # 10MB per attachment
 MAX_ATTACHMENTS_PER_MESSAGE = 10

--- a/src/deadrop/api.py
+++ b/src/deadrop/api.py
@@ -1256,10 +1256,32 @@ class RoomMemberInfo(BaseModel):
     metadata: dict[str, Any]
 
 
+class AttachmentRequest(BaseModel):
+    filename: str | None = None
+    content_type: str  # e.g. "image/png"
+    data: str  # base64-encoded content
+
+
 class SendRoomMessageRequest(BaseModel):
     body: str
     content_type: str = "text/plain"
     reference_mid: str | None = None
+    attachments: list[AttachmentRequest] | None = None
+
+
+class AttachmentInfo(BaseModel):
+    id: str
+    message_mid: str
+    filename: str | None = None
+    content_type: str
+    size: int
+    created_at: str
+
+
+class AttachmentDataInfo(AttachmentInfo):
+    """Attachment info with base64 data included."""
+
+    data: str
 
 
 class RoomMessageInfo(BaseModel):
@@ -1270,10 +1292,24 @@ class RoomMessageInfo(BaseModel):
     content_type: str
     reference_mid: str | None = None
     created_at: str
+    attachments: list[AttachmentInfo] | None = None
 
     @classmethod
-    def from_db(cls, data: dict) -> "RoomMessageInfo":
+    def from_db(cls, data: dict, attachments: list[dict] | None = None) -> "RoomMessageInfo":
         """Create from db result which uses 'from' key."""
+        att_infos = None
+        if attachments:
+            att_infos = [
+                AttachmentInfo(
+                    id=a["id"],
+                    message_mid=a["message_mid"],
+                    filename=a.get("filename"),
+                    content_type=a["content_type"],
+                    size=a.get("size", 0),
+                    created_at=a.get("created_at", ""),
+                )
+                for a in attachments
+            ]
         return cls(
             mid=data["mid"],
             room_id=data["room_id"],
@@ -1282,6 +1318,7 @@ class RoomMessageInfo(BaseModel):
             content_type=data.get("content_type", "text/plain"),
             reference_mid=data.get("reference_mid"),
             created_at=data["created_at"],
+            attachments=att_infos,
         )
 
 
@@ -1529,8 +1566,20 @@ async def get_room_messages(
         )
     )
 
+    # Enrich messages with attachment metadata (without data)
+    enriched = []
+    for m in messages:
+        atts = await _run_sync(
+            functools.partial(
+                db.get_message_attachments,
+                m["mid"],
+                include_data=False,
+            )
+        )
+        enriched.append(RoomMessageInfo.from_db(m, atts or None).model_dump())
+
     return {
-        "messages": [RoomMessageInfo.from_db(m).model_dump() for m in messages],
+        "messages": enriched,
         "room_id": room_id,
     }
 
@@ -1559,6 +1608,22 @@ async def send_room_message(
     if room["ns"] != ns:
         raise HTTPException(404, "Room not found in this namespace")
 
+    # Validate attachment sizes
+    if request.attachments:
+        import base64
+
+        MAX_ATTACHMENT_SIZE = 10 * 1024 * 1024  # 10MB per attachment
+        for att in request.attachments:
+            try:
+                raw = base64.b64decode(att.data, validate=True)
+            except Exception:
+                raise HTTPException(400, "Invalid base64 data in attachment")
+            if len(raw) > MAX_ATTACHMENT_SIZE:
+                raise HTTPException(
+                    400,
+                    f"Attachment too large: {len(raw)} bytes (max {MAX_ATTACHMENT_SIZE})",
+                )
+
     try:
         message = await _run_sync(
             functools.partial(
@@ -1575,6 +1640,25 @@ async def send_room_message(
 
     deduplicated = message.pop("deduplicated", False)
 
+    # Store attachments for genuinely new messages
+    attachment_records = []
+    if not deduplicated and request.attachments:
+        import base64
+
+        for att in request.attachments:
+            raw_size = len(base64.b64decode(att.data))
+            record = await _run_sync(
+                functools.partial(
+                    db.add_attachment,
+                    message_mid=message["mid"],
+                    content_type=att.content_type,
+                    data=att.data,
+                    size=raw_size,
+                    filename=att.filename,
+                )
+            )
+            attachment_records.append(record)
+
     # Only publish events for genuinely new messages
     if not deduplicated:
         try:
@@ -1582,7 +1666,7 @@ async def send_room_message(
         except Exception:
             logger.warning("Failed to publish room event", exc_info=True)
 
-    response_data = RoomMessageInfo.from_db(message).model_dump()
+    response_data = RoomMessageInfo.from_db(message, attachment_records or None).model_dump()
 
     headers = {}
     if deduplicated:
@@ -1692,6 +1776,57 @@ def _validate_subscription_topics_sync(
                 400,
                 f"Unknown topic type: {topic_type!r}. Supported: 'inbox', 'room'",
             )
+
+
+@app.get("/{ns}/attachments/{attachment_id}")
+async def get_attachment(
+    ns: str,
+    attachment_id: str,
+    x_inbox_secret: Annotated[str | None, Header()] = None,
+):
+    """Fetch a single attachment with its base64 data.
+
+    The caller must be a member of the room the attachment's message belongs to.
+    Returns the full attachment including base64-encoded data.
+    """
+    import functools
+
+    if not x_inbox_secret:
+        raise HTTPException(401, "X-Inbox-Secret header required")
+
+    attachment = await _run_sync(
+        functools.partial(db.get_attachment, attachment_id, include_data=True)
+    )
+    if not attachment:
+        raise HTTPException(404, "Attachment not found")
+
+    # Verify caller has access via room membership
+    # Look up the message's room_id directly from room_messages table
+    message_mid = attachment["message_mid"]
+    conn = db.get_connection()
+    cursor = conn.execute("SELECT room_id FROM room_messages WHERE mid = ?", (message_mid,))
+    row = cursor.fetchone()
+    if not row:
+        raise HTTPException(404, "Attachment not found")
+
+    room_id = row[0]
+    room = db.get_room(room_id)
+    if not room or room["ns"] != ns:
+        raise HTTPException(404, "Attachment not found")
+
+    caller_id = derive_id(x_inbox_secret)
+    if not db.is_room_member(room_id, caller_id):
+        raise HTTPException(403, "Not a room member")
+
+    return AttachmentDataInfo(
+        id=attachment["id"],
+        message_mid=attachment["message_mid"],
+        filename=attachment.get("filename"),
+        content_type=attachment["content_type"],
+        size=attachment.get("size", 0),
+        created_at=attachment.get("created_at", ""),
+        data=attachment["data"],
+    ).model_dump()
 
 
 @app.post("/{ns}/subscribe")

--- a/src/deadrop/db.py
+++ b/src/deadrop/db.py
@@ -48,7 +48,7 @@ DEDUP_WINDOW_SECONDS = 60
 DEFAULT_TTL_HOURS = 24
 
 # Current schema version (increment when adding migrations)
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 6
 
 # Thread-local storage for per-thread connections
 # This ensures each thread gets its own SQLite connection, avoiding
@@ -673,6 +673,28 @@ def _migrate_005_add_content_hash(conn: sqlite3.Connection) -> None:
     conn.commit()
 
 
+def _migrate_006_add_attachments(conn: sqlite3.Connection) -> None:
+    """Migration 006: Add attachments table for binary content on messages.
+
+    Attachments are stored separately from messages to keep message payloads
+    lightweight. Each attachment belongs to exactly one message (via message_mid)
+    and stores its content as base64-encoded text.
+    """
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS attachments (
+            id TEXT PRIMARY KEY,
+            message_mid TEXT NOT NULL,
+            filename TEXT,
+            content_type TEXT NOT NULL,
+            data TEXT NOT NULL,
+            size INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL
+        )
+    """)
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_attachments_mid ON attachments(message_mid)")
+    conn.commit()
+
+
 # Migration registry: (version, description, migration_function)
 MIGRATIONS: list[tuple[int, str, Callable[[sqlite3.Connection], None]]] = [
     (1, "Add content_type column to messages", _migrate_001_add_content_type),
@@ -680,6 +702,7 @@ MIGRATIONS: list[tuple[int, str, Callable[[sqlite3.Connection], None]]] = [
     (3, "Add reference_mid to room_messages for reactions", _migrate_003_add_reference_mid),
     (4, "Add mid-based indexes for room_messages and messages", _migrate_004_add_mid_indexes),
     (5, "Add content_hash for implicit message deduplication", _migrate_005_add_content_hash),
+    (6, "Add attachments table for binary content on messages", _migrate_006_add_attachments),
 ]
 
 
@@ -2757,3 +2780,138 @@ def is_room_member_cached(
 
     membership_cache.set(cache_key, is_member)
     return is_member
+
+
+# ---------------------------------------------------------------------------
+# Attachments
+# ---------------------------------------------------------------------------
+
+
+def add_attachment(
+    message_mid: str,
+    content_type: str,
+    data: str,
+    size: int,
+    filename: str | None = None,
+    conn: sqlite3.Connection | None = None,
+) -> dict:
+    """Store an attachment for a message.
+
+    Args:
+        message_mid: The mid of the message this attachment belongs to.
+        content_type: MIME type (e.g. "image/png").
+        data: Base64-encoded content.
+        size: Raw byte size before base64 encoding.
+        filename: Optional original filename.
+        conn: Optional database connection.
+
+    Returns:
+        Attachment info dict with id, message_mid, filename, content_type, size, created_at.
+    """
+    conn = _get_conn(conn)
+    import uuid as _uuid
+
+    attachment_id = str(_uuid.uuid4())
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    conn.execute(
+        """INSERT INTO attachments (id, message_mid, filename, content_type, data, size, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+        (attachment_id, message_mid, filename, content_type, data, size, now_iso),
+    )
+    conn.commit()
+
+    return {
+        "id": attachment_id,
+        "message_mid": message_mid,
+        "filename": filename,
+        "content_type": content_type,
+        "size": size,
+        "created_at": now_iso,
+    }
+
+
+def get_attachment(
+    attachment_id: str,
+    include_data: bool = True,
+    conn: sqlite3.Connection | None = None,
+) -> dict | None:
+    """Retrieve an attachment by ID.
+
+    Args:
+        attachment_id: The attachment ID.
+        include_data: Whether to include the base64 data (default True).
+        conn: Optional database connection.
+
+    Returns:
+        Attachment dict or None if not found.
+    """
+    conn = _get_conn(conn)
+    cols = (
+        "id, message_mid, filename, content_type, data, size, created_at"
+        if include_data
+        else "id, message_mid, filename, content_type, size, created_at"
+    )
+    cursor = conn.execute(f"SELECT {cols} FROM attachments WHERE id = ?", (attachment_id,))
+    row = cursor.fetchone()
+    if not row:
+        return None
+
+    result = {
+        "id": row[0],
+        "message_mid": row[1],
+        "filename": row[2],
+        "content_type": row[3],
+    }
+    if include_data:
+        result["data"] = row[4]
+        result["size"] = row[5]
+        result["created_at"] = row[6]
+    else:
+        result["size"] = row[4]
+        result["created_at"] = row[5]
+    return result
+
+
+def get_message_attachments(
+    message_mid: str,
+    include_data: bool = False,
+    conn: sqlite3.Connection | None = None,
+) -> list[dict]:
+    """Get all attachments for a message.
+
+    Args:
+        message_mid: The message mid.
+        include_data: Whether to include base64 data (default False for listings).
+        conn: Optional database connection.
+
+    Returns:
+        List of attachment dicts.
+    """
+    conn = _get_conn(conn)
+    if include_data:
+        cols = "id, message_mid, filename, content_type, data, size, created_at"
+    else:
+        cols = "id, message_mid, filename, content_type, size, created_at"
+
+    cursor = conn.execute(
+        f"SELECT {cols} FROM attachments WHERE message_mid = ? ORDER BY created_at",
+        (message_mid,),
+    )
+    results = []
+    for row in cursor.fetchall():
+        att = {
+            "id": row[0],
+            "message_mid": row[1],
+            "filename": row[2],
+            "content_type": row[3],
+        }
+        if include_data:
+            att["data"] = row[4]
+            att["size"] = row[5]
+            att["created_at"] = row[6]
+        else:
+            att["size"] = row[4]
+            att["created_at"] = row[5]
+        results.append(att)
+    return results

--- a/src/deadrop/db.py
+++ b/src/deadrop/db.py
@@ -683,7 +683,8 @@ def _migrate_006_add_attachments(conn: sqlite3.Connection) -> None:
     conn.execute("""
         CREATE TABLE IF NOT EXISTS attachments (
             id TEXT PRIMARY KEY,
-            message_mid TEXT NOT NULL,
+            message_mid TEXT NOT NULL
+                REFERENCES room_messages(mid) ON DELETE CASCADE,
             filename TEXT,
             content_type TEXT NOT NULL,
             data TEXT NOT NULL,
@@ -2914,4 +2915,53 @@ def get_message_attachments(
             att["size"] = row[4]
             att["created_at"] = row[5]
         results.append(att)
+    return results
+
+
+def get_batch_message_attachments(
+    message_mids: list[str],
+    include_data: bool = False,
+    conn: sqlite3.Connection | None = None,
+) -> dict[str, list[dict]]:
+    """Get attachments for multiple messages in a single query.
+
+    Args:
+        message_mids: List of message mids to fetch attachments for.
+        include_data: Whether to include base64 data (default False for listings).
+        conn: Optional database connection.
+
+    Returns:
+        Dict mapping message_mid -> list of attachment dicts.
+    """
+    if not message_mids:
+        return {}
+
+    conn = _get_conn(conn)
+    if include_data:
+        cols = "id, message_mid, filename, content_type, data, size, created_at"
+    else:
+        cols = "id, message_mid, filename, content_type, size, created_at"
+
+    placeholders = ",".join("?" for _ in message_mids)
+    cursor = conn.execute(
+        f"SELECT {cols} FROM attachments WHERE message_mid IN ({placeholders}) ORDER BY created_at",
+        message_mids,
+    )
+
+    results: dict[str, list[dict]] = {}
+    for row in cursor.fetchall():
+        att = {
+            "id": row[0],
+            "message_mid": row[1],
+            "filename": row[2],
+            "content_type": row[3],
+        }
+        if include_data:
+            att["data"] = row[4]
+            att["size"] = row[5]
+            att["created_at"] = row[6]
+        else:
+            att["size"] = row[4]
+            att["created_at"] = row[5]
+        results.setdefault(att["message_mid"], []).append(att)
     return results

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ def reset_database():
     # Temporarily disable foreign keys to allow dropping in any order
     conn.execute("PRAGMA foreign_keys=OFF")
     conn.executescript("""
+        DROP TABLE IF EXISTS attachments;
         DROP TABLE IF EXISTS room_messages;
         DROP TABLE IF EXISTS room_members;
         DROP TABLE IF EXISTS rooms;

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -394,6 +394,7 @@ class TestAttachmentValidation:
         """Stored XSS: text/html must be rejected."""
         s = room_setup
         import base64
+
         html_b64 = base64.b64encode(b"<script>alert(1)</script>").decode()
         resp = client.post(
             f"/{s['ns']}/rooms/{s['room_id']}/messages",
@@ -412,6 +413,7 @@ class TestAttachmentValidation:
         """SVG can contain scripts — must be rejected."""
         s = room_setup
         import base64
+
         svg_b64 = base64.b64encode(b"<svg onload='alert(1)'/>").decode()
         resp = client.post(
             f"/{s['ns']}/rooms/{s['room_id']}/messages",
@@ -428,13 +430,18 @@ class TestAttachmentValidation:
     def test_reject_javascript_content_type(self, client, room_setup):
         s = room_setup
         import base64
+
         js_b64 = base64.b64encode(b"alert(1)").decode()
         resp = client.post(
             f"/{s['ns']}/rooms/{s['room_id']}/messages",
             json={
                 "body": "JS",
                 "attachments": [
-                    {"filename": "evil.js", "content_type": "application/javascript", "data": js_b64},
+                    {
+                        "filename": "evil.js",
+                        "content_type": "application/javascript",
+                        "data": js_b64,
+                    },
                 ],
             },
             headers={"X-Inbox-Secret": s["alice_secret"]},
@@ -445,6 +452,7 @@ class TestAttachmentValidation:
         """application/pdf should be allowed."""
         s = room_setup
         import base64
+
         pdf_b64 = base64.b64encode(b"%PDF-1.4 fake content").decode()
         resp = client.post(
             f"/{s['ns']}/rooms/{s['room_id']}/messages",
@@ -463,8 +471,7 @@ class TestAttachmentValidation:
         s = room_setup
         png = _make_png_b64()
         attachments = [
-            {"filename": f"img{i}.png", "content_type": "image/png", "data": png}
-            for i in range(11)
+            {"filename": f"img{i}.png", "content_type": "image/png", "data": png} for i in range(11)
         ]
         resp = client.post(
             f"/{s['ns']}/rooms/{s['room_id']}/messages",
@@ -479,8 +486,7 @@ class TestAttachmentValidation:
         s = room_setup
         png = _make_png_b64()
         attachments = [
-            {"filename": f"img{i}.png", "content_type": "image/png", "data": png}
-            for i in range(10)
+            {"filename": f"img{i}.png", "content_type": "image/png", "data": png} for i in range(10)
         ]
         resp = client.post(
             f"/{s['ns']}/rooms/{s['room_id']}/messages",
@@ -494,6 +500,7 @@ class TestAttachmentValidation:
         """Attachment over 10MB should return 413."""
         s = room_setup
         import base64
+
         # 10MB + 1 byte
         big_data = base64.b64encode(b"x" * (10 * 1024 * 1024 + 1)).decode()
         resp = client.post(

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -385,6 +385,206 @@ class TestAttachmentAPI:
 
 
 # ---------------------------------------------------------------------------
+# Validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestAttachmentValidation:
+    def test_reject_html_content_type(self, client, room_setup):
+        """Stored XSS: text/html must be rejected."""
+        s = room_setup
+        import base64
+        html_b64 = base64.b64encode(b"<script>alert(1)</script>").decode()
+        resp = client.post(
+            f"/{s['ns']}/rooms/{s['room_id']}/messages",
+            json={
+                "body": "XSS attempt",
+                "attachments": [
+                    {"filename": "evil.html", "content_type": "text/html", "data": html_b64},
+                ],
+            },
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        assert resp.status_code == 400
+        assert "Unsupported attachment type" in resp.json()["detail"]
+
+    def test_reject_svg_content_type(self, client, room_setup):
+        """SVG can contain scripts — must be rejected."""
+        s = room_setup
+        import base64
+        svg_b64 = base64.b64encode(b"<svg onload='alert(1)'/>").decode()
+        resp = client.post(
+            f"/{s['ns']}/rooms/{s['room_id']}/messages",
+            json={
+                "body": "SVG XSS",
+                "attachments": [
+                    {"filename": "evil.svg", "content_type": "image/svg+xml", "data": svg_b64},
+                ],
+            },
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        assert resp.status_code == 400
+
+    def test_reject_javascript_content_type(self, client, room_setup):
+        s = room_setup
+        import base64
+        js_b64 = base64.b64encode(b"alert(1)").decode()
+        resp = client.post(
+            f"/{s['ns']}/rooms/{s['room_id']}/messages",
+            json={
+                "body": "JS",
+                "attachments": [
+                    {"filename": "evil.js", "content_type": "application/javascript", "data": js_b64},
+                ],
+            },
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        assert resp.status_code == 400
+
+    def test_allow_pdf(self, client, room_setup):
+        """application/pdf should be allowed."""
+        s = room_setup
+        import base64
+        pdf_b64 = base64.b64encode(b"%PDF-1.4 fake content").decode()
+        resp = client.post(
+            f"/{s['ns']}/rooms/{s['room_id']}/messages",
+            json={
+                "body": "PDF",
+                "attachments": [
+                    {"filename": "doc.pdf", "content_type": "application/pdf", "data": pdf_b64},
+                ],
+            },
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        assert resp.status_code == 200
+
+    def test_too_many_attachments(self, client, room_setup):
+        """More than 10 attachments must be rejected."""
+        s = room_setup
+        png = _make_png_b64()
+        attachments = [
+            {"filename": f"img{i}.png", "content_type": "image/png", "data": png}
+            for i in range(11)
+        ]
+        resp = client.post(
+            f"/{s['ns']}/rooms/{s['room_id']}/messages",
+            json={"body": "Too many", "attachments": attachments},
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        assert resp.status_code == 400
+        assert "Too many attachments" in resp.json()["detail"]
+
+    def test_exactly_max_attachments_ok(self, client, room_setup):
+        """Exactly 10 attachments should succeed."""
+        s = room_setup
+        png = _make_png_b64()
+        attachments = [
+            {"filename": f"img{i}.png", "content_type": "image/png", "data": png}
+            for i in range(10)
+        ]
+        resp = client.post(
+            f"/{s['ns']}/rooms/{s['room_id']}/messages",
+            json={"body": "Max ok", "attachments": attachments},
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        assert resp.status_code == 200
+        assert len(resp.json()["attachments"]) == 10
+
+    def test_oversized_attachment_returns_413(self, client, room_setup):
+        """Attachment over 10MB should return 413."""
+        s = room_setup
+        import base64
+        # 10MB + 1 byte
+        big_data = base64.b64encode(b"x" * (10 * 1024 * 1024 + 1)).decode()
+        resp = client.post(
+            f"/{s['ns']}/rooms/{s['room_id']}/messages",
+            json={
+                "body": "Too big",
+                "attachments": [
+                    {"filename": "huge.png", "content_type": "image/png", "data": big_data},
+                ],
+            },
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        assert resp.status_code == 413
+
+
+# ---------------------------------------------------------------------------
+# Batch query tests
+# ---------------------------------------------------------------------------
+
+
+class TestBatchAttachmentQuery:
+    def test_batch_fetch(self, client, room_setup):
+        """get_batch_message_attachments returns grouped results."""
+        s = room_setup
+        # Send two messages with attachments
+        r1 = client.post(
+            f"/{s['ns']}/rooms/{s['room_id']}/messages",
+            json={
+                "body": "msg1",
+                "attachments": [
+                    {"filename": "a.png", "content_type": "image/png", "data": _make_png_b64()},
+                ],
+            },
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        r2 = client.post(
+            f"/{s['ns']}/rooms/{s['room_id']}/messages",
+            json={
+                "body": "msg2",
+                "attachments": [
+                    {"filename": "b.jpg", "content_type": "image/jpeg", "data": _make_jpeg_b64()},
+                    {"filename": "c.png", "content_type": "image/png", "data": _make_png_b64()},
+                ],
+            },
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        mid1 = r1.json()["mid"]
+        mid2 = r2.json()["mid"]
+
+        result = db.get_batch_message_attachments([mid1, mid2])
+        assert mid1 in result
+        assert mid2 in result
+        assert len(result[mid1]) == 1
+        assert len(result[mid2]) == 2
+
+    def test_batch_empty_list(self, client, room_setup):
+        result = db.get_batch_message_attachments([])
+        assert result == {}
+
+    def test_listing_uses_batch(self, client, room_setup):
+        """GET /messages should work correctly with batch query."""
+        s = room_setup
+        client.post(
+            f"/{s['ns']}/rooms/{s['room_id']}/messages",
+            json={
+                "body": "with att",
+                "attachments": [
+                    {"filename": "test.png", "content_type": "image/png", "data": _make_png_b64()},
+                ],
+            },
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        client.post(
+            f"/{s['ns']}/rooms/{s['room_id']}/messages",
+            json={"body": "no att"},
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        resp = client.get(
+            f"/{s['ns']}/rooms/{s['room_id']}/messages",
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        assert resp.status_code == 200
+        msgs = resp.json()["messages"]
+        assert len(msgs) == 2
+        with_att = [m for m in msgs if m["attachments"]]
+        without_att = [m for m in msgs if not m["attachments"]]
+        assert len(with_att) == 1
+        assert len(without_att) == 1
+
+
+# ---------------------------------------------------------------------------
 # Migration tests
 # ---------------------------------------------------------------------------
 
@@ -403,3 +603,13 @@ class TestAttachmentMigration:
             "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_attachments_mid'"
         )
         assert cursor.fetchone() is not None
+
+    def test_foreign_key_constraint(self, client, room_setup):
+        """attachments.message_mid should reference room_messages(mid)."""
+        conn = db.get_connection()
+        fks = conn.execute("PRAGMA foreign_key_list(attachments)").fetchall()
+        # FK should reference room_messages.mid
+        assert len(fks) >= 1
+        fk = fks[0]
+        assert fk[2] == "room_messages"  # table
+        assert fk[4] == "mid"  # to column

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -1,0 +1,405 @@
+"""Tests for the attachments feature."""
+
+import base64
+import struct
+import zlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+from deadrop import db
+from deadrop.api import app
+
+
+@pytest.fixture
+def client():
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+
+
+@pytest.fixture
+def admin_headers():
+    return {"X-Admin-Token": "test-admin-token"}
+
+
+@pytest.fixture
+def room_setup(client, admin_headers):
+    """Create a namespace, identity, and room."""
+    ns = client.post("/admin/namespaces", headers=admin_headers).json()
+    alice = client.post(
+        f"/{ns['ns']}/identities",
+        headers={"X-Namespace-Secret": ns["secret"]},
+        json={"metadata": {"display_name": "Alice"}},
+    ).json()
+
+    room = client.post(
+        f"/{ns['ns']}/rooms",
+        headers={"X-Inbox-Secret": alice["secret"]},
+        json={"display_name": "Test Room"},
+    ).json()
+
+    return {
+        "ns": ns["ns"],
+        "ns_secret": ns["secret"],
+        "room_id": room["room_id"],
+        "alice_secret": alice["secret"],
+        "alice_id": alice["id"],
+    }
+
+
+@pytest.fixture
+def two_member_setup(client, room_setup, admin_headers):
+    """Room with two members (Alice + Bob)."""
+    setup = room_setup
+    bob = client.post(
+        f"/{setup['ns']}/identities",
+        headers={"X-Namespace-Secret": setup["ns_secret"]},
+        json={"metadata": {"display_name": "Bob"}},
+    ).json()
+
+    client.post(
+        f"/{setup['ns']}/rooms/{setup['room_id']}/members",
+        headers={"X-Inbox-Secret": setup["alice_secret"]},
+        json={"identity_id": bob["id"]},
+    )
+
+    return {**setup, "bob_secret": bob["secret"], "bob_id": bob["id"]}
+
+
+def _make_png_b64():
+    """Create a minimal valid 1x1 red pixel PNG as base64."""
+
+    def _chunk(chunk_type, data):
+        c = chunk_type + data
+        crc = struct.pack(">I", zlib.crc32(c) & 0xFFFFFFFF)
+        return struct.pack(">I", len(data)) + c + crc
+
+    sig = b"\x89PNG\r\n\x1a\n"
+    ihdr = struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0)
+    raw = b"\x00\xff\x00\x00"
+    idat = zlib.compress(raw)
+    png = sig + _chunk(b"IHDR", ihdr) + _chunk(b"IDAT", idat) + _chunk(b"IEND", b"")
+    return base64.b64encode(png).decode()
+
+
+def _make_jpeg_b64():
+    """Minimal JPEG-like blob for testing."""
+    data = b"\xff\xd8\xff\xe0" + b"\x00" * 100 + b"\xff\xd9"
+    return base64.b64encode(data).decode()
+
+
+# ---------------------------------------------------------------------------
+# DB-level tests
+# ---------------------------------------------------------------------------
+
+
+class TestAttachmentDB:
+    def test_add_and_get(self, client, room_setup):
+        s = room_setup
+        resp = client.post(
+            f"/{s['ns']}/rooms/{s['room_id']}/messages",
+            json={"body": "test"},
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        mid = resp.json()["mid"]
+
+        png = _make_png_b64()
+        raw_size = len(base64.b64decode(png))
+        att = db.add_attachment(mid, "image/png", png, raw_size, "test.png")
+
+        assert att["id"]
+        assert att["message_mid"] == mid
+        assert att["filename"] == "test.png"
+        assert att["content_type"] == "image/png"
+        assert att["size"] == raw_size
+
+        fetched = db.get_attachment(att["id"])
+        assert fetched is not None
+        assert fetched["data"] == png
+        assert fetched["content_type"] == "image/png"
+
+    def test_get_without_data(self, client, room_setup):
+        s = room_setup
+        resp = client.post(
+            f"/{s['ns']}/rooms/{s['room_id']}/messages",
+            json={"body": "test"},
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        mid = resp.json()["mid"]
+
+        att = db.add_attachment(mid, "image/jpeg", _make_jpeg_b64(), 104, "photo.jpg")
+        fetched = db.get_attachment(att["id"], include_data=False)
+        assert fetched is not None
+        assert "data" not in fetched
+        assert fetched["content_type"] == "image/jpeg"
+
+    def test_multiple_attachments(self, client, room_setup):
+        s = room_setup
+        resp = client.post(
+            f"/{s['ns']}/rooms/{s['room_id']}/messages",
+            json={"body": "multi"},
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        mid = resp.json()["mid"]
+
+        db.add_attachment(mid, "image/png", _make_png_b64(), 100, "a.png")
+        db.add_attachment(mid, "image/jpeg", _make_jpeg_b64(), 104, "b.jpg")
+
+        atts = db.get_message_attachments(mid, include_data=False)
+        assert len(atts) == 2
+        assert atts[0]["filename"] == "a.png"
+        assert atts[1]["filename"] == "b.jpg"
+
+    def test_nonexistent_attachment(self, client, room_setup):
+        assert db.get_attachment("nonexistent-id") is None
+
+    def test_no_attachments(self, client, room_setup):
+        s = room_setup
+        resp = client.post(
+            f"/{s['ns']}/rooms/{s['room_id']}/messages",
+            json={"body": "plain"},
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        mid = resp.json()["mid"]
+        assert db.get_message_attachments(mid) == []
+
+    def test_optional_filename(self, client, room_setup):
+        s = room_setup
+        resp = client.post(
+            f"/{s['ns']}/rooms/{s['room_id']}/messages",
+            json={"body": "test"},
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        mid = resp.json()["mid"]
+        att = db.add_attachment(mid, "image/png", _make_png_b64(), 100)
+        assert att["filename"] is None
+
+        fetched = db.get_attachment(att["id"])
+        assert fetched["filename"] is None
+
+
+# ---------------------------------------------------------------------------
+# API-level tests
+# ---------------------------------------------------------------------------
+
+
+class TestAttachmentAPI:
+    def test_send_with_attachment(self, client, room_setup):
+        s = room_setup
+        png = _make_png_b64()
+
+        resp = client.post(
+            f"/{s['ns']}/rooms/{s['room_id']}/messages",
+            json={
+                "body": "Screenshot",
+                "content_type": "text/markdown",
+                "attachments": [
+                    {"filename": "shot.png", "content_type": "image/png", "data": png},
+                ],
+            },
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["body"] == "Screenshot"
+        assert data["attachments"] is not None
+        assert len(data["attachments"]) == 1
+        att = data["attachments"][0]
+        assert att["filename"] == "shot.png"
+        assert att["content_type"] == "image/png"
+        assert att["size"] > 0
+        assert "data" not in att  # Metadata only in response
+
+    def test_send_multiple_attachments(self, client, room_setup):
+        s = room_setup
+        resp = client.post(
+            f"/{s['ns']}/rooms/{s['room_id']}/messages",
+            json={
+                "body": "Two files",
+                "attachments": [
+                    {"filename": "a.png", "content_type": "image/png", "data": _make_png_b64()},
+                    {"filename": "b.jpg", "content_type": "image/jpeg", "data": _make_jpeg_b64()},
+                ],
+            },
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        assert resp.status_code == 200
+        assert len(resp.json()["attachments"]) == 2
+
+    def test_send_without_attachments(self, client, room_setup):
+        s = room_setup
+        resp = client.post(
+            f"/{s['ns']}/rooms/{s['room_id']}/messages",
+            json={"body": "Plain text"},
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["attachments"] is None
+
+    def test_list_includes_attachment_metadata(self, client, room_setup):
+        s = room_setup
+
+        # Message with attachment
+        client.post(
+            f"/{s['ns']}/rooms/{s['room_id']}/messages",
+            json={
+                "body": "With image",
+                "attachments": [
+                    {"filename": "img.png", "content_type": "image/png", "data": _make_png_b64()},
+                ],
+            },
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        # Message without
+        client.post(
+            f"/{s['ns']}/rooms/{s['room_id']}/messages",
+            json={"body": "No image"},
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+
+        resp = client.get(
+            f"/{s['ns']}/rooms/{s['room_id']}/messages",
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        assert resp.status_code == 200
+        msgs = resp.json()["messages"]
+        assert len(msgs) == 2
+        assert msgs[0]["attachments"] is not None
+        assert len(msgs[0]["attachments"]) == 1
+        assert msgs[0]["attachments"][0]["filename"] == "img.png"
+        assert msgs[1]["attachments"] is None
+
+    def test_fetch_attachment_data(self, client, room_setup):
+        s = room_setup
+        png = _make_png_b64()
+
+        resp = client.post(
+            f"/{s['ns']}/rooms/{s['room_id']}/messages",
+            json={
+                "body": "Fetch me",
+                "attachments": [
+                    {"filename": "test.png", "content_type": "image/png", "data": png},
+                ],
+            },
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        att_id = resp.json()["attachments"][0]["id"]
+
+        resp = client.get(
+            f"/{s['ns']}/attachments/{att_id}",
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["data"] == png
+        assert data["content_type"] == "image/png"
+
+    def test_fetch_attachment_not_found(self, client, room_setup):
+        s = room_setup
+        resp = client.get(
+            f"/{s['ns']}/attachments/nonexistent-id",
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        assert resp.status_code == 404
+
+    def test_fetch_attachment_requires_auth(self, client, room_setup):
+        s = room_setup
+        resp = client.get(f"/{s['ns']}/attachments/any-id")
+        assert resp.status_code == 401
+
+    def test_fetch_attachment_requires_room_membership(
+        self, client, two_member_setup, admin_headers
+    ):
+        """Non-member can't fetch attachment."""
+        s = two_member_setup
+
+        # Alice sends message with attachment
+        resp = client.post(
+            f"/{s['ns']}/rooms/{s['room_id']}/messages",
+            json={
+                "body": "Secret image",
+                "attachments": [
+                    {
+                        "filename": "secret.png",
+                        "content_type": "image/png",
+                        "data": _make_png_b64(),
+                    },
+                ],
+            },
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        att_id = resp.json()["attachments"][0]["id"]
+
+        # Create Charlie (not a room member)
+        charlie = client.post(
+            f"/{s['ns']}/identities",
+            headers={"X-Namespace-Secret": s["ns_secret"]},
+            json={"metadata": {"display_name": "Charlie"}},
+        ).json()
+
+        resp = client.get(
+            f"/{s['ns']}/attachments/{att_id}",
+            headers={"X-Inbox-Secret": charlie["secret"]},
+        )
+        assert resp.status_code == 403
+
+    def test_invalid_base64_rejected(self, client, room_setup):
+        s = room_setup
+        # Use characters that are definitely not valid base64 (= padding in wrong place)
+        resp = client.post(
+            f"/{s['ns']}/rooms/{s['room_id']}/messages",
+            json={
+                "body": "Bad data",
+                "attachments": [
+                    {"filename": "bad.png", "content_type": "image/png", "data": "===invalid==="},
+                ],
+            },
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        assert resp.status_code == 400
+
+    def test_dedup_no_duplicate_attachments(self, client, room_setup):
+        """Deduped messages should not create extra attachments."""
+        s = room_setup
+        msg = {
+            "body": "Dedup test",
+            "attachments": [
+                {"filename": "test.png", "content_type": "image/png", "data": _make_png_b64()},
+            ],
+        }
+
+        resp1 = client.post(
+            f"/{s['ns']}/rooms/{s['room_id']}/messages",
+            json=msg,
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        resp2 = client.post(
+            f"/{s['ns']}/rooms/{s['room_id']}/messages",
+            json=msg,
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+
+        assert resp1.json()["mid"] == resp2.json()["mid"]
+        atts = db.get_message_attachments(resp1.json()["mid"])
+        assert len(atts) == 1
+
+
+# ---------------------------------------------------------------------------
+# Migration tests
+# ---------------------------------------------------------------------------
+
+
+class TestAttachmentMigration:
+    def test_table_exists(self, client, room_setup):
+        conn = db.get_connection()
+        cursor = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='attachments'"
+        )
+        assert cursor.fetchone() is not None
+
+    def test_index_exists(self, client, room_setup):
+        conn = db.get_connection()
+        cursor = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_attachments_mid'"
+        )
+        assert cursor.fetchone() is not None

--- a/tests/test_migration_v5_to_v6.py
+++ b/tests/test_migration_v5_to_v6.py
@@ -1,0 +1,256 @@
+"""Test schema migration from v5 (current deployed) to v6 (attachments).
+
+Simulates the real migration path:
+1. Create a v5 database with realistic data (50 room msgs, 20 DMs)
+2. Run the v6 migration
+3. Verify all existing data is intact
+4. Verify new attachment CRUD operations work
+"""
+
+import sqlite3
+import uuid
+import base64
+import hashlib
+from datetime import datetime, timezone
+
+import pytest
+
+from deadrop.db import (
+    get_schema_version,
+    run_migrations,
+    add_attachment,
+    get_attachment,
+    get_message_attachments,
+)
+
+
+@pytest.fixture
+def v5_database(tmp_path):
+    """Create a database at schema version 5 with realistic data."""
+    db_path = tmp_path / "test.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+
+    conn.executescript("""
+        CREATE TABLE namespaces (
+            id TEXT PRIMARY KEY, display_name TEXT, created_at TEXT NOT NULL
+        );
+        CREATE TABLE identities (
+            pubkey TEXT PRIMARY KEY, namespace_id TEXT NOT NULL,
+            display_name TEXT, created_at TEXT NOT NULL
+        );
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, namespace_id TEXT NOT NULL,
+            sender_pubkey TEXT NOT NULL, mid TEXT UNIQUE, body TEXT NOT NULL,
+            created_at TEXT NOT NULL, content_type TEXT NOT NULL DEFAULT 'text/plain'
+        );
+        CREATE TABLE schema_version (
+            version INTEGER PRIMARY KEY, description TEXT,
+            applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        CREATE TABLE rooms (
+            id TEXT PRIMARY KEY, namespace_id TEXT NOT NULL,
+            name TEXT NOT NULL, created_at TEXT NOT NULL, created_by TEXT NOT NULL
+        );
+        CREATE TABLE room_members (
+            room_id TEXT NOT NULL, pubkey TEXT NOT NULL,
+            role TEXT NOT NULL DEFAULT 'member', joined_at TEXT NOT NULL,
+            PRIMARY KEY (room_id, pubkey)
+        );
+        CREATE TABLE room_messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, room_id TEXT NOT NULL,
+            sender_pubkey TEXT NOT NULL, mid TEXT UNIQUE, body TEXT NOT NULL,
+            content_type TEXT NOT NULL DEFAULT 'text/markdown',
+            created_at TEXT NOT NULL, reference_mid TEXT, content_hash TEXT
+        );
+        CREATE INDEX idx_room_messages_mid ON room_messages(mid);
+        CREATE INDEX idx_messages_mid ON messages(mid);
+        CREATE INDEX idx_room_messages_content_hash
+            ON room_messages(room_id, content_hash);
+    """)
+
+    for v in range(1, 6):
+        conn.execute(
+            "INSERT INTO schema_version (version, description) VALUES (?, ?)",
+            (v, f"Migration {v}"),
+        )
+
+    now = datetime.now(timezone.utc).isoformat()
+    ns_id = "test-ns"
+    conn.execute("INSERT INTO namespaces VALUES (?, ?, ?)", (ns_id, "Test", now))
+
+    pubkeys = [f"pk_{uuid.uuid4().hex[:16]}" for _ in range(3)]
+    for i, pk in enumerate(pubkeys):
+        conn.execute(
+            "INSERT INTO identities VALUES (?, ?, ?, ?)",
+            (pk, ns_id, f"User {i}", now),
+        )
+
+    room_id = str(uuid.uuid4())
+    conn.execute(
+        "INSERT INTO rooms VALUES (?, ?, ?, ?, ?)",
+        (room_id, ns_id, "twin", now, pubkeys[0]),
+    )
+    for pk in pubkeys:
+        conn.execute(
+            "INSERT INTO room_members VALUES (?, ?, ?, ?)",
+            (room_id, pk, "member", now),
+        )
+
+    mids = []
+    for i in range(50):
+        mid = f"069df{i:03x}-test-{uuid.uuid4().hex[:4]}"
+        mids.append(mid)
+        body = f"Test message {i}: {'x' * (100 + i * 10)}"
+        ch = hashlib.sha256(body.encode()).hexdigest()[:16]
+        conn.execute(
+            """INSERT INTO room_messages
+               (room_id, sender_pubkey, mid, body, content_type,
+                created_at, content_hash)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (room_id, pubkeys[i % 3], mid, body, "text/markdown", now, ch),
+        )
+
+    for i in range(20):
+        conn.execute(
+            """INSERT INTO messages
+               (namespace_id, sender_pubkey, mid, body, created_at, content_type)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (
+                ns_id,
+                pubkeys[0],
+                f"dm_{uuid.uuid4().hex[:8]}",
+                f"DM {i}",
+                now,
+                "text/plain",
+            ),
+        )
+
+    conn.commit()
+    yield {
+        "conn": conn,
+        "db_path": str(db_path),
+        "ns": ns_id,
+        "room": room_id,
+        "pubkeys": pubkeys,
+        "mids": mids,
+        "room_msg_count": 50,
+        "dm_count": 20,
+    }
+    conn.close()
+
+
+class TestMigrationV5ToV6:
+    """Test the v5 to v6 schema migration (add attachments table)."""
+
+    def test_pre_migration_version(self, v5_database):
+        assert get_schema_version(v5_database["conn"]) == 5
+
+    def test_migration_runs(self, v5_database):
+        run_migrations(v5_database["conn"])
+        assert get_schema_version(v5_database["conn"]) == 6
+
+    def test_existing_room_messages_intact(self, v5_database):
+        run_migrations(v5_database["conn"])
+        count = v5_database["conn"].execute("SELECT COUNT(*) FROM room_messages").fetchone()[0]
+        assert count == v5_database["room_msg_count"]
+
+    def test_existing_dms_intact(self, v5_database):
+        run_migrations(v5_database["conn"])
+        count = v5_database["conn"].execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+        assert count == v5_database["dm_count"]
+
+    def test_attachments_table_created_empty(self, v5_database):
+        run_migrations(v5_database["conn"])
+        count = v5_database["conn"].execute("SELECT COUNT(*) FROM attachments").fetchone()[0]
+        assert count == 0
+
+    def test_attachment_index_created(self, v5_database):
+        run_migrations(v5_database["conn"])
+        indexes = (
+            v5_database["conn"]
+            .execute("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='attachments'")
+            .fetchall()
+        )
+        names = [i[0] for i in indexes]
+        assert "idx_attachments_mid" in names
+
+    def test_add_attachment_after_migration(self, v5_database):
+        conn = v5_database["conn"]
+        run_migrations(conn)
+        data = base64.b64encode(b"fake png" * 100).decode()
+        result = add_attachment(
+            message_mid=v5_database["mids"][0],
+            content_type="image/png",
+            data=data,
+            size=len(b"fake png" * 100),
+            filename="test.png",
+            conn=conn,
+        )
+        assert "id" in result
+        assert result["filename"] == "test.png"
+
+    def test_get_attachment_with_data(self, v5_database):
+        conn = v5_database["conn"]
+        run_migrations(conn)
+        data = base64.b64encode(b"test data" * 50).decode()
+        result = add_attachment(
+            message_mid=v5_database["mids"][0],
+            content_type="image/png",
+            data=data,
+            size=len(b"test data" * 50),
+            conn=conn,
+        )
+        fetched = get_attachment(result["id"], include_data=True, conn=conn)
+        assert fetched is not None
+        assert fetched["data"] == data
+
+    def test_get_attachment_metadata_only(self, v5_database):
+        conn = v5_database["conn"]
+        run_migrations(conn)
+        data = base64.b64encode(b"x" * 100).decode()
+        result = add_attachment(
+            message_mid=v5_database["mids"][0],
+            content_type="image/png",
+            data=data,
+            size=100,
+            conn=conn,
+        )
+        fetched = get_attachment(result["id"], include_data=False, conn=conn)
+        assert fetched is not None
+        assert fetched.get("data") is None
+
+    def test_get_message_attachments(self, v5_database):
+        conn = v5_database["conn"]
+        run_migrations(conn)
+        mid = v5_database["mids"][0]
+        data = base64.b64encode(b"x" * 50).decode()
+        add_attachment(
+            message_mid=mid,
+            content_type="image/png",
+            data=data,
+            size=50,
+            conn=conn,
+        )
+        add_attachment(
+            message_mid=mid,
+            content_type="image/jpeg",
+            data=data,
+            size=50,
+            conn=conn,
+        )
+        atts = get_message_attachments(mid, conn=conn)
+        assert len(atts) == 2
+
+    def test_original_messages_unchanged(self, v5_database):
+        conn = v5_database["conn"]
+        mid = v5_database["mids"][0]
+        original = conn.execute(
+            "SELECT body, content_hash FROM room_messages WHERE mid=?", (mid,)
+        ).fetchone()
+        run_migrations(conn)
+        after = conn.execute(
+            "SELECT body, content_hash FROM room_messages WHERE mid=?", (mid,)
+        ).fetchone()
+        assert original == after


### PR DESCRIPTION
## Overview

Adds support for binary attachments (images, files) on room messages. Attachments are stored alongside messages and served via a dedicated endpoint.

## Changes

### Database
- **Migration 006:** `attachments` table with `id`, `message_mid`, `filename`, `content_type`, `data` (base64), `size`
- CRUD functions: `add_attachment`, `get_attachment`, `get_message_attachments`
- Schema version 5 → 6

### API
- **Send:** `POST /{ns}/rooms/{room_id}/messages` now accepts optional `attachments` array
- **List:** Room message responses include `attachments` metadata (id, filename, content_type, size — no data)
- **Fetch:** `GET /{ns}/attachments/{id}` returns full attachment including base64 data
- **Validation:** Strict base64 validation + 10MB per-attachment size limit
- **Auth:** Attachment fetch requires room membership
- **Dedup:** Attachments only stored for genuinely new messages (not on dedup hits)

### Models
```python
AttachmentRequest(filename, content_type, data)      # In send request
AttachmentInfo(id, message_mid, filename, content_type, size)  # In list responses
AttachmentDataInfo(... + data)                       # In fetch responses
```

### Example Usage
```json
POST /{ns}/rooms/{room_id}/messages
{
  "body": "Here's a screenshot",
  "content_type": "text/markdown",
  "attachments": [
    {"filename": "shot.png", "content_type": "image/png", "data": "iVBORw0KGgo..."}
  ]
}
```

## Tests
18 new tests covering:
- DB CRUD (add, get with/without data, multiple, optional filename, empty)
- API send (single, multiple, without, invalid base64, dedup)
- API fetch (data, 404, auth, room membership)
- Migration (table + index existence)

## Next Steps (separate PRs)
- Web UI: file picker + paste + inline image display
- Harness1: daemon watcher attachment handling → Anthropic image content blocks