### PR TITLE
feat: web UI for image attachments

### DIFF
--- a/src/deadrop/static/css/style.css
+++ b/src/deadrop/static/css/style.css
@@ -870,3 +870,67 @@ button:disabled {
 .view > .compose-area {
     flex-shrink: 0;
 }
+
+/* Attachment preview strip */
+.attachment-preview {
+    display: flex;
+    gap: 8px;
+    padding: 8px 12px;
+    background: var(--surface, #f5f5f5);
+    border-top: 1px solid var(--border, #e0e0e0);
+    overflow-x: auto;
+}
+.attachment-preview.hidden { display: none; }
+.attachment-preview .thumb {
+    position: relative;
+    width: 60px;
+    height: 60px;
+    border-radius: 6px;
+    overflow: hidden;
+    flex-shrink: 0;
+    border: 1px solid var(--border, #ddd);
+}
+.attachment-preview .thumb img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+.attachment-preview .thumb .remove-btn {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: rgba(0,0,0,0.6);
+    color: white;
+    font-size: 11px;
+    line-height: 18px;
+    text-align: center;
+    cursor: pointer;
+    border: none;
+    padding: 0;
+}
+
+/* Inline image attachments in messages */
+.message-attachments {
+    margin-top: 6px;
+}
+.message-attachments img {
+    max-width: 300px;
+    max-height: 260px;
+    border-radius: 8px;
+    cursor: pointer;
+    display: block;
+    margin: 4px 0;
+}
+.message-attachments .file-attachment {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    background: var(--surface, #f0f0f0);
+    border-radius: 6px;
+    font-size: 13px;
+    margin: 4px 0;
+}

--- a/src/deadrop/static/js/api.js
+++ b/src/deadrop/static/js/api.js
@@ -148,13 +148,21 @@ const DeadropAPI = {
     /**
      * Send a message to a room.
      */
-    async sendRoomMessage(credentials, roomId, body, contentType = 'text/plain', referenceMid = null) {
+    async sendRoomMessage(credentials, roomId, body, contentType = 'text/plain', referenceMid = null, attachments = null) {
         const payload = { body, content_type: contentType };
         if (referenceMid) payload.reference_mid = referenceMid;
+        if (attachments && attachments.length > 0) payload.attachments = attachments;
         return this.request('POST', `/${credentials.ns}/rooms/${roomId}/messages`, {
             body: payload,
             credentials,
         });
+    },
+
+    /**
+     * Fetch a single attachment with its base64 data.
+     */
+    async getAttachment(credentials, attachmentId) {
+        return this.request('GET', `/${credentials.ns}/attachments/${attachmentId}`, { credentials });
     },
 
     /**

--- a/src/deadrop/templates/app.html
+++ b/src/deadrop/templates/app.html
@@ -102,7 +102,10 @@
         
         <div id="room-message-list" class="message-list"></div>
         
+        <div id="room-attachment-preview" class="attachment-preview hidden"></div>
         <div class="compose-area">
+            <button id="room-attach-btn" class="btn btn-icon" title="Attach image">📎</button>
+            <input type="file" id="room-file-input" accept="image/*" multiple style="display:none">
             <textarea id="room-message-input" class="compose-input" 
                       placeholder="Type a message..." rows="1" enterkeyhint="send"></textarea>
             <button id="room-send-btn" class="btn btn-primary">Send ➤</button>
@@ -313,6 +316,95 @@
      * Apply syntax highlighting to all code blocks in a container.
      * Call after inserting rendered markdown HTML into the DOM.
      */
+    // ==================== ATTACHMENTS ====================
+
+    // Pending attachments for the current compose
+    let pendingAttachments = [];
+
+    function renderAttachments(msg) {
+        if (!msg.attachments || msg.attachments.length === 0) return '';
+        const parts = msg.attachments.map(att => {
+            if (att.content_type && att.content_type.startsWith('image/')) {
+                // Image: render inline thumbnail (click to load full via lightbox)
+                return `<img src="data:${escapeHtml(att.content_type)};base64,${att._data || ''}"
+                             alt="${escapeHtml(att.filename || 'image')}"
+                             data-attachment-id="${att.id}"
+                             onclick="loadAndShowAttachment(this, '${att.id}')"
+                             style="${att._data ? '' : 'min-height:40px;background:var(--surface,#eee);'}"
+                             loading="lazy">`;
+            } else {
+                return `<div class="file-attachment">📄 ${escapeHtml(att.filename || 'file')} (${formatFileSize(att.size)})</div>`;
+            }
+        });
+        return `<div class="message-attachments">${parts.join('')}</div>`;
+    }
+
+    function formatFileSize(bytes) {
+        if (!bytes) return '0B';
+        if (bytes < 1024) return bytes + 'B';
+        if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + 'KB';
+        return (bytes / (1024 * 1024)).toFixed(1) + 'MB';
+    }
+
+    async function loadAndShowAttachment(imgEl, attachmentId) {
+        // If already loaded, just open lightbox
+        if (imgEl.dataset.loaded === 'true') {
+            openLightbox(imgEl);
+            return;
+        }
+        try {
+            const att = await DeadropAPI.getAttachment(credentials, attachmentId);
+            imgEl.src = `data:${att.content_type};base64,${att.data}`;
+            imgEl.dataset.loaded = 'true';
+            openLightbox(imgEl);
+        } catch (e) {
+            console.error('Failed to load attachment:', e);
+        }
+    }
+
+    function addFileToPreview(file) {
+        const reader = new FileReader();
+        reader.onload = (e) => {
+            const dataUrl = e.target.result;
+            const base64 = dataUrl.split(',')[1];
+            const mime = dataUrl.split(':')[1].split(';')[0];
+            const att = { filename: file.name, content_type: mime, data: base64, size: file.size };
+            pendingAttachments.push(att);
+            renderAttachmentPreview();
+        };
+        reader.readAsDataURL(file);
+    }
+
+    function removeAttachment(idx) {
+        pendingAttachments.splice(idx, 1);
+        renderAttachmentPreview();
+    }
+
+    function renderAttachmentPreview() {
+        const preview = document.getElementById('room-attachment-preview');
+        if (!preview) return;
+        if (pendingAttachments.length === 0) {
+            preview.classList.add('hidden');
+            preview.innerHTML = '';
+            return;
+        }
+        preview.classList.remove('hidden');
+        preview.innerHTML = pendingAttachments.map((att, i) => {
+            const isImage = att.content_type.startsWith('image/');
+            const thumbContent = isImage
+                ? `<img src="data:${att.content_type};base64,${att.data}" alt="${escapeHtml(att.filename)}">`
+                : `<div style="display:flex;align-items:center;justify-content:center;height:100%;font-size:24px;">📄</div>`;
+            return `<div class="thumb">
+                ${thumbContent}
+                <button class="remove-btn" onclick="removeAttachment(${i})">✕</button>
+            </div>`;
+        }).join('');
+    }
+
+    // Make removeAttachment available globally for onclick
+    window.removeAttachment = removeAttachment;
+    window.loadAndShowAttachment = loadAndShowAttachment;
+
     function highlightCodeBlocks(container) {
         if (typeof hljs === 'undefined') return;
         container.querySelectorAll('pre code').forEach(block => {
@@ -814,6 +906,7 @@
                 <div class="room-message ${isMe ? 'from-me' : ''} ${isPending ? 'pending' : ''}" data-mid="${msg.mid}">
                     <div class="sender-name">${getMemberName(msg.from_id)}</div>
                     <div class="message-body markdown-body">${renderMessageBody(msg.body, msg.content_type)}</div>
+                    ${renderAttachments(msg)}
                     ${renderReactionBadges(msg.mid, reactionMap)}
                     <div class="message-time">${isPending ? 'Sending...' : formatTime(msg.created_at)}</div>
                 </div>
@@ -863,10 +956,18 @@
         const input = document.getElementById('room-message-input');
         const sendBtn = document.getElementById('room-send-btn');
         const body = input.value.trim();
-        if (!body) return;
+        const hasAttachments = pendingAttachments.length > 0;
+        if (!body && !hasAttachments) return;
+        
+        // Capture attachments before clearing
+        const attachmentsToSend = hasAttachments
+            ? pendingAttachments.map(a => ({ filename: a.filename, content_type: a.content_type, data: a.data }))
+            : null;
         
         // Immediately clear input and disable button
         input.value = '';
+        pendingAttachments = [];
+        renderAttachmentPreview();
         sendBtn.disabled = true;
         sendBtn.textContent = 'Sending...';
         
@@ -874,7 +975,7 @@
         const optimisticMsg = {
             mid: 'pending-' + Date.now(),
             from_id: credentials.id,
-            body: body,
+            body: body || (hasAttachments ? '📎' : ''),
             created_at: new Date().toISOString(),
             pending: true
         };
@@ -884,7 +985,10 @@
         const startTime = performance.now();
         
         try {
-            const result = await DeadropAPI.sendRoomMessage(credentials, currentRoomId, body);
+            const result = await DeadropAPI.sendRoomMessage(
+                credentials, currentRoomId, body || '📎',
+                'text/markdown', null, attachmentsToSend
+            );
             const elapsed = Math.round(performance.now() - startTime);
             console.log(`Room message sent in ${elapsed}ms`);
             
@@ -1200,6 +1304,30 @@
         if (e.key === 'Enter' && !e.shiftKey) {
             e.preventDefault();
             sendRoomMessage();
+        }
+    });
+
+    // Attach button
+    document.getElementById('room-attach-btn').addEventListener('click', () => {
+        document.getElementById('room-file-input').click();
+    });
+    document.getElementById('room-file-input').addEventListener('change', (e) => {
+        for (const file of e.target.files) {
+            addFileToPreview(file);
+        }
+        e.target.value = '';  // Reset so same file can be re-selected
+    });
+
+    // Paste handler for images
+    document.getElementById('room-message-input').addEventListener('paste', (e) => {
+        const items = e.clipboardData?.items;
+        if (!items) return;
+        for (const item of items) {
+            if (item.type.startsWith('image/')) {
+                e.preventDefault();
+                const file = item.getAsFile();
+                if (file) addFileToPreview(file);
+            }
         }
     });
     

--- a/test-env/test_images.py
+++ b/test-env/test_images.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Integration test: send and receive image attachments.
+
+Starts a local deaddrop server, creates a namespace/room, sends a message
+with an image attachment, fetches it back, and verifies the round-trip.
+"""
+
+import base64
+import os
+import struct
+import sys
+import threading
+import time
+import zlib
+
+import httpx
+import uvicorn
+
+# Ensure we use the local source
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+os.environ["DEADROP_ADMIN_TOKEN"] = "test-admin-token"
+os.environ["DEADROP_DB"] = ":memory:"
+
+
+def make_test_png() -> bytes:
+    """Create a 2x2 red/blue PNG for testing."""
+
+    def chunk(ctype, data):
+        c = ctype + data
+        crc = struct.pack(">I", zlib.crc32(c) & 0xFFFFFFFF)
+        return struct.pack(">I", len(data)) + c + crc
+
+    sig = b"\x89PNG\r\n\x1a\n"
+    ihdr = struct.pack(">IIBBBBB", 2, 2, 8, 2, 0, 0, 0)
+    # 2x2 RGB: red, green, blue, white (with filter bytes)
+    scanlines = b"\x00\xff\x00\x00\x00\xff\x00" + b"\x00\x00\x00\xff\xff\xff\xff"
+    idat = zlib.compress(scanlines)
+    return sig + chunk(b"IHDR", ihdr) + chunk(b"IDAT", idat) + chunk(b"IEND", b"")
+
+
+def main():
+    from deadrop.api import app
+
+    # Start server in background thread
+    config = uvicorn.Config(app, host="127.0.0.1", port=18999, log_level="warning")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+
+    # Wait for server to be ready
+    base = "http://127.0.0.1:18999"
+    for _ in range(50):
+        try:
+            httpx.get(f"{base}/health", timeout=1)
+            break
+        except Exception:
+            time.sleep(0.1)
+    else:
+        print("FAIL: Server didn't start")
+        sys.exit(1)
+
+    client = httpx.Client(base_url=base, timeout=10)
+    admin = {"X-Admin-Token": "test-admin-token"}
+
+    # 1. Create namespace
+    ns_resp = client.post("/admin/namespaces", headers=admin).json()
+    ns = ns_resp["ns"]
+    ns_secret = ns_resp["secret"]
+    print(f"✓ Namespace: {ns}")
+
+    # 2. Create identity
+    alice = client.post(
+        f"/{ns}/identities",
+        headers={"X-Namespace-Secret": ns_secret},
+        json={"metadata": {"display_name": "Alice"}},
+    ).json()
+    alice_headers = {"X-Inbox-Secret": alice["secret"]}
+    print(f"✓ Identity: {alice['id'][:8]}")
+
+    # 3. Create room
+    room = client.post(
+        f"/{ns}/rooms",
+        headers=alice_headers,
+        json={"display_name": "Image Test Room"},
+    ).json()
+    room_id = room["room_id"]
+    print(f"✓ Room: {room_id[:8]}")
+
+    # 4. Send message with image attachment
+    png_bytes = make_test_png()
+    png_b64 = base64.b64encode(png_bytes).decode()
+
+    send_resp = client.post(
+        f"/{ns}/rooms/{room_id}/messages",
+        headers=alice_headers,
+        json={
+            "body": "Check out this test image!",
+            "content_type": "text/markdown",
+            "attachments": [
+                {
+                    "filename": "test.png",
+                    "content_type": "image/png",
+                    "data": png_b64,
+                }
+            ],
+        },
+    )
+    assert send_resp.status_code == 200, f"Send failed: {send_resp.text}"
+    msg = send_resp.json()
+    assert msg["attachments"] is not None
+    assert len(msg["attachments"]) == 1
+    att_info = msg["attachments"][0]
+    att_id = att_info["id"]
+    print(f"✓ Sent message with attachment: {att_id[:8]}")
+    print(
+        f"  filename={att_info['filename']}, type={att_info['content_type']}, size={att_info['size']}"
+    )
+
+    # 5. List messages — should include attachment metadata
+    list_resp = client.get(f"/{ns}/rooms/{room_id}/messages", headers=alice_headers)
+    assert list_resp.status_code == 200
+    messages = list_resp.json()["messages"]
+    assert len(messages) == 1
+    assert messages[0]["attachments"] is not None
+    assert len(messages[0]["attachments"]) == 1
+    assert "data" not in messages[0]["attachments"][0]  # No data in list!
+    print("✓ Listed messages — attachment metadata present, data omitted")
+
+    # 6. Fetch full attachment with data
+    fetch_resp = client.get(f"/{ns}/attachments/{att_id}", headers=alice_headers)
+    assert fetch_resp.status_code == 200
+    att_data = fetch_resp.json()
+    assert att_data["data"] == png_b64
+    assert att_data["content_type"] == "image/png"
+    assert att_data["filename"] == "test.png"
+    round_trip_bytes = base64.b64decode(att_data["data"])
+    assert round_trip_bytes == png_bytes
+    print(f"✓ Fetched attachment — data round-trips perfectly ({len(round_trip_bytes)} bytes)")
+
+    # 7. Send message with multiple attachments
+    jpeg_b64 = base64.b64encode(b"\xff\xd8\xff\xe0" + b"\x00" * 50 + b"\xff\xd9").decode()
+    multi_resp = client.post(
+        f"/{ns}/rooms/{room_id}/messages",
+        headers=alice_headers,
+        json={
+            "body": "Multiple files",
+            "attachments": [
+                {"filename": "photo.png", "content_type": "image/png", "data": png_b64},
+                {"filename": "thumb.jpg", "content_type": "image/jpeg", "data": jpeg_b64},
+            ],
+        },
+    )
+    assert multi_resp.status_code == 200
+    assert len(multi_resp.json()["attachments"]) == 2
+    print(f"✓ Multiple attachments work ({len(multi_resp.json()['attachments'])})")
+
+    # 8. Verify Anthropic-compatible shape
+    # This is what harness1 would construct from the attachment
+    anthropic_image_block = {
+        "type": "image",
+        "source": {
+            "type": "base64",
+            "media_type": att_data["content_type"],
+            "data": att_data["data"],
+        },
+    }
+    assert anthropic_image_block["source"]["media_type"] == "image/png"
+    assert len(anthropic_image_block["source"]["data"]) > 0
+    print("✓ Anthropic image block shape validated")
+
+    print("\n🎉 All integration tests passed!")
+    server.should_exit = True
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Stacked on #32 (attachment API).

## Changes

### Compose
- 📎 attach button next to message input
- File picker (`accept=image/*`) for selecting images
- **Clipboard paste** handler — paste screenshots directly into the compose area
- Thumbnail preview strip above compose area with ✕ remove buttons
- Multiple attachments per message

### Display
- Inline image thumbnails in room messages (max 300×260px)
- Click to lazy-load full image via API + open in existing lightbox
- Non-image attachments shown as file pills with size
- `renderAttachments()` integrated into room message rendering

### API (api.js)
- `sendRoomMessage()` now accepts attachments array
- New `getAttachment()` method

### CSS
- `.attachment-preview` strip with thumbnails
- `.message-attachments` for inline images
- `.file-attachment` for non-image files

## Testing
Needs a running deaddrop instance. Will set up a containerized test environment (per Sean's direction).