### PR TITLE
fix: restore backward-compatible statsd metric names (Grafana dashboard recovery)

### DIFF
--- a/src/deadrop/api.py
+++ b/src/deadrop/api.py
@@ -206,12 +206,9 @@ async def add_timing_middleware(request: Request, call_next):
         endpoint = "other"
 
     metrics.record_request(endpoint, duration_ms, status=response.status_code)
-
-    # Also emit to pluggable sink via instrument module
-    instrument.sink.timing("request.duration_ms", duration_ms, tags={"endpoint": endpoint})
-    instrument.sink.counter(
-        "request.status", tags={"status": str(response.status_code), "endpoint": endpoint}
-    )
+    # Note: metrics.record_request() already forwards to instrument.sink with
+    # backward-compatible flat names.  No additional direct sink calls here to
+    # avoid emitting duplicate/tagged metrics that break Grafana dashboard queries.
 
     # Add timing header for debugging
     response.headers["X-Response-Time-Ms"] = f"{duration_ms:.1f}"

--- a/src/deadrop/metrics.py
+++ b/src/deadrop/metrics.py
@@ -104,30 +104,38 @@ class Metrics:
             self._request_durations[endpoint] = self._request_durations[endpoint][-500:]
         self._status_counts[f"{status}"] += 1
 
-        instrument.sink.timing("request.duration_ms", duration_ms, tags={"endpoint": endpoint})
-        instrument.sink.counter("request.count", tags={"endpoint": endpoint})
-        instrument.sink.counter("response.status", tags={"status": str(status)})
+        # Emit backward-compatible flat metric names (same as pre-PR53 statsd calls).
+        # These are the names the Grafana dashboard queries expect.
+        instrument.sink.timing(f"request.{endpoint}", duration_ms)
+        instrument.sink.counter(f"request.{endpoint}.count")
+        instrument.sink.counter(f"response.{status}")
 
     def record_cache_hit(self, cache_name: str) -> None:
         self._cache_hits[cache_name] += 1
-        instrument.sink.counter("cache.hit", tags={"cache": cache_name})
+        # Backward-compatible flat name: deadrop.cache.{name}.hit
+        instrument.sink.counter(f"cache.{cache_name}.hit")
 
     def record_cache_miss(self, cache_name: str) -> None:
         self._cache_misses[cache_name] += 1
-        instrument.sink.counter("cache.miss", tags={"cache": cache_name})
+        # Backward-compatible flat name: deadrop.cache.{name}.miss
+        instrument.sink.counter(f"cache.{cache_name}.miss")
 
     def record_db_operation(self, operation: str, duration_ms: float) -> None:
         self._db_operation_counts[operation] += 1
         self._db_operation_durations[operation].append(duration_ms)
         if len(self._db_operation_durations[operation]) > 1000:
             self._db_operation_durations[operation] = self._db_operation_durations[operation][-500:]
-        instrument.sink.timing("db.operation_ms", duration_ms, tags={"op": operation})
+        # Backward-compatible flat name: deadrop.db.{operation}
+        # (pre-PR53: statsd_timing(f"db.{operation}", duration_ms))
+        instrument.sink.timing(f"db.{operation}", duration_ms)
 
     def incr(self, key: str, count: int = 1) -> None:
         self._counters[key] += count
+        # Flat key forwarded as-is (same as pre-PR53 statsd_incr behaviour)
         instrument.sink.counter(key, count)
 
     def gauge(self, key: str, value: int | float) -> None:
+        # Flat key forwarded as-is (same as pre-PR53 statsd_gauge behaviour)
         instrument.sink.gauge(key, float(value))
 
     def to_dict(self) -> dict:
@@ -258,8 +266,13 @@ def timed_query(name: str):
 
 
 def _record_query(name: str, ms: float) -> None:
-    """Emit a per-SQL timing to sink + per-request query buffer."""
-    instrument.sink.timing("db.sql_ms", ms, tags={"query": name})
+    """Emit a per-SQL timing to sink + per-request query buffer.
+
+    Emits the backward-compatible flat metric name ``db.sql.{name}``
+    (same format as pre-PR53: ``statsd_timing(f"db.sql.{name}", ms)``).
+    """
+    # Backward-compatible flat name: deadrop.db.sql.{name}
+    instrument.sink.timing(f"db.sql.{name}", ms)
     buf = _request_query_buffer.get()
     if buf is not None:
         buf.append({"name": name, "ms": ms})

