### PR TITLE
fix: debounce executor replace + throttle health checks to prevent runtime hangs

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: uvicorn deadrop.api:app --host 0.0.0.0 --port ${PORT:-8000}
+web: uvicorn deadrop.api:app --host 0.0.0.0 --port ${PORT:-8000} --timeout-graceful-shutdown 300

--- a/src/deadrop/db.py
+++ b/src/deadrop/db.py
@@ -83,6 +83,20 @@ _libsql_lock = threading.Lock()
 LIBSQL_CONNECT_TIMEOUT = 10.0
 LIBSQL_HEALTH_CHECK_TIMEOUT = 5.0
 
+# Minimum seconds between consecutive _replace_db_executor() calls.
+# Under load, many concurrent handlers can time out simultaneously and each
+# independently call _replace_db_executor(), creating N×(read+write) threads
+# in a single burst.  This cooldown ensures only the first call within the
+# window creates new pools; subsequent calls skip the replacement.
+_EXECUTOR_REPLACE_COOLDOWN = 10.0
+_last_executor_replace: float = 0.0
+
+# How often (in seconds) to health-check a thread-local libsql connection.
+# Previously the health check ran on EVERY get_connection() call, adding
+# one Turso round-trip (~100ms) to every DB operation.  Now we only check
+# if the connection is older than this interval, or after an error.
+LIBSQL_HEALTH_CHECK_INTERVAL = 30.0
+
 # Separate read and write executor pools.
 #
 # Reads (SELECT-only) and writes (INSERT/UPDATE/DELETE + commit) are routed to
@@ -188,16 +202,34 @@ def _replace_db_executor():
     Old executors (and their stuck threads) are abandoned — threads are daemons
     so they won't prevent process exit.  Old executors are intentionally NOT
     shut down (that would block waiting for the stuck threads to finish).
