### PR TITLE
fix: wrap _post_deploy_annotation in asyncio.to_thread to unblock startup

### DIFF
--- a/src/deadrop/api.py
+++ b/src/deadrop/api.py
@@ -114,7 +114,10 @@ async def lifespan(app: FastAPI):
     except Exception:
         logger.warning("Cache warming failed on startup", exc_info=True)
 
-    _post_deploy_annotation()
+    # Run in a background thread so urllib.request.urlopen doesn't block the
+    # ASGI event loop during startup. Fire-and-forget: failures are logged but
+    # never surface to callers.
+    asyncio.create_task(asyncio.to_thread(_post_deploy_annotation))
 
     yield
 


### PR DESCRIPTION
## Problem

`_post_deploy_annotation()` was called synchronously from `lifespan()`, blocking the ASGI event loop with `urllib.request.urlopen` + `subprocess.check_output` until Grafana responded. This caused the Apr 27 30+ min outage.

## Fix

Wrap the call in `asyncio.create_task(asyncio.to_thread(_post_deploy_annotation))` so:
- Startup completes immediately
- The annotation posts in a background thread
- Failures are logged but never surface to callers

## Audit

Checked `lifespan()` for other blocking sync I/O (`urlopen`, `requests.`, `subprocess.check_output`) — all other occurrences are inside `_post_deploy_annotation` itself, now safely off the event loop.

Fixes #47