--- a/tests/test_instrumented_connection.py
+++ b/tests/test_instrumented_connection.py
@@ -76,10 +76,13 @@ class TestRecordQuery:
         try:
             instrument.sink = test_sink
             _record_query("send_message.insert", 2.5)
+            # Backward-compatible flat name: db.sql.{name} (no tags).
+            # This matches the pre-PR53 statsd_timing(f"db.sql.{name}", ms) behaviour
+            # that the Grafana dashboard queries depend on.
             assert any(
-                name == "db.sql_ms" and tags == {"query": "send_message.insert"}
+                name == "db.sql.send_message.insert" and tags is None
                 for name, _, tags in test_sink.calls
-            ), f"Expected db.sql_ms with query tag, got: {test_sink.calls}"
+            ), f"Expected db.sql.send_message.insert (flat, no tags), got: {test_sink.calls}"
         finally:
             instrument.sink = original_sink
             _request_query_buffer.reset(token)


### PR DESCRIPTION
## Problem

After PR #53 (pluggable instrumentation) deployed, the Grafana dashboard went dark — all panels showing 0.

Two compounding issues:

### Issue 1: `DEADROP_METRICS_SINK` defaults to `null`
The new instrumentation system defaults to `NullSink` if the env var isn't set. The deployed app had the old `STATSD_HOST` / `STATSD_PORT` / `STATSD_PREFIX` env vars but not the new `DEADROP_METRICS_*` equivalents. **Result: zero metrics emitted at all.**

### Issue 2: Metric names completely changed
Even after fixing Issue 1, the metric names would still be wrong. The new `Metrics` class emitted tagged generic names, which `StatsdSink` folds into metric names as `metric.key_value` suffixes:

| What Grafana expects (pre-#53) | What #53 emitted |
|---|---|
| `deadrop.request.subscribe` | `deadrop.request.duration_ms.endpoint_subscribe` |
| `deadrop.request.subscribe.count` | `deadrop.request.count.endpoint_subscribe` |
| `deadrop.response.200` | `deadrop.response.status.status_200` |
| `deadrop.cache.auth.hit` | `deadrop.cache.hit.cache_auth` |
| `deadrop.db.query.send_room_message` | `deadrop.db.operation_ms.op_query.send_room_message` |
| `deadrop.db.sql.commit` | `deadrop.db.sql_ms.query_commit` |

Also, `api.py` middleware added a second direct `instrument.sink` emit with yet different names (`request.duration_ms` tagged, `request.status` tagged), creating a triple-emit with three different name formats.

## Fix

Restore backward-compatible flat metric names in `metrics.py` that match what the Grafana dashboard queries:
- `f"request.{endpoint}"` / `f"request.{endpoint}.count"` / `f"response.{status}"`
- `f"cache.{name}.hit"` / `f"cache.{name}.miss"`  
- `f"db.{operation}"` (covers `db.query.*` from `timed_query`)
- `f"db.sql.{name}"` (from `InstrumentedConnection`)

Remove the duplicate direct `instrument.sink` calls from `api.py` middleware.

Update `test_instrumented_connection.py` to assert the restored flat name.

## Deploy step required

Need to set new env vars on the deployed app to enable the statsd sink using the existing graphite infrastructure:

```bash
dokku config:set deaddrop \
  DEADROP_METRICS_SINK=statsd \
  DEADROP_METRICS_STATSD_HOST=dokku-graphite-lollipop \
  DEADROP_METRICS_STATSD_PORT=8125 \
  DEADROP_METRICS_PREFIX=deadrop
```

The old `STATSD_HOST` / `STATSD_PORT` / `STATSD_PREFIX` vars are no longer read by the new instrumentation layer.

## Verification

Metric name output validated by unit test + manual Python check confirming exact match with pre-PR53 names. All instrument + InstrumentedConnection tests pass.