+
+    Debounced: if called multiple times within _EXECUTOR_REPLACE_COOLDOWN seconds,
+    only the first call actually replaces the pools.  Under load, many concurrent
+    handlers can time out simultaneously and each call _replace_db_executor(),
+    which would otherwise create N×(read+write) threads in a single burst and
+    overwhelm Turso with simultaneous reconnect attempts.
     """
-    global _read_executor, _write_executor
+    global _read_executor, _write_executor, _last_executor_replace
 
     if not is_using_libsql():
         return  # Only relevant for libsql
 
-    with _executor_lock:
-        from concurrent.futures import ThreadPoolExecutor
+    import logging
+    import time
 
-        import logging
+    now = time.monotonic()
+    with _executor_lock:
+        # Debounce: skip if a replacement already happened recently.
+        if now - _last_executor_replace < _EXECUTOR_REPLACE_COOLDOWN:
+            logging.getLogger(__name__).debug(
+                "Skipping _replace_db_executor — cooldown active "
+                f"({now - _last_executor_replace:.1f}s < {_EXECUTOR_REPLACE_COOLDOWN}s)"
+            )
+            return
+
+        _last_executor_replace = now
+
+        from concurrent.futures import ThreadPoolExecutor
 
         _read_executor = ThreadPoolExecutor(
             max_workers=READ_POOL_SIZE, thread_name_prefix="db-read"
@@ -348,9 +380,21 @@ def get_connection(db_path: str | Path | None = None) -> sqlite3.Connection:
     if db_url.startswith("libsql://"):
         # Check thread-local connection
         if hasattr(_local, "libsql_conn") and _local.libsql_conn is not None:
-            # Health check existing connection
+            # Throttled health check: only ping Turso if the connection hasn't
+            # been checked recently.  Previously we ran SELECT 1 on every
+            # get_connection() call, adding ~100ms overhead to every DB
+            # operation and creating constant Turso traffic that could cascade
+            # into a reconnect storm when all connections expired simultaneously.
+            import time as _time
+
+            last_check = getattr(_local, "libsql_last_health", 0.0)
+            if _time.monotonic() - last_check < LIBSQL_HEALTH_CHECK_INTERVAL:
+                # Connection was recently verified — skip the health check.
+                return cast(sqlite3.Connection, InstrumentedConnection(_local.libsql_conn))
+
             try:
                 _health_check_conn(_local.libsql_conn, timeout=LIBSQL_HEALTH_CHECK_TIMEOUT)
+                _local.libsql_last_health = _time.monotonic()
                 return cast(sqlite3.Connection, InstrumentedConnection(_local.libsql_conn))
             except (TimeoutError, Exception) as e:
                 is_timeout = isinstance(e, TimeoutError)
@@ -374,6 +418,7 @@ def get_connection(db_path: str | Path | None = None) -> sqlite3.Connection:
                     except Exception:
                         pass
                     _local.libsql_conn = None
+                    _local.libsql_last_health = 0.0  # force health check on next connection
                     # Fall through to create new connection
                 else:
                     raise
@@ -391,6 +436,11 @@ def get_connection(db_path: str | Path | None = None) -> sqlite3.Connection:
                 description=f"libsql.connect() on {thread_name}",
             )
             _is_libsql = True
+            # Stamp the connection time so we don't immediately health-check
+            # on the next get_connection() call for this thread.
+            import time as _time
+
+            _local.libsql_last_health = _time.monotonic()
         except TimeoutError:
             logging.error(f"libsql.connect() timed out after {LIBSQL_CONNECT_TIMEOUT}s")
             raise RuntimeError(


### PR DESCRIPTION
Fixes #49 — runtime hangs every ~30-60 minutes.

## Root Cause

Turso Hrana HTTP/2 streams expire after ~30-60 minutes. All executor threads are created at startup within seconds of each other, so their connections expire **simultaneously**. This triggered a cascade:

1. Health check ran on **every `get_connection()` call** — adding ~100ms `SELECT 1` round-trip to every DB operation, and creating constant Turso traffic
2. When streams expired, all 6+4=10 threads hit stale connections at the same time
3. `_run_with_timeout` abandoned threads mid-operation (5s health check timeout)
4. `asyncio.wait_for(15s)` fired for all N concurrent requests simultaneously
5. **`_replace_db_executor()` was called N times** → N×10 new threads all connecting at once
6. Turso overwhelmed with simultaneous reconnects; abandoned threads held partial Tokio state
7. Enough state corruption → process hung (complete silence, nginx 502, requires restart)

The 30-60 minute interval matched the Hrana stream lifetime exactly.

## Changes

### `db.py` — Fix 1: Debounce `_replace_db_executor()`

Added `_EXECUTOR_REPLACE_COOLDOWN = 10.0` seconds. When N concurrent requests all time out simultaneously, only the **first** call to `_replace_db_executor()` within the window creates new pools. Subsequent calls log a debug message and return. This prevents the N×10 thread explosion.

### `db.py` — Fix 2: Throttle health checks

Changed `get_connection()` to only run `SELECT 1` health check if the thread's connection is older than `LIBSQL_HEALTH_CHECK_INTERVAL = 30.0` seconds. Previously it ran on **every** call, adding ~100ms to every DB operation (visible as the high `overhead_ms` values in slow-request logs). After reconnect, stamps the connection time so the next call skips the check immediately.

### `Procfile` — Fix 3: Uvicorn graceful shutdown timeout

Added `--timeout-graceful-shutdown 300` as a safety net — if a future hang occurs, uvicorn will force-kill after 5 minutes rather than hanging indefinitely.

## Impact

- Eliminates per-request `SELECT 1` overhead (~100ms per DB op)  
- Prevents thread explosion under concurrent connection expiry
- `overhead_ms` on simple endpoints should drop from 600-4000ms to near-zero

## Testing

```
tests/test_rooms.py ........ 89 passed
tests/test_events.py
tests/test_subscribe_api.py
```

All existing tests pass. The debounce logic is straightforward and doesn't affect normal operation (the cooldown only activates when multiple concurrent timeouts occur within 10 seconds, which should be rare in non-degraded operation).