### PR TITLE
feat: split timed_query timing into conn_acquire vs query_execution

### DIFF
--- a/src/deadrop/api.py
+++ b/src/deadrop/api.py
@@ -214,7 +214,9 @@ async def add_timing_middleware(request: Request, call_next):
 
         # Emit slow-request diagnostic if over threshold
         if duration_ms > slow_threshold_ms:
-            db_total = sum(q["ms"] for q in query_buffer)
+            db_total = sum(q["total_ms"] for q in query_buffer)
+            db_conn_total = sum(q["conn_ms"] for q in query_buffer)
+            db_query_total = sum(q["query_ms"] for q in query_buffer)
             structlog.get_logger("deadrop.access").warning(
                 "slow_request",
                 request_id=request_id,
@@ -225,6 +227,8 @@ async def add_timing_middleware(request: Request, call_next):
                 status=response.status_code,
                 db_queries=query_buffer,
                 db_total_ms=round(db_total, 1),
+                db_conn_ms=round(db_conn_total, 1),
+                db_query_ms=round(db_query_total, 1),
                 overhead_ms=round(duration_ms - db_total, 1),
             )
 

--- a/src/deadrop/db.py
+++ b/src/deadrop/db.py
@@ -38,7 +38,7 @@ from typing import Any, Iterator
 from uuid_extensions import uuid7 as make_uuid7
 
 from .auth import derive_id, generate_secret, hash_secret
-from .metrics import timed_query
+from .metrics import _conn_acquire_ms, timed_query
 
 # Deduplication window in seconds — messages with the same sender,
 # destination, and content hash within this window are considered
@@ -441,10 +441,23 @@ def close_thread_connection():
 
 
 def _get_conn(conn: sqlite3.Connection | None) -> sqlite3.Connection:
-    """Helper to get connection - uses provided conn or falls back to global."""
+    """Helper to get connection - uses provided conn or falls back to global.
+
+    When ``conn`` is None, times the ``get_connection()`` call and accumulates
+    the duration into the ``_conn_acquire_ms`` ContextVar so that
+    :func:`~deadrop.metrics.timed_query` can report conn vs query breakdown.
+    If a connection is provided directly (e.g. test fixtures), there is no
+    acquire cost and we skip the timing.
+    """
     if conn is not None:
         return conn
-    return get_connection()
+    import time as _time
+
+    _t0 = _time.perf_counter()
+    _c = get_connection()
+    _elapsed = (_time.perf_counter() - _t0) * 1000
+    _conn_acquire_ms.set(_conn_acquire_ms.get() + _elapsed)
+    return _c
 
 
 def _execute_with_retry(

--- a/src/deadrop/metrics.py
+++ b/src/deadrop/metrics.py
@@ -25,6 +25,14 @@ _request_query_buffer: contextvars.ContextVar[list[dict] | None] = contextvars.C
     "_request_query_buffer", default=None
 )
 
+# --- Per-call connection-acquire accumulator (ContextVar so it's async-safe) ---
+# Reset at the start of each timed_query call, incremented by get_connection().
+# Allows timed_query to split total_ms into conn_ms + query_ms.
+
+_conn_acquire_ms: contextvars.ContextVar[float] = contextvars.ContextVar(
+    "_conn_acquire_ms", default=0.0
+)
+
 # --- StatsD transport ---
 
 _STATSD_HOST = os.environ.get("STATSD_HOST")
@@ -206,7 +214,16 @@ def timed_query(name: str):
     Emits:
         - statsd timing:  deadrop.db.query.<name>  (ms)
         - statsd counter: deadrop.db.query.<name>.count
-        - DEBUG log:      DB query <name>: <ms>ms
+        - statsd timing:  deadrop.db.conn_acquire.<name>  (ms) — connection-acquire portion
+        - DEBUG log:      DB query <name>: total=<ms>ms conn=<ms>ms query=<ms>ms
+
+    The buffer entry format is::
+
+        {"name": str, "total_ms": float, "conn_ms": float, "query_ms": float}
+
+    where ``conn_ms`` is the time spent in ``get_connection()`` / ``_get_conn()``
+    (accumulated via the ``_conn_acquire_ms`` ContextVar) and ``query_ms`` is
+    the remainder (actual SQL execution + row processing).
 
     Usage::
 
@@ -222,23 +239,43 @@ def timed_query(name: str):
     def decorator(fn):
         @functools.wraps(fn)
         def wrapper(*args, **kwargs):
+            # Reset the conn-acquire accumulator for this call so we get a
+            # clean reading that belongs only to this invocation.
+            _conn_acquire_ms.set(0.0)
             start = time.perf_counter()
             try:
                 return fn(*args, **kwargs)
             finally:
-                elapsed_ms = (time.perf_counter() - start) * 1000
+                total_ms = (time.perf_counter() - start) * 1000
+                conn_ms = _conn_acquire_ms.get()
+                query_ms = max(total_ms - conn_ms, 0.0)
+
                 metric_name = f"query.{name}"
-                statsd_timing(f"db.{metric_name}", elapsed_ms)
+                statsd_timing(f"db.{metric_name}", total_ms)
                 statsd_incr(f"db.{metric_name}.count")
