### PR TITLE
fix: eliminate scroll jump when prepending older room messages on backscroll

### DIFF
--- a/src/deadrop/static/css/style.css
+++ b/src/deadrop/static/css/style.css
@@ -250,6 +250,7 @@ textarea.form-input {
     overflow-y: auto;
     flex: 1;
     min-height: 0;  /* Allow shrinking in flex container */
+    overflow-anchor: none;  /* We manage scroll anchoring manually on backscroll */
 }
 
 .message {

--- a/src/deadrop/templates/app.html
+++ b/src/deadrop/templates/app.html
@@ -928,17 +928,24 @@
             const cacheKey = `room_messages_${currentRoomId}`;
             localStorage.setItem(cacheKey, JSON.stringify(roomMessages));
             
-            // Re-render preserving scroll position.
-            // With column-reverse, the "top" in visual terms is the bottom of
-            // the DOM scroll.  We record scrollHeight before, render, then
-            // adjust scrollTop by the delta so the viewport stays on the same
-            // messages.
+            // Preserve scroll position across the DOM replacement.
+            // column-reverse: scrollTop=0 is the bottom (newest); negative
+            // values mean scrolled up toward older messages.
+            // Strategy: snapshot scrollHeight+scrollTop before innerHTML
+            // replacement, then restore in rAF (post-layout, post-paint)
+            // so late reflows from image loads don't re-jump us.
             const prevScrollHeight = list.scrollHeight;
+            const prevScrollTop = list.scrollTop;
             renderRoomMessages({skipReadCursor: true});
-            const newScrollHeight = list.scrollHeight;
-            // column-reverse: scrollTop is negative (or 0 at bottom).
-            // Adding the height delta keeps the same content in view.
-            list.scrollTop -= (newScrollHeight - prevScrollHeight);
+            requestAnimationFrame(() => {
+                // New content was prepended (visually at the "top", i.e.
+                // the most-negative scrollTop region in column-reverse).
+                // The delta in scrollHeight is how much the content grew;
+                // we subtract it from scrollTop (making it more negative)
+                // to keep the same messages in view.
+                const newScrollHeight = list.scrollHeight;
+                list.scrollTop = prevScrollTop - (newScrollHeight - prevScrollHeight);
+            });
             
             console.log(`Loaded ${olderPage.length} older messages (total: ${roomMessages.length})`);
         } catch (e) {
@@ -1391,18 +1398,25 @@
         }
     });
     
-    // Scroll-up to load older messages + scroll-to-bottom to mark as read
+    // Scroll-up to load older messages + scroll-to-bottom to mark as read.
+    // Debounced: IntersectionObserver on the sentinel would be ideal, but a
+    // debounced scroll listener is simpler and avoids races on inertial scroll.
+    let _scrollDebounceTimer = null;
     document.getElementById('room-message-list').addEventListener('scroll', () => {
         const list = document.getElementById('room-message-list');
         
         // column-reverse: scrollTop is 0 at bottom, negative when scrolled up.
         // When the user scrolls near the "top" (oldest, most negative scrollTop),
-        // load more history.
+        // load more history. Debounce to avoid multiple in-flight fetches.
         if (roomHasOlderMessages && !roomLoadingOlder) {
             const scrolledUp = -list.scrollTop;
             const threshold = list.scrollHeight - list.clientHeight - 200;
             if (scrolledUp >= threshold) {
-                loadOlderRoomMessages();
+                if (_scrollDebounceTimer) clearTimeout(_scrollDebounceTimer);
+                _scrollDebounceTimer = setTimeout(() => {
+                    _scrollDebounceTimer = null;
+                    loadOlderRoomMessages();
+                }, 80);
             }
         }
         


### PR DESCRIPTION
## Problem

When scrolling up in a room to load older messages, the viewport jumps wildly after the page prepends to the DOM.

## Root Cause

Three compounding issues in `loadOlderRoomMessages()`:

1. **Synchronous scroll restoration** — `list.scrollTop` was adjusted immediately after `renderRoomMessages()` (full `innerHTML` replace), but the browser hadn't finished layout. Images loaded inline via `loadImageInline()` caused secondary reflows that re-jumped the viewport after the correction.

2. **Missing `prevScrollTop` snapshot** — the old code only captured `scrollHeight` before render, not `scrollTop`. It used `list.scrollTop` after render to compute the delta, but that value was already stale/reset by the DOM replacement.

3. **Scroll listener races** — on inertial/fast scrolling, the threshold check fired multiple times before `roomLoadingOlder` was set, triggering concurrent `loadOlderRoomMessages()` calls.

## Fixes

### `app.html` — `loadOlderRoomMessages()`
- Snapshot **both** `scrollHeight` and `scrollTop` before `innerHTML` replacement
- Move scroll restoration into `requestAnimationFrame()` — fires after layout, capturing true post-render scrollHeight
- Formula: `scrollTop = prevScrollTop - (newHeight - prevHeight)`  
  (column-reverse: scrollTop is negative when scrolled up; subtracting the height delta makes it more negative = keeps same content in view)

### `app.html` — scroll listener
- Add 80ms debounce before calling `loadOlderRoomMessages()` to prevent concurrent fetches from inertial scroll

### `style.css` — `.message-list`
- Add `overflow-anchor: none` — prevents the browser's native scroll anchoring from fighting our manual restoration on `column-reverse` containers

## Testing

Manual: open a room with history, scroll up, verify older messages load without viewport jump. New messages arriving while at bottom still auto-scroll correctly (unaffected path).