### PR TITLE
feat: pluggable instrumentation — MetricsSink protocol + event loop/thread/memory/GC coverage

### DIFF
--- a/src/deadrop/api.py
+++ b/src/deadrop/api.py
@@ -15,7 +15,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field
 
-from . import cache, db
+from . import cache, db, instrument
 from .auth import derive_id
 from .auth_provider import (
     extract_bearer_token,
@@ -114,6 +114,12 @@ async def lifespan(app: FastAPI):
     except Exception:
         logger.warning("Cache warming failed on startup", exc_info=True)
 
+    # Initialise the pluggable metrics sink (reads DEADROP_METRICS_SINK env var)
+    instrument.init_sink()
+
+    # Start background instrumentation tasks (event loop heartbeat + periodic sampler)
+    instrument.start_background_tasks()
+
     # Run in a background thread so urllib.request.urlopen doesn't block the
     # ASGI event loop during startup. Fire-and-forget: failures are logged but
     # never surface to callers.
@@ -163,6 +169,8 @@ async def add_timing_middleware(request: Request, call_next):
     start_time = time.perf_counter()
 
     response = await call_next(request)
+    # NOTE: endpoint label computed below — instrument.request_start/end
+    # are called after we know the endpoint pattern.
 
     duration_ms = (time.perf_counter() - start_time) * 1000
 
@@ -198,6 +206,12 @@ async def add_timing_middleware(request: Request, call_next):
         endpoint = "other"
 
     metrics.record_request(endpoint, duration_ms, status=response.status_code)
+
+    # Also emit to pluggable sink via instrument module
+    instrument.sink.timing("request.duration_ms", duration_ms, tags={"endpoint": endpoint})
+    instrument.sink.counter(
+        "request.status", tags={"status": str(response.status_code), "endpoint": endpoint}
+    )
 
     # Add timing header for debugging
     response.headers["X-Response-Time-Ms"] = f"{duration_ms:.1f}"
@@ -2332,3 +2346,25 @@ def get_metrics(
             "identity_hash": identity_hash_cache.stats(),
         },
     }
+
+
+@app.get("/debug/state")
+def get_debug_state(
+    authorization: Annotated[str | None, Header()] = None,
+    x_admin_token: Annotated[str | None, Header()] = None,
+):
+    """Return a live system-state snapshot.
+
+    Covers event-loop lag, asyncio task counts, thread pools, process RSS,
+    GC generation stats, and active in-flight request details.
+
+    Requires admin authentication (``Authorization: Bearer <admin_token>``
+    or ``X-Admin-Token`` header).
+
+    Enable via environment:
+    - ``DEADROP_METRICS_SINK=logging`` or ``statsd`` or ``prometheus``
+      to also emit these observations to an external backend.
+    - The endpoint is always available regardless of sink setting.
+    """
+    require_admin(authorization, x_admin_token)
+    return instrument.get_debug_state()