+                statsd_timing(f"db.conn_acquire.{name}", conn_ms)
                 # Also feed into the in-memory metrics (same bucket as record_db_operation)
-                metrics.record_db_operation(f"query.{name}", elapsed_ms)
+                metrics.record_db_operation(f"query.{name}", total_ms)
                 # Append to per-request query buffer if one is active;
                 # otherwise fall back to a plain DEBUG log.
                 buf = _request_query_buffer.get()
                 if buf is not None:
-                    buf.append({"name": name, "ms": elapsed_ms})
+                    buf.append(
+                        {
+                            "name": name,
+                            "total_ms": total_ms,
+                            "conn_ms": conn_ms,
+                            "query_ms": query_ms,
+                        }
+                    )
                 else:
-                    _db_logger.debug("DB query %s: %.1fms", name, elapsed_ms)
+                    _db_logger.debug(
+                        "DB query %s: total=%.1fms conn=%.1fms query=%.1fms",
+                        name,
+                        total_ms,
+                        conn_ms,
+                        query_ms,
+                    )
 
         return wrapper
 

--- a/tests/test_slow_request_diagnostics.py
+++ b/tests/test_slow_request_diagnostics.py
@@ -8,6 +8,9 @@ Covers:
 - Threshold configurable via SLOW_REQUEST_THRESHOLD_MS env var
 - Fast requests do NOT emit slow_request warning
 - Buffer isolation between concurrent requests (ContextVar async-safety)
