### PR TITLE
feat: sub-query timing inside send_room_message + get_room

### DIFF
--- a/src/deadrop/db.py
+++ b/src/deadrop/db.py
@@ -1992,6 +1992,7 @@ def create_room(
     }
 
 
+@timed_query("get_room")
 def get_room(
     room_id: str,
     conn: sqlite3.Connection | None = None,
@@ -2290,6 +2291,8 @@ def send_room_message(
 
     # Check for recent duplicate within the dedup window
     window_start = (now - timedelta(seconds=DEDUP_WINDOW_SECONDS)).isoformat()
+    import time as _t
+    _t0_dedup = _t.perf_counter()
     cursor = conn.execute(
         """SELECT mid, room_id, from_id, body, content_type, reference_mid, created_at
            FROM room_messages
@@ -2299,6 +2302,12 @@ def send_room_message(
         (room_id, from_id, content_hash, window_start),
     )
     existing = _row_to_dict(cursor.description, cursor.fetchone())
+    _dedup_ms = (_t.perf_counter() - _t0_dedup) * 1000
+    from .metrics import _request_query_buffer, statsd_timing
+    statsd_timing("db.send_room_message.dedup_check", _dedup_ms)
+    _buf = _request_query_buffer.get()
+    if _buf is not None:
+        _buf.append({"name": "send_room_message.dedup_check", "ms": _dedup_ms})
     if existing:
         return {
             "mid": existing["mid"],
@@ -2313,6 +2322,7 @@ def send_room_message(
 
     mid = str(make_uuid7())
 
+    _t0_insert = _t.perf_counter()
     conn.execute(
         """INSERT INTO room_messages
                (mid, room_id, from_id, body, content_type, content_hash, reference_mid, created_at)
@@ -2320,6 +2330,11 @@ def send_room_message(
         (mid, room_id, from_id, body, content_type, content_hash, reference_mid, now_iso),
     )
     conn.commit()
+    _insert_ms = (_t.perf_counter() - _t0_insert) * 1000
+    statsd_timing("db.send_room_message.insert_commit", _insert_ms)
+    _buf = _request_query_buffer.get()
+    if _buf is not None:
+        _buf.append({"name": "send_room_message.insert_commit", "ms": _insert_ms})
 
     return {
         "mid": mid,

--- a/src/deadrop/db.py
+++ b/src/deadrop/db.py
@@ -2292,6 +2292,7 @@ def send_room_message(
     # Check for recent duplicate within the dedup window
     window_start = (now - timedelta(seconds=DEDUP_WINDOW_SECONDS)).isoformat()
     import time as _t
+
     _t0_dedup = _t.perf_counter()
     cursor = conn.execute(
         """SELECT mid, room_id, from_id, body, content_type, reference_mid, created_at
@@ -2304,6 +2305,7 @@ def send_room_message(
     existing = _row_to_dict(cursor.description, cursor.fetchone())
     _dedup_ms = (_t.perf_counter() - _t0_dedup) * 1000
     from .metrics import _request_query_buffer, statsd_timing
+
     statsd_timing("db.send_room_message.dedup_check", _dedup_ms)
     _buf = _request_query_buffer.get()
     if _buf is not None:

--- a/tests/test_contextvar_propagation.py
+++ b/tests/test_contextvar_propagation.py
@@ -1,10 +1,11 @@
 """Integration test: ContextVar propagation to DB executor threads."""
 
+import asyncio
+import contextvars
 import os
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
-import structlog
 from fastapi.testclient import TestClient
 
 from deadrop import db
@@ -39,23 +40,6 @@ def test_post_populates_db_queries(client, room_setup):
     original_get = api_mod._get_db_executor
     api_mod._get_db_executor = lambda: custom_executor
 
-    # Capture the slow_request event by patching the middleware's log call
-    captured_events = []
-    original_warning = structlog.get_logger("deadrop.access").warning
-
-    def capture_warning(event, **kw):
-        if event == "slow_request":
-            captured_events.append(kw)
-        return original_warning(event, **kw)
-
-    # Patch at the structlog bound logger level
-    # Actually, simpler: just inspect the _request_query_buffer at the right time
-    # by wrapping the send_room_message function
-    buffer_snapshot = []
-    original_send = (
-        db.send_room_message.__wrapped__ if hasattr(db.send_room_message, "__wrapped__") else None
-    )
-
     try:
         resp = client.post(
             f"/{ns}/rooms/{room['room_id']}/messages",
@@ -67,24 +51,11 @@ def test_post_populates_db_queries(client, room_setup):
         custom_executor.shutdown(wait=False)
 
     assert resp.status_code == 200
-
-    # The definitive check: the query buffer should have been populated
-    # during the request. Since the middleware clears it after logging,
-    # we can't check it directly. But we CAN verify the buffer mechanism
-    # works by checking that the timed_query decorator can READ the buffer.
-    #
-    # Alternative: check the response header for timing (proves middleware ran)
     assert "X-Response-Time-Ms" in resp.headers
-
-    # If we got here without error, the request succeeded through the full stack
-    # including _run_sync with custom executor. The real proof is in prod logs.
 
 
 def test_contextvar_propagation_unit():
     """Unit test: ctx.run propagates ContextVars to custom executor threads."""
-    import asyncio
-    import contextvars
-
     test_var: contextvars.ContextVar[list] = contextvars.ContextVar("test", default=None)
 
     def thread_fn():
@@ -97,8 +68,6 @@ def test_contextvar_propagation_unit():
         test_var.set(buf)
         executor = ThreadPoolExecutor(max_workers=1)
         loop = asyncio.get_event_loop()
-
-        # With ctx.run — buffer should be populated
         ctx = contextvars.copy_context()
         await loop.run_in_executor(executor, ctx.run, thread_fn)
         executor.shutdown(wait=False)
@@ -108,40 +77,13 @@ def test_contextvar_propagation_unit():
     assert result == ["from_thread"], f"ctx.run failed to propagate: {result}"
 
 
-def test_contextvar_not_propagated_without_ctx_run():
-    """Without ctx.run, custom executor threads can't see the ContextVar."""
-    import asyncio
-    import contextvars
-
-    test_var: contextvars.ContextVar[list] = contextvars.ContextVar("test2", default=None)
-
-    def thread_fn():
-        buf = test_var.get()
-        if buf is not None:
-            buf.append("from_thread")
-
-    async def run():
-        buf = []
-        test_var.set(buf)
-        executor = ThreadPoolExecutor(max_workers=1)
-        loop = asyncio.get_event_loop()
-
-        # WITHOUT ctx.run — buffer should NOT be populated (on 3.11)
-        # On 3.12 it might still work, so we test the positive case only
-        await loop.run_in_executor(executor, thread_fn)
-        executor.shutdown(wait=False)
-        return buf
-
-    result = asyncio.run(run())
-    # On Python 3.12, this may or may not propagate (implementation detail)
-    # The important thing is test_contextvar_propagation_unit ALWAYS works
-
-
 def test_buffer_cleaned(client, room_setup):
+    """Buffer is None outside request context."""
     ns = room_setup["ns"]
     alice = room_setup["alice"]
     room = room_setup["room"]
     client.get(
-        f"/{ns}/rooms/{room['room_id']}/messages", headers={"X-Inbox-Secret": alice["secret"]}
+        f"/{ns}/rooms/{room['room_id']}/messages",
+        headers={"X-Inbox-Secret": alice["secret"]},
     )
     assert _request_query_buffer.get() is None


### PR DESCRIPTION
Adds granular timing inside `send_room_message` to break down the 1.5s into its components:

- `get_room` — @timed_query decorator (was undecorated)
- `send_room_message.dedup_check` — the SELECT for dedup window
- `send_room_message.insert_commit` — the INSERT + commit

After this, slow_request logs will show:
```
db_queries=[
  {name: get_room, ms: X},
  {name: is_room_member, ms: X},
  {name: send_room_message.dedup_check, ms: X},
  {name: send_room_message.insert_commit, ms: X},
  {name: send_room_message, ms: TOTAL}
]
```

This tells us exactly whether the INSERT, the dedup SELECT, or the room/member lookups are the bottleneck.