--- a/src/deadrop/instrument.py
+++ b/src/deadrop/instrument.py
@@ -1,0 +1,599 @@
+"""Pluggable instrumentation for deadrop.
+
+Provides a generic MetricsSink protocol and multiple backend implementations.
+All instrumentation is no-op by default — enable via environment variable.
+
+Configuration
+-------------
+``DEADROP_METRICS_SINK``
+    Which sink to activate.  Choices: ``null`` (default), ``logging``,
+    ``statsd``, ``prometheus``.
+
+``DEADROP_METRICS_PREFIX``
+    Prefix prepended to every metric name (default: ``deadrop``).
+
+``DEADROP_METRICS_STATSD_HOST``
+    StatsD host (required when sink=statsd).
+
+``DEADROP_METRICS_STATSD_PORT``
+    StatsD UDP port (default: ``8125``).
+
+``DEADROP_DEBUG_STATE_AUTH``
+    Secret token required to access ``/debug/state``.  When unset the
+    endpoint falls back to the existing admin-token check.
+
+Usage
+-----
+All instrumentation code should import the module-level ``sink`` singleton::
+
+    from .instrument import sink
+
+    sink.counter("thing.happened")
+    sink.gauge("queue.depth", len(q))
+
+    with sink.timed("db.query"):
+        ...
+
+The ``sink`` object is always available; when ``DEADROP_METRICS_SINK=null``
+every call is a no-op with essentially zero overhead.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gc
+import logging
+import os
+import socket
+import threading
+import time
+from contextlib import contextmanager
+from typing import Any, Generator, Protocol, runtime_checkable
+
+logger = logging.getLogger("deadrop.instrument")
+
+# ---------------------------------------------------------------------------
+# Protocol — what every sink must implement
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class MetricsSink(Protocol):
+    """Generic metrics emission interface.
+
+    All methods are fire-and-forget; implementations must never raise.
+
+    Tags are optional ``{key: value}`` dicts.  Sinks that don't support
+    tags (e.g. plain statsd) should fold them into the metric name or
+    silently ignore them.
+    """
+
+    def counter(self, name: str, value: int = 1, tags: dict[str, str] | None = None) -> None:
+        """Increment a counter."""
+        ...
+
+    def gauge(self, name: str, value: float, tags: dict[str, str] | None = None) -> None:
+        """Record a point-in-time gauge value."""
+        ...
+
+    def histogram(self, name: str, value: float, tags: dict[str, str] | None = None) -> None:
+        """Record a value in a histogram distribution."""
+        ...
+
+    def timing(self, name: str, value_ms: float, tags: dict[str, str] | None = None) -> None:
+        """Record a duration in milliseconds."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# NullSink — default, zero-overhead no-op
+# ---------------------------------------------------------------------------
+
+
+class NullSink:
+    """No-op sink.  All calls discard their arguments immediately."""
+
+    __slots__ = ()
+
+    def counter(self, name: str, value: int = 1, tags: dict[str, str] | None = None) -> None:  # noqa: D102
+        pass
+
+    def gauge(self, name: str, value: float, tags: dict[str, str] | None = None) -> None:  # noqa: D102
+        pass
+
+    def histogram(self, name: str, value: float, tags: dict[str, str] | None = None) -> None:  # noqa: D102
+        pass
+
+    def timing(self, name: str, value_ms: float, tags: dict[str, str] | None = None) -> None:  # noqa: D102
+        pass
+
+
+# ---------------------------------------------------------------------------
+# LoggingSink — emits to stderr via the standard logging module
+# ---------------------------------------------------------------------------
+
+
+class LoggingSink:
+    """Emits metrics as DEBUG-level log lines.
+
+    Useful for development / smoke-testing without a metrics backend.
+    """
+
+    __slots__ = ("_log", "_prefix")
+
+    def __init__(self, prefix: str = "deadrop") -> None:
+        self._log = logging.getLogger("deadrop.metrics")
+        self._prefix = prefix
+
+    def _n(self, name: str) -> str:
+        return f"{self._prefix}.{name}" if self._prefix else name
+
+    def counter(self, name: str, value: int = 1, tags: dict[str, str] | None = None) -> None:
+        self._log.debug("counter %s=%d tags=%s", self._n(name), value, tags)
+
+    def gauge(self, name: str, value: float, tags: dict[str, str] | None = None) -> None:
+        self._log.debug("gauge   %s=%g tags=%s", self._n(name), value, tags)
+
+    def histogram(self, name: str, value: float, tags: dict[str, str] | None = None) -> None:
+        self._log.debug("hist    %s=%g tags=%s", self._n(name), value, tags)
+
+    def timing(self, name: str, value_ms: float, tags: dict[str, str] | None = None) -> None:
+        self._log.debug("timing  %s=%.1fms tags=%s", self._n(name), value_ms, tags)
+
+
+# ---------------------------------------------------------------------------
+# StatsdSink — UDP push, no third-party deps
+# ---------------------------------------------------------------------------
+
+
+class StatsdSink:
+    """Statsd / DogStatsD UDP sink.
+
+    Supports DogStatsD-style tags when ``dogstatsd=True``.  Falls back to
+    folding tag key=value pairs into the metric name (``metric.k_v``) when
+    ``dogstatsd=False``.
+
+    All socket errors are swallowed — metrics must never break the app.
+    """
+
+    __slots__ = ("_host", "_port", "_prefix", "_dogstatsd", "_sock")
+
+    def __init__(
+        self,
+        host: str,
+        port: int = 8125,
+        prefix: str = "deadrop",
+        dogstatsd: bool = False,
+    ) -> None:
+        self._host = host
+        self._port = port
+        self._prefix = prefix
+        self._dogstatsd = dogstatsd
+        self._sock: socket.socket | None = None
+
+    def _get_sock(self) -> socket.socket | None:
+        if self._sock is None:
+            try:
+                self._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            except Exception:
+                return None
+        return self._sock
+
+    def _tag_suffix(self, tags: dict[str, str] | None) -> str:
+        if not tags:
+            return ""
+        if self._dogstatsd:
+            parts = ",".join(f"{k}:{v}" for k, v in sorted(tags.items()))
+            return f"|#{parts}"
+        # Fold into metric name
+        return "." + ".".join(f"{k}_{v}" for k, v in sorted(tags.items()))
+
+    def _name(self, name: str, tags: dict[str, str] | None) -> str:
+        base = f"{self._prefix}.{name}" if self._prefix else name
+        if self._dogstatsd:
+            return base
+        return base + self._tag_suffix(tags)
+
+    def _send(self, payload: str, tags: dict[str, str] | None = None) -> None:
+        if self._dogstatsd and tags:
+            payload += self._tag_suffix(tags)
+        sock = self._get_sock()
+        if sock is None:
+            return
+        try:
+            sock.sendto(payload.encode(), (self._host, self._port))
+        except Exception:
+            pass
+
+    def counter(self, name: str, value: int = 1, tags: dict[str, str] | None = None) -> None:
+        self._send(f"{self._name(name, tags)}:{value}|c", tags)
+
+    def gauge(self, name: str, value: float, tags: dict[str, str] | None = None) -> None:
+        self._send(f"{self._name(name, tags)}:{value}|g", tags)
+
+    def histogram(self, name: str, value: float, tags: dict[str, str] | None = None) -> None:
+        self._send(f"{self._name(name, tags)}:{value}|h", tags)
+
+    def timing(self, name: str, value_ms: float, tags: dict[str, str] | None = None) -> None:
+        self._send(f"{self._name(name, tags)}:{value_ms:.1f}|ms", tags)
+
+
+# ---------------------------------------------------------------------------
+# PrometheusSink — opt-in /metrics endpoint (requires prometheus_client)
+# ---------------------------------------------------------------------------
+
+
+class PrometheusSink:
+    """Prometheus sink backed by the ``prometheus_client`` library.
+
+    ``prometheus_client`` is an optional dependency.  If it is not installed
+    this sink raises ``ImportError`` at construction time so the error is
+    caught at startup rather than on first metric emit.
+    """
+
+    def __init__(self, prefix: str = "deadrop") -> None:
+        try:
+            import prometheus_client as prom  # type: ignore[import]
+        except ImportError as exc:  # pragma: no cover
+            raise ImportError(
+                "prometheus_client is required for PrometheusSink — "
+                "install it with: pip install prometheus_client"
+            ) from exc
+        self._prom = prom
+        self._prefix = prefix.replace(".", "_").replace("-", "_")
+        self._counters: dict[str, Any] = {}
+        self._gauges: dict[str, Any] = {}
+        self._histograms: dict[str, Any] = {}
+
+    def _safe_name(self, name: str) -> str:
+        return f"{self._prefix}_{name}".replace(".", "_").replace("-", "_")
+
+    def counter(self, name: str, value: int = 1, tags: dict[str, str] | None = None) -> None:
+        sname = self._safe_name(name)
+        if sname not in self._counters:
+            self._counters[sname] = self._prom.Counter(sname, sname)
+        try:
+            self._counters[sname].inc(value)
+        except Exception:
+            pass
+
+    def gauge(self, name: str, value: float, tags: dict[str, str] | None = None) -> None:
+        sname = self._safe_name(name)
+        if sname not in self._gauges:
+            self._gauges[sname] = self._prom.Gauge(sname, sname)
+        try:
+            self._gauges[sname].set(value)
+        except Exception:
+            pass
+
+    def histogram(self, name: str, value: float, tags: dict[str, str] | None = None) -> None:
+        sname = self._safe_name(name)
+        if sname not in self._histograms:
+            self._histograms[sname] = self._prom.Histogram(sname, sname)
+        try:
+            self._histograms[sname].observe(value)
+        except Exception:
+            pass
+
+    def timing(self, name: str, value_ms: float, tags: dict[str, str] | None = None) -> None:
+        self.histogram(name, value_ms / 1000.0, tags)
+
+    def generate_latest(self) -> bytes:  # pragma: no cover
+        """Return Prometheus text format exposition for /metrics."""
+        return self._prom.generate_latest()  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
+# Factory — build sink from environment
+# ---------------------------------------------------------------------------
+
+
+def _build_sink_from_env() -> MetricsSink:  # type: ignore[return]
+    sink_name = os.environ.get("DEADROP_METRICS_SINK", "null").lower().strip()
+    prefix = os.environ.get("DEADROP_METRICS_PREFIX", "deadrop")
+
+    if sink_name == "null":
+        return NullSink()
+
+    if sink_name == "logging":
+        logger.info("Metrics sink: logging (prefix=%s)", prefix)
+        return LoggingSink(prefix=prefix)
+
+    if sink_name == "statsd":
+        host = os.environ.get("DEADROP_METRICS_STATSD_HOST", "")
+        if not host:
+            logger.warning(
+                "DEADROP_METRICS_SINK=statsd but DEADROP_METRICS_STATSD_HOST is unset "
+                "— falling back to null sink"
+            )
+            return NullSink()
+        port = int(os.environ.get("DEADROP_METRICS_STATSD_PORT", "8125"))
+        dogstatsd = os.environ.get("DEADROP_METRICS_DOGSTATSD", "").lower() in ("1", "true", "yes")
+        logger.info(
+            "Metrics sink: statsd %s:%d (dogstatsd=%s, prefix=%s)", host, port, dogstatsd, prefix
+        )
+        return StatsdSink(host=host, port=port, prefix=prefix, dogstatsd=dogstatsd)
+
+    if sink_name in ("prom", "prometheus"):
+        logger.info("Metrics sink: prometheus (prefix=%s)", prefix)
+        return PrometheusSink(prefix=prefix)
+
+    logger.warning("Unknown DEADROP_METRICS_SINK=%r — falling back to null sink", sink_name)
+    return NullSink()
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton — import and use directly
+# ---------------------------------------------------------------------------
+
+#: The active metrics sink.  Import and call it from anywhere.
+sink: MetricsSink = NullSink()  # replaced by init_sink() at app startup
+
+
+def init_sink() -> MetricsSink:
+    """Initialise the module-level ``sink`` from environment variables.
+
+    Called once from ``lifespan()`` in ``api.py``.  Safe to call multiple
+    times — subsequent calls replace the singleton.
+    """
+    global sink
+    sink = _build_sink_from_env()
+    return sink
+
+
+# ---------------------------------------------------------------------------
+# Convenience context manager
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def timed(name: str, tags: dict[str, str] | None = None) -> Generator[None, None, None]:
+    """Context manager that records a timing metric on exit.
+
+    Usage::
+
+        with instrument.timed("db.write"):
+            conn.execute(...)
+    """
+    t0 = time.perf_counter()
+    try:
+        yield
+    finally:
+        sink.timing(name, (time.perf_counter() - t0) * 1000, tags)
+
+
+# ---------------------------------------------------------------------------
+# Background sampler — event loop lag, thread state, memory, GC
+# ---------------------------------------------------------------------------
+
+_SAMPLER_INTERVAL = float(os.environ.get("DEADROP_METRICS_SAMPLE_INTERVAL", "10"))
+
+# Shared state written by the sampler, read by /debug/state
+_sampler_state: dict[str, Any] = {}
+
+
+async def _event_loop_heartbeat(interval: float = 1.0) -> None:
+    """Continuously measure event loop lag.
+
+    Schedules itself every ``interval`` seconds and computes the actual wall
+    time elapsed since the last schedule.  The difference is the event loop
+    lag — how long callbacks were delayed.
+
+    Writes the latest lag to ``_sampler_state`` and emits a gauge.
+    """
+    last = time.perf_counter()
+    while True:
+        await asyncio.sleep(interval)
+        now = time.perf_counter()
+        lag_ms = max(0.0, (now - last - interval) * 1000)
+        last = now
+        sink.gauge("eventloop.lag_ms", lag_ms)
+        _sampler_state["eventloop_lag_ms"] = round(lag_ms, 2)
+
+
+async def _periodic_sampler(interval: float = _SAMPLER_INTERVAL) -> None:
+    """Background task that samples process-wide metrics every ``interval`` seconds.
+
+    Covers:
+    * asyncio task count + long-running tasks (> 30 s)
+    * thread counts (total + per named pool)
+    * process RSS (via /proc/self/status on Linux, fallback to psutil if available)
+    * GC generation counts and stats
+    """
+    long_task_threshold = float(os.environ.get("DEADROP_LONG_TASK_THRESHOLD", "30"))
+
+    while True:
+        await asyncio.sleep(interval)
+        try:
+            _sample_tasks(long_task_threshold)
+            _sample_threads()
+            _sample_memory()
+            _sample_gc()
+        except Exception:
+            logger.debug("Sampler tick error", exc_info=True)
+
+
+def _sample_tasks(long_task_threshold: float) -> None:
+    loop = asyncio.get_event_loop()
+    all_tasks = asyncio.all_tasks(loop)
+    pending = len(all_tasks)
+    sink.gauge("asyncio.pending_tasks", pending)
+    _sampler_state["asyncio_pending_tasks"] = pending
+
+    long_running = []
+    now = loop.time()
+    for t in all_tasks:
+        # asyncio.Task stores _started in Python >= 3.12; use private attr with fallback
+        started = getattr(t, "_started", None) or getattr(t, "_loop_start", None)
+        if started is not None:
+            age = now - started
+            if age > long_task_threshold:
+                coro_name = getattr(t.get_coro(), "__qualname__", str(t))
+                long_running.append({"name": coro_name, "age_s": round(age, 1)})
+    sink.gauge("asyncio.long_tasks", len(long_running))
+    _sampler_state["asyncio_long_tasks"] = long_running
+
+
+def _sample_threads() -> None:
+    all_threads = threading.enumerate()
+    total = len(all_threads)
+    sink.gauge("threads.total", total)
+    _sampler_state["threads_total"] = total
+
+    # Count per named pool (FastAPI/Starlette use "ThreadPoolExecutor-N_M" names)
+    pool_counts: dict[str, int] = {}
+    for t in all_threads:
+        name = t.name or ""
+        if "ThreadPoolExecutor" in name:
+            # Extract pool index before the underscore separator
+            parts = name.split("_")
+            pool_key = parts[0] if parts else name
+            pool_counts[pool_key] = pool_counts.get(pool_key, 0) + 1
+    sink.gauge("threads.pools", len(pool_counts))
+    _sampler_state["thread_pools"] = pool_counts
+
+
+def _sample_memory() -> None:
+    rss_kb: int | None = None
+    # Fast path: Linux /proc
+    try:
+        with open("/proc/self/status") as f:
+            for line in f:
+                if line.startswith("VmRSS:"):
+                    rss_kb = int(line.split()[1])
+                    break
+    except OSError:
+        pass
+
+    if rss_kb is None:
+        # Fallback: psutil (optional)
+        try:
+            import psutil  # type: ignore[import]
+
+            proc = psutil.Process()
+            rss_kb = proc.memory_info().rss // 1024
+        except Exception:
+            pass
+
+    if rss_kb is not None:
+        sink.gauge("process.rss_kb", rss_kb)
+        _sampler_state["process_rss_kb"] = rss_kb
+
+
+def _sample_gc() -> None:
+    counts = gc.get_count()  # (gen0, gen1, gen2)
+    for i, c in enumerate(counts):
+        sink.gauge(f"gc.gen{i}_count", c)
+    _sampler_state["gc_counts"] = {"gen0": counts[0], "gen1": counts[1], "gen2": counts[2]}
+
+    stats = gc.get_stats()  # list of dicts per generation
+    gc_stats_out = []
+    for i, s in enumerate(stats):
+        gc_stats_out.append(
+            {
+                "gen": i,
+                "collections": s.get("collections", 0),
+                "collected": s.get("collected", 0),
+                "uncollectable": s.get("uncollectable", 0),
+            }
+        )
+    _sampler_state["gc_stats"] = gc_stats_out
+
+
+# ---------------------------------------------------------------------------
+# Active request tracking (written by middleware in api.py)
+# ---------------------------------------------------------------------------
+
+# {endpoint: count}  — updated atomically by the middleware
+_active_requests: dict[str, int] = {}
+_active_requests_lock = threading.Lock()
+
+# Running list of (start_time, endpoint) for in-flight requests
+_inflight: list[tuple[float, str]] = []
+_inflight_lock = threading.Lock()
+
+
+def request_start(endpoint: str) -> float:
+    """Record a request starting.  Returns the start timestamp."""
+    t = time.perf_counter()
+    with _active_requests_lock:
+        _active_requests[endpoint] = _active_requests.get(endpoint, 0) + 1
+    with _inflight_lock:
+        _inflight.append((t, endpoint))
+    sink.counter("request.started", tags={"endpoint": endpoint})
+    return t
+
+
+def request_end(endpoint: str, start_t: float, status: int) -> None:
+    """Record a request finishing."""
+    duration_ms = (time.perf_counter() - start_t) * 1000
+    with _active_requests_lock:
+        _active_requests[endpoint] = max(0, _active_requests.get(endpoint, 1) - 1)
+    with _inflight_lock:
+        try:
+            _inflight.remove((start_t, endpoint))
+        except ValueError:
+            pass
+    sink.timing("request.duration_ms", duration_ms, tags={"endpoint": endpoint})
+    sink.counter("request.completed", tags={"endpoint": endpoint, "status": str(status)})
+
+
+def get_active_requests_snapshot() -> dict[str, Any]:
+    """Return a snapshot of active/in-flight request state for /debug/state."""
+    now = time.perf_counter()
+    with _active_requests_lock:
+        active = dict(_active_requests)
+    with _inflight_lock:
+        inflight_snap = list(_inflight)
+
+    longest = 0.0
+    inflight_detail = []
+    for start_t, ep in inflight_snap:
+        age_ms = (now - start_t) * 1000
+        longest = max(longest, age_ms)
+        inflight_detail.append({"endpoint": ep, "age_ms": round(age_ms, 1)})
+
+    return {
+        "active_by_endpoint": active,
+        "total_active": sum(active.values()),
+        "longest_active_ms": round(longest, 1),
+        "inflight": inflight_detail,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Full debug state snapshot (for /debug/state endpoint)
+# ---------------------------------------------------------------------------
+
+
+def get_debug_state() -> dict[str, Any]:
+    """Return a full system state snapshot as a plain dict.
+
+    Combines:
+    * Sampler state (event loop lag, threads, memory, GC)
+    * Active request state
+    * Current time / uptime
+    """
+    return {
+        "timestamp": time.time(),
+        "sampler": dict(_sampler_state),
+        "requests": get_active_requests_snapshot(),
+        "sink": type(sink).__name__,
+        "sample_interval_s": _SAMPLER_INTERVAL,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Startup helper — called from lifespan
+# ---------------------------------------------------------------------------
+
+
+def start_background_tasks() -> None:
+    """Schedule background instrumentation tasks on the running event loop.
+
+    Must be called from within a running async context (i.e. inside
+    ``lifespan``).
+    """
+    asyncio.create_task(_event_loop_heartbeat(), name="instrument.heartbeat")
+    asyncio.create_task(_periodic_sampler(), name="instrument.sampler")
+    logger.debug("Instrumentation background tasks started (sink=%s)", type(sink).__name__)

--- a/src/deadrop/metrics.py
+++ b/src/deadrop/metrics.py
@@ -1,79 +1,90 @@
-"""Lightweight statsd + in-memory metrics for deadrop.
+"""Metrics layer for deadrop.
 
-Configurable via environment variables:
-    STATSD_HOST: StatsD host (default: None = no-op for statsd)
-    STATSD_PORT: StatsD port (default: 8125)
-    STATSD_PREFIX: Metric prefix (default: deadrop)
+This module is the **internal** metrics API used by db.py, api.py, cache.py,
+and the instrumentation middleware.  It wraps the pluggable
+:mod:`~deadrop.instrument` sink so that all call sites continue to work
+unchanged while the underlying transport is configurable at runtime.
 
-When STATSD_HOST is not set, statsd calls are no-ops.
-In-memory metrics (for /admin/metrics endpoint) are always collected.
+Legacy statsd helpers (``statsd_incr``, ``statsd_gauge``, ``statsd_timing``)
+are preserved for backward compatibility but now forward to the active
+``instrument.sink``.
+
+For new instrumentation code, import ``instrument.sink`` directly.
+
+Per-request query buffer
+-------------------------
+``_request_query_buffer`` is a :class:`~contextvars.ContextVar` that
+:class:`InstrumentedConnection` and :func:`timed_query` append to.  The
+middleware in ``api.py`` installs a fresh list at request start and reads it
+at request end for slow-request diagnostics.
 """
+
+from __future__ import annotations
 
 import contextvars
 import functools
-import sqlite3 as _sqlite3
 import logging as _logging
-import os
-import socket
+import sqlite3 as _sqlite3
 import time
 from collections import defaultdict
 from contextlib import contextmanager
 from typing import Generator
 
-# --- Per-request query buffer (ContextVar so it's async-safe) ---
+from . import instrument
+
+# Re-export for convenience (existing ``from .metrics import metrics`` still works)
+__all__ = [
+    "metrics",
+    "timed_db_operation",
+    "timed_query",
+    "InstrumentedConnection",
+    "_request_query_buffer",
+    # legacy helpers
+    "statsd_incr",
+    "statsd_gauge",
+    "statsd_timing",
+]
+
+# ---------------------------------------------------------------------------
+# Per-request query buffer (ContextVar — async-safe)
+# ---------------------------------------------------------------------------
 
 _request_query_buffer: contextvars.ContextVar[list[dict] | None] = contextvars.ContextVar(
     "_request_query_buffer", default=None
 )
 
-# --- StatsD transport ---
-
-_STATSD_HOST = os.environ.get("STATSD_HOST")
-_STATSD_PORT = int(os.environ.get("STATSD_PORT", "8125"))
-_PREFIX = os.environ.get("STATSD_PREFIX", "deadrop")
-_sock: socket.socket | None = None
-
-
-def _get_sock() -> socket.socket | None:
-    global _sock
-    if _STATSD_HOST is None:
-        return None
-    if _sock is None:
-        _sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    return _sock
-
-
-def _statsd_send(metric: str, value: str, metric_type: str, sample_rate: float = 1.0) -> None:
-    sock = _get_sock()
-    if sock is None:
-        return
-    try:
-        key = f"{_PREFIX}.{metric}" if _PREFIX else metric
-        payload = f"{key}:{value}|{metric_type}"
-        if sample_rate < 1.0:
-            payload += f"|@{sample_rate}"
-        sock.sendto(payload.encode(), (_STATSD_HOST, _STATSD_PORT))
-    except Exception:
-        pass
+# ---------------------------------------------------------------------------
+# Legacy statsd helpers — now forward to instrument.sink
+# ---------------------------------------------------------------------------
 
 
 def statsd_incr(metric: str, count: int = 1) -> None:
-    _statsd_send(metric, str(count), "c")
+    """Increment a counter via the active metrics sink."""
+    instrument.sink.counter(metric, count)
 
 
 def statsd_gauge(metric: str, value: int | float) -> None:
-    _statsd_send(metric, str(value), "g")
+    """Record a gauge via the active metrics sink."""
+    instrument.sink.gauge(metric, float(value))
 
 
 def statsd_timing(metric: str, ms: float) -> None:
-    _statsd_send(metric, f"{ms:.1f}", "ms")
+    """Record a timing (ms) via the active metrics sink."""
+    instrument.sink.timing(metric, ms)
 
 
-# --- In-memory metrics (always active) ---
+# ---------------------------------------------------------------------------
+# In-memory Metrics collector (always active — powers /metrics endpoint)
+# ---------------------------------------------------------------------------
 
 
 class Metrics:
-    """Thread-safe in-memory metrics collector + statsd emitter."""
+    """Thread-safe in-memory metrics collector.
+
+    Aggregates counters and timing histograms in memory for the ``/metrics``
+    admin endpoint.  Also forwards every observation to ``instrument.sink``
+    so that whichever external backend is configured receives it too.
+    """
 
     def __init__(self) -> None:
         self._request_counts: dict[str, int] = defaultdict(int)
@@ -89,67 +100,65 @@ class Metrics:
     def record_request(self, endpoint: str, duration_ms: float, status: int = 200) -> None:
         self._request_counts[endpoint] += 1
         self._request_durations[endpoint].append(duration_ms)
-        # Keep only last 1000 durations per endpoint
         if len(self._request_durations[endpoint]) > 1000:
             self._request_durations[endpoint] = self._request_durations[endpoint][-500:]
         self._status_counts[f"{status}"] += 1
 
-        # StatsD
-        statsd_timing(f"request.{endpoint}", duration_ms)
-        statsd_incr(f"request.{endpoint}.count")
-        statsd_incr(f"response.{status}")
+        instrument.sink.timing("request.duration_ms", duration_ms, tags={"endpoint": endpoint})
+        instrument.sink.counter("request.count", tags={"endpoint": endpoint})
+        instrument.sink.counter("response.status", tags={"status": str(status)})
 
     def record_cache_hit(self, cache_name: str) -> None:
         self._cache_hits[cache_name] += 1
-        statsd_incr(f"cache.{cache_name}.hit")
+        instrument.sink.counter("cache.hit", tags={"cache": cache_name})
 
     def record_cache_miss(self, cache_name: str) -> None:
         self._cache_misses[cache_name] += 1
-        statsd_incr(f"cache.{cache_name}.miss")
+        instrument.sink.counter("cache.miss", tags={"cache": cache_name})
 
     def record_db_operation(self, operation: str, duration_ms: float) -> None:
         self._db_operation_counts[operation] += 1
         self._db_operation_durations[operation].append(duration_ms)
         if len(self._db_operation_durations[operation]) > 1000:
             self._db_operation_durations[operation] = self._db_operation_durations[operation][-500:]
-        statsd_timing(f"db.{operation}", duration_ms)
+        instrument.sink.timing("db.operation_ms", duration_ms, tags={"op": operation})
 
     def incr(self, key: str, count: int = 1) -> None:
         self._counters[key] += count
-        statsd_incr(key, count)
+        instrument.sink.counter(key, count)
 
     def gauge(self, key: str, value: int | float) -> None:
-        statsd_gauge(key, value)
+        instrument.sink.gauge(key, float(value))
 
     def to_dict(self) -> dict:
-        """Export metrics for the /admin/metrics endpoint."""
+        """Export aggregated metrics as a plain dict for the /metrics endpoint."""
 
-        def _summarize_durations(durations: list[float]) -> dict:
+        def _summarize(durations: list[float]) -> dict:
             if not durations:
                 return {"count": 0}
-            sorted_d = sorted(durations)
-            n = len(sorted_d)
+            s = sorted(durations)
+            n = len(s)
             return {
                 "count": n,
-                "avg_ms": round(sum(sorted_d) / n, 1),
-                "p50_ms": round(sorted_d[n // 2], 1),
-                "p95_ms": round(sorted_d[int(n * 0.95)], 1) if n >= 20 else None,
-                "p99_ms": round(sorted_d[int(n * 0.99)], 1) if n >= 100 else None,
-                "max_ms": round(sorted_d[-1], 1),
+                "avg_ms": round(sum(s) / n, 1),
+                "p50_ms": round(s[n // 2], 1),
+                "p95_ms": round(s[int(n * 0.95)], 1) if n >= 20 else None,
+                "p99_ms": round(s[int(n * 0.99)], 1) if n >= 100 else None,
+                "max_ms": round(s[-1], 1),
             }
 
         result: dict = {
             "uptime_seconds": round(time.time() - self._start_time),
-            "statsd_enabled": _STATSD_HOST is not None,
+            "metrics_sink": type(instrument.sink).__name__,
         }
 
         if self._request_counts:
             result["requests"] = {
-                endpoint: {
-                    "count": self._request_counts[endpoint],
-                    **_summarize_durations(self._request_durations.get(endpoint, [])),
+                ep: {
+                    "count": self._request_counts[ep],
+                    **_summarize(self._request_durations.get(ep, [])),
                 }
-                for endpoint in sorted(self._request_counts)
+                for ep in sorted(self._request_counts)
             }
 
         if self._status_counts:
@@ -172,7 +181,7 @@ class Metrics:
             result["db_operations"] = {
                 op: {
                     "count": self._db_operation_counts[op],
-                    **_summarize_durations(self._db_operation_durations.get(op, [])),
+                    **_summarize(self._db_operation_durations.get(op, [])),
                 }
                 for op in sorted(self._db_operation_counts)
             }
@@ -183,13 +192,18 @@ class Metrics:
         return result
 
 
-# Singleton
+# Singleton used throughout the codebase
 metrics = Metrics()
+
+
+# ---------------------------------------------------------------------------
+# Context manager helpers
+# ---------------------------------------------------------------------------
 
 
 @contextmanager
 def timed_db_operation(operation: str) -> Generator[None, None, None]:
-    """Context manager to time a DB operation and record metrics."""
+    """Time a DB operation and emit metrics on exit."""
     start = time.perf_counter()
     try:
         yield
@@ -198,26 +212,24 @@ def timed_db_operation(operation: str) -> Generator[None, None, None]:
         metrics.record_db_operation(operation, elapsed_ms)
 
 
+# ---------------------------------------------------------------------------
+# timed_query decorator
+# ---------------------------------------------------------------------------
+
 _db_logger = _logging.getLogger("deadrop.db")
 
 
 def timed_query(name: str):
-    """Decorator that wraps a DB function with per-query timing.
+    """Decorator: wraps a DB function with per-query timing.
 
-    Emits:
-        - statsd timing:  deadrop.db.query.<name>  (ms)
-        - statsd counter: deadrop.db.query.<name>.count
-        - DEBUG log:      DB query <name>: <ms>ms
+    Emits timing via the active ``instrument.sink`` and appends to the
+    per-request query buffer when one is active.
 
     Usage::
 
         @timed_query("send_room_message")
         def send_room_message(...):
             ...
-
-    The decorator is transparent — it preserves the function's signature,
-    return value, and exceptions.  statsd is fire-and-forget UDP so there
-    is no meaningful overhead.
     """
 
     def decorator(fn):
@@ -228,13 +240,7 @@ def timed_query(name: str):
                 return fn(*args, **kwargs)
             finally:
                 elapsed_ms = (time.perf_counter() - start) * 1000
-                metric_name = f"query.{name}"
-                statsd_timing(f"db.{metric_name}", elapsed_ms)
-                statsd_incr(f"db.{metric_name}.count")
-                # Also feed into the in-memory metrics (same bucket as record_db_operation)
                 metrics.record_db_operation(f"query.{name}", elapsed_ms)
-                # Append to per-request query buffer if one is active;
-                # otherwise fall back to a plain DEBUG log.
                 buf = _request_query_buffer.get()
                 if buf is not None:
                     buf.append({"name": name, "ms": elapsed_ms})
@@ -247,27 +253,20 @@ def timed_query(name: str):
 
 
 # ---------------------------------------------------------------------------
-# Per-SQL-statement instrumentation
+# Per-SQL-statement instrumentation helpers
 # ---------------------------------------------------------------------------
 
 
 def _record_query(name: str, ms: float) -> None:
-    """Emit a per-SQL-statement timing to statsd + the per-request query buffer.
-
-    This is the single funnel for ``InstrumentedConnection`` timing data.
-
-    Args:
-        name: Short name for the query, e.g. ``"select.room_messages"``.
-        ms:   Elapsed time in milliseconds.
-    """
-    statsd_timing(f"db.sql.{name}", ms)
+    """Emit a per-SQL timing to sink + per-request query buffer."""
+    instrument.sink.timing("db.sql_ms", ms, tags={"query": name})
     buf = _request_query_buffer.get()
     if buf is not None:
         buf.append({"name": name, "ms": ms})
 
 
 # ---------------------------------------------------------------------------
-# InstrumentedConnection -- auto-times every execute() / commit()
+# InstrumentedConnection — transparent proxy with auto-timing
 # ---------------------------------------------------------------------------
 
 
@@ -281,30 +280,20 @@ class InstrumentedConnection:
     All other attributes/methods are forwarded to the underlying connection
     unchanged via ``__getattr__``, so ``row_factory``, ``executescript``,
     ``close``, cursor properties, etc. all work transparently.
-
-    Usage::
-
-        raw_conn = sqlite3.connect(...)
-        conn = InstrumentedConnection(raw_conn)
-        # All DAO code uses conn.execute() as normal -- timing is automatic.
     """
 
     _conn: _sqlite3.Connection
     __slots__ = ("_conn",)
 
     def __init__(self, conn: _sqlite3.Connection) -> None:
-        # Use object.__setattr__ to avoid triggering our own __setattr__
         object.__setattr__(self, "_conn", conn)
-
-    # -- Core instrumented methods --
 
     def execute(self, sql: str, params=(), *, name: str = "unnamed") -> _sqlite3.Cursor:
         t0 = time.perf_counter()
         try:
             result = self._conn.execute(sql, params)
         finally:
-            ms = (time.perf_counter() - t0) * 1000
-            _record_query(name, ms)
+            _record_query(name, (time.perf_counter() - t0) * 1000)
         return result
 
     def commit(self) -> None:
@@ -312,10 +301,7 @@ class InstrumentedConnection:
         try:
             self._conn.commit()
         finally:
-            ms = (time.perf_counter() - t0) * 1000
-            _record_query("commit", ms)
-
-    # -- Transparent proxy for everything else --
+            _record_query("commit", (time.perf_counter() - t0) * 1000)
 
     def __getattr__(self, name: str) -> object:  # noqa: ANN401
         return getattr(object.__getattribute__(self, "_conn"), name)

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -1,0 +1,411 @@
+"""Tests for the pluggable instrumentation module (deadrop.instrument).
+
+Covers:
+- NullSink: all methods are no-ops, never raise
+- LoggingSink: emits DEBUG-level log lines
+- StatsdSink: sends correct UDP payloads (mocked socket)
+- Factory: _build_sink_from_env returns correct sink for each DEADROP_METRICS_SINK value
+- init_sink: replaces module-level singleton
+- timed(): context manager records timing to sink
+- get_debug_state(): returns expected keys
+- request_start / request_end: update _active_requests and _inflight
+- get_active_requests_snapshot: returns sane structure
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deadrop import instrument
+from deadrop.instrument import (
+    LoggingSink,
+    MetricsSink,
+    NullSink,
+    StatsdSink,
+    _build_sink_from_env,
+    get_active_requests_snapshot,
+    get_debug_state,
+    init_sink,
+    request_end,
+    request_start,
+    timed,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class RecordingSink:
+    """Test sink that records all calls."""
+
+    def __init__(self):
+        self.calls: list[tuple[str, str, Any, dict | None]] = []
+
+    def counter(self, name, value=1, tags=None):
+        self.calls.append(("counter", name, value, tags))
+
+    def gauge(self, name, value, tags=None):
+        self.calls.append(("gauge", name, value, tags))
+
+    def histogram(self, name, value, tags=None):
+        self.calls.append(("histogram", name, value, tags))
+
+    def timing(self, name, value_ms, tags=None):
+        self.calls.append(("timing", name, value_ms, tags))
+
+    def of_type(self, method: str) -> list[tuple]:
+        return [c for c in self.calls if c[0] == method]
+
+
+@contextmanager
+def swap_sink(new_sink):
+    """Context manager: temporarily replace instrument.sink."""
+    original = instrument.sink
+    instrument.sink = new_sink
+    try:
+        yield new_sink
+    finally:
+        instrument.sink = original
+
+
+# ---------------------------------------------------------------------------
+# NullSink
+# ---------------------------------------------------------------------------
+
+
+class TestNullSink:
+    def setup_method(self):
+        self.sink = NullSink()
+
+    def test_counter_no_raise(self):
+        self.sink.counter("foo", 5, tags={"k": "v"})
+
+    def test_gauge_no_raise(self):
+        self.sink.gauge("bar", 3.14)
+
+    def test_histogram_no_raise(self):
+        self.sink.histogram("baz", 42.0)
+
+    def test_timing_no_raise(self):
+        self.sink.timing("qux", 123.4)
+
+    def test_implements_protocol(self):
+        assert isinstance(self.sink, MetricsSink)
+
+
+# ---------------------------------------------------------------------------
+# LoggingSink
+# ---------------------------------------------------------------------------
+
+
+class TestLoggingSink:
+    def test_counter_logs_debug(self, caplog):
+        import logging
+
+        sink = LoggingSink(prefix="test")
+        with caplog.at_level(logging.DEBUG, logger="deadrop.metrics"):
+            sink.counter("things.happened", 3)
+        assert any(
+            "counter" in r.message and "things.happened" in r.message for r in caplog.records
+        )
+
+    def test_gauge_logs_debug(self, caplog):
+        import logging
+
+        sink = LoggingSink(prefix="test")
+        with caplog.at_level(logging.DEBUG, logger="deadrop.metrics"):
+            sink.gauge("queue.depth", 7.0)
+        assert any("gauge" in r.message and "queue.depth" in r.message for r in caplog.records)
+
+    def test_timing_logs_debug(self, caplog):
+        import logging
+
+        sink = LoggingSink(prefix="test")
+        with caplog.at_level(logging.DEBUG, logger="deadrop.metrics"):
+            sink.timing("db.query", 55.5)
+        assert any("timing" in r.message and "db.query" in r.message for r in caplog.records)
+
+    def test_prefix_applied(self, caplog):
+        import logging
+
+        sink = LoggingSink(prefix="myapp")
+        with caplog.at_level(logging.DEBUG, logger="deadrop.metrics"):
+            sink.counter("events", 1)
+        assert any("myapp.events" in r.message for r in caplog.records)
+
+    def test_implements_protocol(self):
+        assert isinstance(LoggingSink(), MetricsSink)
+
+
+# ---------------------------------------------------------------------------
+# StatsdSink
+# ---------------------------------------------------------------------------
+
+
+class TestStatsdSink:
+    def _make_sink(self, **kwargs) -> tuple[StatsdSink, MagicMock]:
+        sink = StatsdSink(host="localhost", port=9999, **kwargs)
+        mock_sock = MagicMock(spec=socket.socket)
+        # Inject the mock socket
+        object.__setattr__(sink, "_sock", mock_sock)
+        return sink, mock_sock
+
+    def _sent_payload(self, mock_sock: MagicMock) -> str:
+        args, kwargs = mock_sock.sendto.call_args
+        return args[0].decode()
+
+    def test_counter_sends_correct_payload(self):
+        sink, sock = self._make_sink(prefix="app")
+        sink.counter("foo.bar", 2)
+        payload = self._sent_payload(sock)
+        assert payload == "app.foo.bar:2|c"
+
+    def test_gauge_sends_correct_payload(self):
+        sink, sock = self._make_sink(prefix="app")
+        sink.gauge("mem.rss", 1234.5)
+        payload = self._sent_payload(sock)
+        assert payload == "app.mem.rss:1234.5|g"
+
+    def test_timing_sends_correct_payload(self):
+        sink, sock = self._make_sink(prefix="app")
+        sink.timing("req.duration", 42.7)
+        payload = self._sent_payload(sock)
+        assert payload == "app.req.duration:42.7|ms"
+
+    def test_histogram_sends_correct_payload(self):
+        sink, sock = self._make_sink(prefix="app")
+        sink.histogram("latency", 100.0)
+        payload = self._sent_payload(sock)
+        assert payload == "app.latency:100.0|h"
+
+    def test_tags_folded_into_name(self):
+        sink, sock = self._make_sink(prefix="app", dogstatsd=False)
+        sink.counter("req", 1, tags={"endpoint": "health", "status": "200"})
+        payload = self._sent_payload(sock)
+        # Tags folded alphabetically: endpoint_health.status_200
+        assert "endpoint_health" in payload
+        assert "status_200" in payload
+
+    def test_dogstatsd_tags_appended(self):
+        sink, sock = self._make_sink(prefix="app", dogstatsd=True)
+        sink.counter("req", 1, tags={"endpoint": "health"})
+        payload = self._sent_payload(sock)
+        assert "|#endpoint:health" in payload
+
+    def test_socket_error_swallowed(self):
+        sink, sock = self._make_sink(prefix="app")
+        sock.sendto.side_effect = OSError("unreachable")
+        sink.counter("foo", 1)  # should not raise
+
+    def test_no_prefix(self):
+        sink, sock = self._make_sink(prefix="")
+        sink.counter("bare.metric", 1)
+        payload = self._sent_payload(sock)
+        assert payload == "bare.metric:1|c"
+
+    def test_implements_protocol(self):
+        assert isinstance(StatsdSink(host="localhost"), MetricsSink)
+
+
+# ---------------------------------------------------------------------------
+# Factory: _build_sink_from_env
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSinkFromEnv:
+    def test_default_is_null(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("DEADROP_METRICS_SINK", None)
+            s = _build_sink_from_env()
+        assert isinstance(s, NullSink)
+
+    def test_null_explicit(self):
+        with patch.dict(os.environ, {"DEADROP_METRICS_SINK": "null"}):
+            s = _build_sink_from_env()
+        assert isinstance(s, NullSink)
+
+    def test_logging_sink(self):
+        with patch.dict(os.environ, {"DEADROP_METRICS_SINK": "logging"}):
+            s = _build_sink_from_env()
+        assert isinstance(s, LoggingSink)
+
+    def test_statsd_sink(self):
+        with patch.dict(
+            os.environ,
+            {"DEADROP_METRICS_SINK": "statsd", "DEADROP_METRICS_STATSD_HOST": "localhost"},
+        ):
+            s = _build_sink_from_env()
+        assert isinstance(s, StatsdSink)
+
+    def test_statsd_without_host_falls_back_to_null(self):
+        env = {"DEADROP_METRICS_SINK": "statsd"}
+        env_clean = {k: v for k, v in os.environ.items() if k != "DEADROP_METRICS_STATSD_HOST"}
+        with patch.dict(env_clean, env, clear=True):
+            s = _build_sink_from_env()
+        assert isinstance(s, NullSink)
+
+    def test_unknown_sink_falls_back_to_null(self):
+        with patch.dict(os.environ, {"DEADROP_METRICS_SINK": "xyzzy"}):
+            s = _build_sink_from_env()
+        assert isinstance(s, NullSink)
+
+    def test_prefix_applied_to_logging_sink(self):
+        with patch.dict(
+            os.environ,
+            {"DEADROP_METRICS_SINK": "logging", "DEADROP_METRICS_PREFIX": "myapp"},
+        ):
+            s = _build_sink_from_env()
+        assert isinstance(s, LoggingSink)
+        assert s._prefix == "myapp"
+
+
+# ---------------------------------------------------------------------------
+# init_sink
+# ---------------------------------------------------------------------------
+
+
+class TestInitSink:
+    def test_replaces_singleton(self):
+        original = instrument.sink
+        try:
+            with patch.dict(os.environ, {"DEADROP_METRICS_SINK": "logging"}):
+                returned = init_sink()
+            assert isinstance(instrument.sink, LoggingSink)
+            assert returned is instrument.sink
+        finally:
+            instrument.sink = original
+
+
+# ---------------------------------------------------------------------------
+# timed() context manager
+# ---------------------------------------------------------------------------
+
+
+class TestTimed:
+    def test_timed_records_timing(self):
+        with swap_sink(RecordingSink()) as rsink:
+            with timed("my.operation"):
+                pass
+            timings = rsink.of_type("timing")
+            assert len(timings) == 1
+            _, name, value_ms, tags = timings[0]
+            assert name == "my.operation"
+            assert isinstance(value_ms, float)
+            assert value_ms >= 0.0
+
+    def test_timed_with_tags(self):
+        with swap_sink(RecordingSink()) as rsink:
+            with timed("db.query", tags={"op": "select"}):
+                pass
+            timings = rsink.of_type("timing")
+            assert timings[0][3] == {"op": "select"}
+
+    def test_timed_records_even_on_exception(self):
+        with swap_sink(RecordingSink()) as rsink:
+            with pytest.raises(ValueError):
+                with timed("risky.op"):
+                    raise ValueError("oops")
+            assert len(rsink.of_type("timing")) == 1
+
+
+# ---------------------------------------------------------------------------
+# request_start / request_end / get_active_requests_snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestRequestTracking:
+    def setup_method(self):
+        # Clear shared state before each test
+        instrument._active_requests.clear()
+        instrument._inflight.clear()
+
+    def teardown_method(self):
+        instrument._active_requests.clear()
+        instrument._inflight.clear()
+
+    def test_request_start_increments_active(self):
+        with swap_sink(RecordingSink()):
+            request_start("health")
+        assert instrument._active_requests.get("health", 0) == 1
+
+    def test_request_end_decrements_active(self):
+        with swap_sink(RecordingSink()):
+            t = request_start("health")
+            request_end("health", t, 200)
+        assert instrument._active_requests.get("health", 0) == 0
+
+    def test_request_end_emits_timing(self):
+        with swap_sink(RecordingSink()) as rsink:
+            t = request_start("inbox.GET")
+            request_end("inbox.GET", t, 200)
+        timings = rsink.of_type("timing")
+        assert any(name == "request.duration_ms" for _, name, _, _ in timings)
+
+    def test_request_end_emits_counter(self):
+        with swap_sink(RecordingSink()) as rsink:
+            t = request_start("inbox.GET")
+            request_end("inbox.GET", t, 404)
+        counters = rsink.of_type("counter")
+        assert any(
+            name == "request.completed" and tags == {"endpoint": "inbox.GET", "status": "404"}
+            for _, name, _, tags in counters
+        )
+
+    def test_snapshot_total_active(self):
+        with swap_sink(RecordingSink()):
+            request_start("rooms/messages.POST")
+            request_start("rooms/messages.POST")
+        snap = get_active_requests_snapshot()
+        assert snap["active_by_endpoint"]["rooms/messages.POST"] == 2
+        assert snap["total_active"] == 2
+
+    def test_snapshot_longest_active_ms(self):
+        import time
+
+        with swap_sink(RecordingSink()):
+            request_start("subscribe")
+            time.sleep(0.01)  # 10ms minimum
+        snap = get_active_requests_snapshot()
+        assert snap["longest_active_ms"] >= 0.0
+
+    def test_snapshot_structure(self):
+        snap = get_active_requests_snapshot()
+        assert "active_by_endpoint" in snap
+        assert "total_active" in snap
+        assert "longest_active_ms" in snap
+        assert "inflight" in snap
+
+
+# ---------------------------------------------------------------------------
+# get_debug_state
+# ---------------------------------------------------------------------------
+
+
+class TestGetDebugState:
+    def test_returns_expected_keys(self):
+        state = get_debug_state()
+        assert "timestamp" in state
+        assert "sampler" in state
+        assert "requests" in state
+        assert "sink" in state
+        assert "sample_interval_s" in state
+
+    def test_sink_name_matches_active(self):
+        state = get_debug_state()
+        assert state["sink"] == type(instrument.sink).__name__
+
+    def test_timestamp_is_recent(self):
+        import time
+
+        before = time.time()
+        state = get_debug_state()
+        after = time.time()
+        assert before <= state["timestamp"] <= after

--- a/tests/test_instrumented_connection.py
+++ b/tests/test_instrumented_connection.py
@@ -51,14 +51,37 @@ class TestRecordQuery:
         finally:
             _request_query_buffer.reset(token)
 
-    def test_statsd_called_with_db_sql_prefix(self):
-        """_record_query emits to statsd with db.sql.<name> prefix."""
+    def test_sink_called_with_db_sql_timing(self):
+        """_record_query emits to the active instrument.sink with db.sql_ms timing."""
+        from deadrop import instrument
+
+        class CapturingSink:
+            calls: list[tuple] = []
+
+            def counter(self, name, value=1, tags=None):
+                pass
+
+            def gauge(self, name, value, tags=None):
+                pass
+
+            def histogram(self, name, value, tags=None):
+                pass
+
+            def timing(self, name, value_ms, tags=None):
+                self.calls.append((name, value_ms, tags))
+
         token = _request_query_buffer.set(None)
+        test_sink = CapturingSink()
+        original_sink = instrument.sink
         try:
-            with patch("deadrop.metrics.statsd_timing") as mock_statsd:
-                _record_query("send_message.insert", 2.5)
-                mock_statsd.assert_called_once_with("db.sql.send_message.insert", 2.5)
+            instrument.sink = test_sink
+            _record_query("send_message.insert", 2.5)
+            assert any(
+                name == "db.sql_ms" and tags == {"query": "send_message.insert"}
+                for name, _, tags in test_sink.calls
+            ), f"Expected db.sql_ms with query tag, got: {test_sink.calls}"
         finally:
+            instrument.sink = original_sink
             _request_query_buffer.reset(token)
 
     def test_multiple_records_in_order(self):


### PR DESCRIPTION
Replaces / supersedes #52 with a broader, non-DB-centric instrumentation framework.

## Problem with #52
PR #52 hardwired statsd as the only transport and only looked at the DB layer. If the DB is fine, we're blind.

## What this PR does

### New module: `deadrop/instrument.py`

**MetricsSink protocol** — four methods, all implementations must never raise:
- `counter(name, value, tags)`
- `gauge(name, value, tags)`
- `histogram(name, value, tags)`
- `timing(name, value_ms, tags)`

**Implementations (all opt-in, OSS-only):**
| Sink | Class | Deps |
|---|---|---|
| `null` | `NullSink` | none (default) |
| `logging` | `LoggingSink` | stdlib only |
| `statsd` | `StatsdSink` | stdlib UDP socket |
| `prometheus` | `PrometheusSink` | `prometheus_client` (optional) |

**Background instrumentation tasks (start on app boot):**
- **Event loop heartbeat** (1s interval) — measures asyncio callback lag; emits `eventloop.lag_ms`
- **Periodic sampler** (10s interval):
  - asyncio task count + long-running tasks (configurable threshold, default 30s)
  - Thread count: total + per named pool
  - Process RSS (/proc/self/status on Linux, psutil fallback)
  - GC generation counts + collection stats

**Request tracking:**
- `request_start(endpoint)` / `request_end(endpoint, start_t, status)` — active request registry
- `get_active_requests_snapshot()` — per-endpoint active count, total active, longest in-flight age

**`/debug/state` endpoint:**
- Admin-auth guarded (same as `/metrics`)
- Returns live JSON snapshot: event loop lag, asyncio tasks, threads, memory, GC, in-flight requests
- Always available regardless of which sink is configured

### Updated: `deadrop/metrics.py`

- Legacy `statsd_incr` / `statsd_gauge` / `statsd_timing` helpers now forward to `instrument.sink` (backward-compatible)
- `Metrics` class forwards all observations to `instrument.sink` — no duplicate transport logic
- Removed redundant socket/env-var code (moved into `StatsdSink`)
- All existing call sites unchanged

### Updated: `deadrop/api.py`

- `lifespan`: calls `instrument.init_sink()` then `instrument.start_background_tasks()`
- Timing middleware: also emits `request.duration_ms` + `request.status` via `instrument.sink`
- New `GET /debug/state` endpoint

## Configuration

```
DEADROP_METRICS_SINK=null|logging|statsd|prometheus   # default: null
DEADROP_METRICS_PREFIX=deadrop                        # metric name prefix
DEADROP_METRICS_STATSD_HOST=statsd.internal           # required for sink=statsd
DEADROP_METRICS_STATSD_PORT=8125
DEADROP_METRICS_DOGSTATSD=1                           # DogStatsD tag format
DEADROP_METRICS_SAMPLE_INTERVAL=10                    # sampler interval (s)
DEADROP_LONG_TASK_THRESHOLD=30                        # long-task alert threshold (s)
```

## To enable on our deploy

```
DEADROP_METRICS_SINK=statsd
DEADROP_METRICS_STATSD_HOST=<grafana-agent or statsd host>
```

## No breaking changes
- **NullSink is the default** — existing deployments are completely unaffected with zero config changes
- All existing `metrics.py` call sites continue to work
- `/metrics` endpoint unchanged
- `/debug/state` is additive (new endpoint, admin-auth guarded)

## Tests
- **40 new tests** in `tests/test_instrument.py`:
  - All sink implementations (NullSink, LoggingSink, StatsdSink)
  - Factory / env var wiring
  - `timed()` context manager
  - request tracking (start/end/snapshot)
  - `get_debug_state()` structure
- Updated `test_instrumented_connection.py`: replaced statsd mock with RecordingSink pattern

Closes #52