+- Buffer entry has {name, total_ms, conn_ms, query_ms} breakdown
+- conn_ms reflects time spent in get_connection(); query_ms = total_ms - conn_ms
+- slow_request WARNING includes db_conn_ms and db_query_ms aggregates
 """
 
 import logging
@@ -18,7 +21,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from deadrop.api import app
-from deadrop.metrics import _request_query_buffer, timed_query
+from deadrop.metrics import _conn_acquire_ms, _request_query_buffer, timed_query
 
 
 # ---------------------------------------------------------------------------
@@ -39,7 +42,7 @@ class TestQueryBuffer:
             _request_query_buffer.reset(token)
 
     def test_timed_query_appends_to_active_buffer(self):
-        """When a buffer is installed, timed_query should append to it."""
+        """When a buffer is installed, timed_query should append with timing breakdown."""
         buf: list[dict] = []
         token = _request_query_buffer.set(buf)
         try:
@@ -53,8 +56,17 @@ class TestQueryBuffer:
             assert len(buf) == 1
             entry = buf[0]
             assert entry["name"] == "test_op"
-            assert isinstance(entry["ms"], float)
-            assert entry["ms"] >= 0
+            # New breakdown fields
+            assert isinstance(entry["total_ms"], float)
+            assert isinstance(entry["conn_ms"], float)
+            assert isinstance(entry["query_ms"], float)
+            assert entry["total_ms"] >= 0
+            assert entry["conn_ms"] >= 0
+            assert entry["query_ms"] >= 0
+            # total = conn + query (within float rounding)
+            assert abs(entry["total_ms"] - entry["conn_ms"] - entry["query_ms"]) < 0.01
+            # Legacy "ms" key should be gone
+            assert "ms" not in entry
         finally:
             _request_query_buffer.reset(token)
 
@@ -113,7 +125,11 @@ class TestQueryBuffer:
 
             # Timing should still have been recorded even on exception
             assert len(buf) == 1
-            assert buf[0]["name"] == "failing_op"
+            entry = buf[0]
+            assert entry["name"] == "failing_op"
+            assert "total_ms" in entry
+            assert "conn_ms" in entry
+            assert "query_ms" in entry
         finally:
             _request_query_buffer.reset(token)
 
@@ -141,6 +157,85 @@ class TestQueryBuffer:
         assert len(buf_b) == 1
         assert buf_a[0]["name"] == "shared_name"
         assert buf_b[0]["name"] == "shared_name"
+
+
+class TestConnAcquireTiming:
+    """Unit tests for the conn-acquire breakdown in timed_query."""
+
+    def test_conn_ms_accumulates_from_conn_acquire_var(self):
+        """timed_query reads _conn_acquire_ms and splits it into conn_ms.
+
+        We inject a value that is *smaller* than the total wall-clock time so the
+        query_ms remainder is well-defined and positive.  We do this by sleeping
+        slightly longer than the injected acquire time.
+        """
+        import time as _time
+
+        buf: list[dict] = []
+        token = _request_query_buffer.set(buf)
+        try:
+
+            @timed_query("fake_db_op")
+            def db_op_with_fake_acquire():
+                # Simulate 2ms connection acquire, then "do work" for ~4ms total
+                _conn_acquire_ms.set(2.0)
+                _time.sleep(0.004)  # ensure total_ms >= 2ms so query_ms >= 0
+
+            db_op_with_fake_acquire()
+
+            assert len(buf) == 1
+            entry = buf[0]
+            # conn_ms should exactly match what we injected
+            assert entry["conn_ms"] == pytest.approx(2.0, abs=0.1)
+            # query_ms = max(total_ms - conn_ms, 0) — should be positive
+            assert entry["query_ms"] >= 0.0
+            # total_ms >= conn_ms (sleep guarantees this)
+            assert entry["total_ms"] >= entry["conn_ms"]
+            # round-trip invariant: conn + query == total (within float rounding)
+            assert abs(entry["conn_ms"] + entry["query_ms"] - entry["total_ms"]) < 0.01
+        finally:
+            _request_query_buffer.reset(token)
+
+    def test_conn_ms_reset_between_calls(self):
+        """_conn_acquire_ms is reset to 0.0 at the start of each timed_query call."""
+        buf: list[dict] = []
+        token = _request_query_buffer.set(buf)
+        try:
+
+            @timed_query("op_a")
+            def op_a():
+                _conn_acquire_ms.set(10.0)  # simulate 10ms acquire
+
+            @timed_query("op_b")
+            def op_b():
+                pass  # no acquire time injected → should see 0.0
+
+            op_a()
+            op_b()
+
+            assert buf[0]["conn_ms"] == pytest.approx(10.0, abs=0.1)
+            # op_b gets a fresh 0.0 reset — not leftover from op_a
+            assert buf[1]["conn_ms"] == pytest.approx(0.0, abs=0.1)
+        finally:
+            _request_query_buffer.reset(token)
+
+    def test_conn_ms_zero_when_no_acquire(self):
+        """When get_connection() is not called (conn provided directly), conn_ms stays 0."""
+        buf: list[dict] = []
+        token = _request_query_buffer.set(buf)
+        try:
+
+            @timed_query("direct_conn_op")
+            def noop():
+                # Don't touch _conn_acquire_ms — simulates passing conn= directly
+                pass
+
+            noop()
+
+            entry = buf[0]
+            assert entry["conn_ms"] == pytest.approx(0.0, abs=0.01)
+        finally:
+            _request_query_buffer.reset(token)
 
 
 # ---------------------------------------------------------------------------
@@ -228,10 +323,19 @@ class TestSlowRequestMiddleware:
         assert "duration_ms" in w
         assert "db_queries" in w
         assert "db_total_ms" in w
+        assert "db_conn_ms" in w
+        assert "db_query_ms" in w
         assert "overhead_ms" in w
         assert isinstance(w["db_queries"], list)
+        # Each query entry should have the breakdown fields
+        for q in w["db_queries"]:
+            assert "total_ms" in q, f"query entry missing total_ms: {q}"
+            assert "conn_ms" in q, f"query entry missing conn_ms: {q}"
+            assert "query_ms" in q, f"query entry missing query_ms: {q}"
         # overhead + db_total should approximately equal duration
         assert abs(w["overhead_ms"] + w["db_total_ms"] - w["duration_ms"]) < 1.0
+        # conn + query totals should add up to db_total
+        assert abs(w["db_conn_ms"] + w["db_query_ms"] - w["db_total_ms"]) < 0.1
 
     def test_slow_request_warning_includes_endpoint(self, client, admin_headers):
         """slow_request log must include endpoint and method fields."""


### PR DESCRIPTION
## Summary

Splits the `timed_query` timing breakdown so slow-request diagnostics show **connection-acquire time** separately from **query-execution time**.

## Approach

Adds a `_conn_acquire_ms` ContextVar (async-safe, like `_request_query_buffer`) that acts as a per-call accumulator:

1. **`metrics.py` — `timed_query` decorator**: resets `_conn_acquire_ms` to `0.0` at entry, reads it back in `finally` to compute the split:
   - `conn_ms` = time accumulated in `get_connection()`
   - `query_ms` = `max(total_ms - conn_ms, 0.0)` (actual SQL + row processing)

2. **`db.py` — `_get_conn()`**: when no explicit `conn=` is passed, wraps the `get_connection()` call with `perf_counter` and increments `_conn_acquire_ms`. If a connection is provided directly (test fixtures, `scoped_connection`), no timing is added.

3. **`api.py` — slow-request middleware**: updates the `db_total` sum to use `total_ms`, and adds two new aggregates to the `slow_request` WARNING: `db_conn_ms` and `db_query_ms`.

## Buffer entry format change

```python
# Before
{"name": "send_room_message", "ms": 42.3}

# After
{"name": "send_room_message", "total_ms": 42.3, "conn_ms": 1.1, "query_ms": 41.2}
```

## New statsd metric

`deadrop.db.conn_acquire.<name>` — timer for connection-acquire portion per named operation.

## Slow-request WARNING additions

```
db_total_ms=42.3  db_conn_ms=1.1  db_query_ms=41.2
```

## Tests

- Updated all existing assertions to use `total_ms`/`conn_ms`/`query_ms` field names
- Added `TestConnAcquireTiming` class (3 new tests):
  - `test_conn_ms_accumulates_from_conn_acquire_var` — verifies split is correct when acquire time is injected
  - `test_conn_ms_reset_between_calls` — verifies `_conn_acquire_ms` is reset between `timed_query` calls (no bleed)
  - `test_conn_ms_zero_when_no_acquire` — verifies `conn_ms=0` when no `get_connection()` is called

16/16 tests pass.