### PR TITLE
fix: incremental DOM prepend for reverse infinite scroll — eliminate viewport jump

### DIFF
--- a/src/deadrop/static/css/style.css
+++ b/src/deadrop/static/css/style.css
@@ -250,7 +250,7 @@ textarea.form-input {
     overflow-y: auto;
     flex: 1;
     min-height: 0;  /* Allow shrinking in flex container */
-    overflow-anchor: none;  /* We manage scroll anchoring manually on backscroll */
+    overflow-anchor: auto;  /* Browser preserves scroll anchor on DOM appends */
 }
 
 .message {

--- a/src/deadrop/templates/app.html
+++ b/src/deadrop/templates/app.html
@@ -897,56 +897,100 @@
     
     /**
      * Load older messages when the user scrolls to the top.
-     * Uses the `before` cursor to fetch the page preceding the oldest
-     * message currently loaded.
+     *
+     * Uses incremental DOM insertion (DocumentFragment appended to the
+     * physical end of the list) rather than a full innerHTML replacement.
+     * In a column-reverse container the physical end of the DOM is the
+     * *visual top* — so appending is the correct "prepend" operation.
+     *
+     * Because existing DOM nodes are preserved, `overflow-anchor: auto`
+     * keeps the currently-visible message anchored without any manual
+     * scrollTop arithmetic.
      */
     async function loadOlderRoomMessages() {
         if (roomLoadingOlder || !roomHasOlderMessages || roomMessages.length === 0) return;
         roomLoadingOlder = true;
-        
+
         const list = document.getElementById('room-message-list');
-        
+
         try {
             // The oldest message we have is the first element (chronological order)
             const oldestMid = roomMessages[0].mid;
-            
+
             const result = await DeadropAPI.getRoomMessages(
                 credentials, currentRoomId, { beforeMid: oldestMid, limit: ROOM_PAGE_SIZE });
             const olderPage = result?.messages || [];
-            
+
             if (olderPage.length === 0) {
                 roomHasOlderMessages = false;
+                // Remove sentinel — nothing more to load
+                const sentinel = document.getElementById('room-load-more');
+                if (sentinel) sentinel.remove();
                 return;
             }
-            
+
             roomHasOlderMessages = olderPage.length >= ROOM_PAGE_SIZE;
-            
-            // Prepend older messages (they come in chronological order)
+
+            // Prepend to data model (older messages go before existing ones)
             roomMessages = [...olderPage, ...roomMessages];
-            
+
             // Save to cache
             const cacheKey = `room_messages_${currentRoomId}`;
             localStorage.setItem(cacheKey, JSON.stringify(roomMessages));
-            
-            // Preserve scroll position across the DOM replacement.
-            // column-reverse: scrollTop=0 is the bottom (newest); negative
-            // values mean scrolled up toward older messages.
-            // Strategy: snapshot scrollHeight+scrollTop before innerHTML
-            // replacement, then restore in rAF (post-layout, post-paint)
-            // so late reflows from image loads don't re-jump us.
-            const prevScrollHeight = list.scrollHeight;
-            const prevScrollTop = list.scrollTop;
-            renderRoomMessages({skipReadCursor: true});
-            requestAnimationFrame(() => {
-                // New content was prepended (visually at the "top", i.e.
-                // the most-negative scrollTop region in column-reverse).
-                // The delta in scrollHeight is how much the content grew;
-                // we subtract it from scrollTop (making it more negative)
-                // to keep the same messages in view.
-                const newScrollHeight = list.scrollHeight;
-                list.scrollTop = prevScrollTop - (newScrollHeight - prevScrollHeight);
+
+            // Build reaction map across the full updated message set
+            const reactionMap = buildReactionMap(roomMessages);
+
+            // Filter out reactions from display set
+            const olderDisplay = olderPage.filter(m => m.content_type !== 'reaction');
+
+            // Build a DocumentFragment with the older messages.
+            // column-reverse: DOM order is newest→oldest, so older messages
+            // belong at the physical END of the list (= visual top).
+            // olderPage is already in chronological order (oldest→newest),
+            // so we reverse it to maintain newest→oldest DOM order.
+            const fragment = document.createDocumentFragment();
+            for (let i = olderDisplay.length - 1; i >= 0; i--) {
+                fragment.appendChild(renderMessageElement(olderDisplay[i], reactionMap));
+            }
+
+            // If there are still more pages, keep the sentinel at the
+            // very end (visual top); otherwise discard it.
+            const existingSentinel = document.getElementById('room-load-more');
+            if (roomHasOlderMessages) {
+                if (!existingSentinel) {
+                    const sentinel = document.createElement('div');
+                    sentinel.id = 'room-load-more';
+                    sentinel.className = 'load-more-sentinel';
+                    sentinel.style.cssText = 'text-align:center;padding:12px;color:var(--text-muted);font-size:13px;';
+                    sentinel.textContent = 'Loading older messages…';
+                    fragment.appendChild(sentinel);
+                } else {
+                    // Move existing sentinel to the end of the fragment
+                    // (it will land at the physical end = visual top)
+                    existingSentinel.remove();
+                    fragment.appendChild(existingSentinel);
+                }
+            } else {
+                if (existingSentinel) existingSentinel.remove();
+            }
+
+            // Append fragment to DOM — overflow-anchor: auto preserves
+            // the visible viewport automatically; no scrollTop math needed.
+            list.appendChild(fragment);
+
+            // Highlight any code blocks in the newly inserted elements
+            highlightCodeBlocks(list);
+
+            // Auto-load image placeholders in newly added messages
+            list.querySelectorAll('.image-placeholder').forEach(el => {
+                const attId = el.dataset.attachmentId;
+                if (attId && !el.dataset.loading) {
+                    el.dataset.loading = 'true';
+                    loadImageInline(el, attId);
+                }
             });
-            
+
             console.log(`Loaded ${olderPage.length} older messages (total: ${roomMessages.length})`);
         } catch (e) {
             console.error('Failed to load older messages:', e);
@@ -984,6 +1028,26 @@
         return `<div class="reaction-badges">${badges}<button class="reaction-badge add-reaction" onclick="showReactionPicker(event, '${mid}')" title="Add reaction">+</button></div>`;
     }
     
+    /**
+     * Render a single room message into an HTMLElement.
+     * Shared by the full-render and incremental-prepend paths.
+     */
+    function renderMessageElement(msg, reactionMap) {
+        const isMe = msg.from_id === credentials.id;
+        const isPending = msg.pending;
+        const el = document.createElement('div');
+        el.className = `room-message${isMe ? ' from-me' : ''}${isPending ? ' pending' : ''}`;
+        el.dataset.mid = msg.mid;
+        el.innerHTML = `
+            <div class="sender-name">${getMemberName(msg.from_id)}</div>
+            <div class="message-body markdown-body">${renderMessageBody(msg.body, msg.content_type)}</div>
+            ${renderAttachments(msg)}
+            ${renderReactionBadges(msg.mid, reactionMap)}
+            <div class="message-time">${isPending ? 'Sending...' : formatTime(msg.created_at)}</div>
+        `;
+        return el;
+    }
+
     function renderRoomMessages({skipReadCursor = false} = {}) {
         const list = document.getElementById('room-message-list');
         
@@ -993,31 +1057,30 @@
         // Filter out reaction messages from the main list
         const displayMessages = roomMessages.filter(m => m.content_type !== 'reaction');
         
-        // Reverse for column-reverse display (newest at bottom visually)
-        const reversed = [...displayMessages].reverse();
+        // column-reverse layout: newest message must be first in DOM order
+        // (DOM top = visual bottom, DOM bottom = visual top / oldest).
+        // We build the full list newest→oldest so the browser renders
+        // newest at the bottom without any scrollTop manipulation.
+        const fragment = document.createDocumentFragment();
 
-        // Show a "load more" sentinel at the visual top (DOM bottom in
-        // column-reverse) when there are older messages to fetch.
-        const loadMoreHtml = roomHasOlderMessages
-            ? '<div id="room-load-more" class="load-more-sentinel" style="text-align:center;padding:12px;color:var(--text-muted);font-size:13px;">Loading older messages…</div>'
-            : '';
-        
-        list.innerHTML = reversed.map(msg => {
-            const isMe = msg.from_id === credentials.id;
-            const isPending = msg.pending;
-            
-            return `
-                <div class="room-message ${isMe ? 'from-me' : ''} ${isPending ? 'pending' : ''}" data-mid="${msg.mid}">
-                    <div class="sender-name">${getMemberName(msg.from_id)}</div>
-                    <div class="message-body markdown-body">${renderMessageBody(msg.body, msg.content_type)}</div>
-                    ${renderAttachments(msg)}
-                    ${renderReactionBadges(msg.mid, reactionMap)}
-                    <div class="message-time">${isPending ? 'Sending...' : formatTime(msg.created_at)}</div>
-                </div>
-            `;
-        }).join('') + loadMoreHtml;
-        
-        // No need to scroll - column-reverse keeps us at bottom
+        // Newest first (DOM order matches visual order for column-reverse)
+        for (let i = displayMessages.length - 1; i >= 0; i--) {
+            fragment.appendChild(renderMessageElement(displayMessages[i], reactionMap));
+        }
+
+        // Sentinel lives at the physical end of the DOM (= visual top).
+        // It is the anchor for IntersectionObserver-triggered backfill.
+        if (roomHasOlderMessages) {
+            const sentinel = document.createElement('div');
+            sentinel.id = 'room-load-more';
+            sentinel.className = 'load-more-sentinel';
+            sentinel.style.cssText = 'text-align:center;padding:12px;color:var(--text-muted);font-size:13px;';
+            sentinel.textContent = 'Loading older messages…';
+            fragment.appendChild(sentinel);
+        }
+
+        list.innerHTML = '';
+        list.appendChild(fragment);
         
         // Apply syntax highlighting to code blocks
         highlightCodeBlocks(list);

--- a/tests/test_reverse_scroll_playwright.py
+++ b/tests/test_reverse_scroll_playwright.py
@@ -1,0 +1,603 @@
+"""
+Playwright test for reverse infinite scroll in room chat view.
+
+Verifies that when a user scrolls up in the room message list:
+1. Older messages load above the current viewport (at the visual top)
+2. The currently-visible message stays visible after the load
+3. No viewport jump / content replacement occurs
+
+Architecture note:
+  The room-message-list uses `flex-direction: column-reverse`.
+  - scrollTop=0  →  at the bottom (newest messages visible)
+  - scrollTop<0  →  scrolled up toward older messages
+  - Physical DOM end = visual top (where older messages are inserted)
+
+The fix (this PR) switches loadOlderRoomMessages() from a full innerHTML
+replacement + manual rAF scrollTop correction to an incremental
+DocumentFragment append, relying on `overflow-anchor: auto` to preserve
+the scroll position natively.
+
+Test approach:
+  We serve the static app HTML directly via a local HTTP server (bypassing
+  FastAPI/Jinja2 to avoid a local version incompatibility) and wire up a
+  mock API handler that returns predictable paginated message sets.
+  The test drives Playwright against this local page to verify the scroll
+  behavior end-to-end in a real browser.
+"""
+
+import http.server
+import json
+import pathlib
+import re
+import threading
+import time
+
+import pytest
+from playwright.sync_api import sync_playwright
+
+# Paths
+REPO_ROOT = pathlib.Path(__file__).parent.parent
+STATIC_DIR = REPO_ROOT / "src" / "deadrop" / "static"
+TEMPLATES_DIR = REPO_ROOT / "src" / "deadrop" / "templates"
+
+# Port for the local test HTTP server
+TEST_HTTP_PORT = 19100
+TEST_API_PORT = 19101
+
+
+# ---------------------------------------------------------------------------
+# Minimal mock API server (returns paginated room messages)
+# ---------------------------------------------------------------------------
+
+# Build 60 fake messages (IDs m001..m060, chronological order)
+ALL_MESSAGES = [
+    {
+        "mid": f"m{i:03d}",
+        "room_id": "room-test",
+        "from_id": "alice-id",
+        "from": "alice-id",
+        "body": f"Message number {i}",
+        "content_type": "text/plain",
+        "reference_mid": None,
+        "created_at": f"2024-01-01T{(i // 60):02d}:{(i % 60):02d}:00Z",
+        "attachments": [],
+    }
+    for i in range(1, 61)
+]
+PAGE_SIZE = 20
+
+
+class MockAPIHandler(http.server.BaseHTTPRequestHandler):
+    """Minimal mock of the deaddrop room messages API."""
+
+    def log_message(self, fmt, *args):  # suppress request logs
+        pass
+
+    def do_OPTIONS(self):
+        self.send_response(200)
+        self._cors()
+        self.end_headers()
+
+    def _cors(self):
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Headers", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+
+    def do_GET(self):
+        # Parse URL
+        path = self.path.split("?")[0]
+        qs = self.path.split("?")[1] if "?" in self.path else ""
+        params = {}
+        for kv in qs.split("&"):
+            if "=" in kv:
+                k, v = kv.split("=", 1)
+                params[k] = v
+
+        if re.match(r"^/[^/]+/rooms/[^/]+/messages$", path):
+            # Room messages endpoint
+            before = params.get("before")
+            after = params.get("after")
+            limit = int(params.get("limit", PAGE_SIZE))
+
+            msgs = list(ALL_MESSAGES)
+
+            if before:
+                # Get messages older than `before` (last N in chrono order)
+                msgs = [m for m in msgs if m["mid"] < before]
+                msgs = msgs[-limit:]  # newest N from the filtered set
+            elif after:
+                msgs = [m for m in msgs if m["mid"] > after]
+                msgs = msgs[:limit]
+            else:
+                # No cursor — return newest N
+                msgs = msgs[-limit:]
+
+            body = json.dumps({"messages": msgs, "room_id": "room-test"}).encode()
+            self.send_response(200)
+            self._cors()
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        elif re.match(r"^/[^/]+/rooms/[^/]+/members$", path):
+            body = json.dumps(
+                [
+                    {"identity_id": "alice-id", "metadata": {"display_name": "Alice"}},
+                ]
+            ).encode()
+            self.send_response(200)
+            self._cors()
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        elif re.match(r"^/[^/]+/rooms/[^/]+$", path):
+            body = json.dumps(
+                {
+                    "room_id": "room-test",
+                    "display_name": "Scroll Test Room",
+                    "member_count": 1,
+                }
+            ).encode()
+            self.send_response(200)
+            self._cors()
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        elif re.match(r"^/[^/]+/rooms/[^/]+/read_cursor$", path):
+            body = b"{}"
+            self.send_response(200)
+            self._cors()
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        else:
+            self.send_response(404)
+            self._cors()
+            self.end_headers()
+
+    def do_POST(self):
+        # Accept read cursor updates silently
+        self.send_response(200)
+        self._cors()
+        self.send_header("Content-Type", "application/json")
+        body = b"{}"
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def start_mock_api():
+    server = http.server.HTTPServer(("127.0.0.1", TEST_API_PORT), MockAPIHandler)
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    return server
+
+
+# ---------------------------------------------------------------------------
+# Static file server — serves app.html + static assets
+# ---------------------------------------------------------------------------
+
+_rendered_app_html: str | None = None
+
+
+def _build_app_html() -> str:
+    """Render app.html with minimal Jinja2 substitution (cached)."""
+    global _rendered_app_html
+    if _rendered_app_html is not None:
+        return _rendered_app_html
+
+    base_html = (TEMPLATES_DIR / "base.html").read_text()
+    app_html = (TEMPLATES_DIR / "app.html").read_text()
+
+    title_match = re.search(r"\{% block title %\}(.+?)\{% endblock %\}", app_html, re.DOTALL)
+    body_match = re.search(r"\{% block body %\}(.+?)\{% endblock %\}", app_html, re.DOTALL)
+    scripts_match = re.search(r"\{% block scripts %\}(.+?)\{% endblock %\}", app_html, re.DOTALL)
+
+    title = title_match.group(1).strip() if title_match else "Deadrop"
+    body_content = body_match.group(1) if body_match else ""
+    scripts_content = scripts_match.group(1) if scripts_match else ""
+
+    # Use lambda replacements to prevent re.sub from interpreting backslash
+    # sequences (e.g. \n) in the content strings as escape sequences.
+    rendered = base_html
+    rendered = re.sub(
+        r"\{% block title %\}.*?\{% endblock %\}", lambda _: title, rendered, flags=re.DOTALL
+    )
+    rendered = re.sub(
+        r"\{% block body %\}.*?\{% endblock %\}", lambda _: body_content, rendered, flags=re.DOTALL
+    )
+    rendered = re.sub(
+        r"\{% block scripts %\}.*?\{% endblock %\}",
+        lambda _: scripts_content,
+        rendered,
+        flags=re.DOTALL,
+    )
+    rendered = re.sub(
+        r"\{% block head %\}.*?\{% endblock %\}", lambda _: "", rendered, flags=re.DOTALL
+    )
+
+    rendered = (
+        rendered.replace("{{ slug | tojson if slug else 'null' }}", "null")
+        .replace("{{ peer_id | tojson if peer_id is defined and peer_id else 'null' }}", "null")
+        .replace("{{ view | tojson if view is defined and view else 'null' }}", "null")
+        .replace("{{ room_id | tojson if room_id is defined and room_id else 'null' }}", "null")
+        .replace("{{ ROOM_PAGE_SIZE }}", str(PAGE_SIZE))
+    )
+
+    _rendered_app_html = rendered
+    return rendered
+
+
+class StaticHandler(http.server.BaseHTTPRequestHandler):
+    """Serve static files and the rendered app HTML."""
+
+    def log_message(self, fmt, *args):
+        pass
+
+    def do_GET(self):
+        path = self.path.split("?")[0]
+
+        if path in ("/", "/app", "/app/"):
+            body_bytes = _build_app_html().encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body_bytes)))
+            self.end_headers()
+            self.wfile.write(body_bytes)
+            return
+
+        # Serve static files from the package static directory
+        # URL: /static/js/foo.js → STATIC_DIR/js/foo.js
+        if path.startswith("/static/"):
+            rel = path[len("/static/") :]
+            file_path = STATIC_DIR / rel
+            if file_path.exists() and file_path.is_file():
+                data = file_path.read_bytes()
+                # Guess content type
+                suffix = file_path.suffix
+                ct = {
+                    ".js": "application/javascript",
+                    ".css": "text/css",
+                    ".html": "text/html",
+                }.get(suffix, "application/octet-stream")
+                self.send_response(200)
+                self.send_header("Content-Type", ct)
+                self.send_header("Content-Length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+                return
+
+        # Everything else 404
+        self.send_response(404)
+        self.end_headers()
+
+
+def start_static_server():
+    server = http.server.HTTPServer(("127.0.0.1", TEST_HTTP_PORT), StaticHandler)
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    # Wait for it
+    import socket
+
+    for _ in range(50):
+        try:
+            s = socket.create_connection(("127.0.0.1", TEST_HTTP_PORT), timeout=0.2)
+            s.close()
+            break
+        except (ConnectionRefusedError, OSError):
+            time.sleep(0.1)
+    return server
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def servers():
+    api_server = start_mock_api()
+    http_server = start_static_server()
+    yield {
+        "app": f"http://127.0.0.1:{TEST_HTTP_PORT}",
+        "api": f"http://127.0.0.1:{TEST_API_PORT}",
+    }
+    api_server.shutdown()
+    http_server.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# JS helper — inject credentials + patch DeadropAPI base URL
+# ---------------------------------------------------------------------------
+
+INJECT_JS = f"""
+    // Set up fake credentials in localStorage
+    const ns = 'test-ns';
+    const slug = 'test-slug';
+    const creds = {{
+        version: 1,
+        namespaces: {{
+            [slug]: {{
+                ns,
+                slug,
+                displayName: 'Test NS',
+                ttlHours: 0,
+                identities: {{
+                    'alice-id': {{
+                        id: 'alice-id',
+                        secret: 'alice-secret',
+                        displayName: 'Alice',
+                        addedAt: '2024-01-01T00:00:00.000Z',
+                    }}
+                }},
+                activeIdentity: 'alice-id',
+            }}
+        }}
+    }};
+    localStorage.setItem('deadrop_credentials', JSON.stringify(creds));
+
+    // Patch the API base URL to point to mock server
+    window._MOCK_API_BASE = 'http://127.0.0.1:{TEST_API_PORT}';
+"""
+
+PATCH_API_JS = """
+    // Monkey-patch DeadropAPI.request to use mock server
+    const origRequest = DeadropAPI.request.bind(DeadropAPI);
+    DeadropAPI.request = async function(method, path, options) {
+        const url = window._MOCK_API_BASE + path;
+        const headers = {};
+        if (options?.credentials?.secret) {
+            headers['X-Inbox-Secret'] = options.credentials.secret;
+        }
+        let body = undefined;
+        if (options?.body) {
+            headers['Content-Type'] = 'application/json';
+            body = JSON.stringify(options.body);
+        }
+        const resp = await fetch(url, { method, headers, body });
+        if (!resp.ok) throw new Error(`API error: ${resp.status}`);
+        return resp.json();
+    };
+    console.log('DeadropAPI patched to mock server');
+"""
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestReverseInfiniteScroll:
+    """
+    Verify the reverse infinite scroll fix.
+
+    Key assertion: after scrolling to the visual top and triggering older
+    message load, the previously-visible message should still be visible
+    and older messages should appear ABOVE it (not replace it).
+    """
+
+    def test_scroll_up_prepends_older_messages(self, servers):
+        """
+        Scroll to the visual top of the room, wait for older messages to
+        load, and verify:
+        1. Older messages are now in the DOM (above the previous oldest)
+        2. The viewport did not jump to the bottom (current messages preserved)
+        3. No content replacement — previously visible messages still visible
+        """
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True)
+            context = browser.new_context(viewport={"width": 375, "height": 812})
+            page = context.new_page()
+
+            # Navigate to the app
+            page.goto(servers["app"])
+            page.wait_for_load_state("networkidle")
+            page.wait_for_timeout(500)
+
+            # Inject credentials + patch API
+            page.evaluate(INJECT_JS)
+            page.evaluate(PATCH_API_JS)
+
+            # Wait for the app JS to fully execute and define openRoom
+            page.wait_for_function("typeof openRoom === 'function'", timeout=10000)
+
+            # Navigate to the room view directly via JS (simulating openRoom)
+            page.evaluate("""
+                const slug = 'test-slug';
+                const roomId = 'room-test';
+                credentials = CredentialStore.getCredentials(slug);
+                currentSlug = slug;
+                currentRoomId = roomId;
+                openRoom(roomId);
+            """)
+
+            # Wait for room message list to appear
+            msg_list = page.locator("#room-message-list")
+            msg_list.wait_for(state="visible", timeout=10000)
+
+            # Wait for messages to render
+            page.wait_for_function(
+                "document.querySelectorAll('.room-message').length > 0",
+                timeout=10000,
+            )
+            page.wait_for_timeout(600)  # let initial render settle
+
+            initial_count = page.locator(".room-message").count()
+            assert initial_count > 0, "Expected messages to be rendered"
+            print(f"\nInitial message count: {initial_count}")
+            assert initial_count == PAGE_SIZE, (
+                f"Expected {PAGE_SIZE} messages on initial load, got {initial_count}"
+            )
+
+            # Get text of the last DOM element (= oldest visible, visually at top)
+            # In column-reverse, the LAST item in DOM is at the visual top
+            last_dom_msg_text = page.locator(".room-message").last.inner_text()
+            print(f"Oldest visible message: {last_dom_msg_text[:60]}")
+
+            # Get scrollTop before scrolling
+            scroll_top_before = page.evaluate(
+                "document.getElementById('room-message-list').scrollTop"
+            )
+            print(f"scrollTop before scroll: {scroll_top_before}")
+            # Initially at bottom → scrollTop near 0
+            assert scroll_top_before >= -10, (
+                f"Expected to be at bottom (scrollTop≈0), got {scroll_top_before}"
+            )
+
+            # Scroll to the visual top (physical bottom in column-reverse)
+            page.evaluate("""
+                const list = document.getElementById('room-message-list');
+                list.scrollTop = -(list.scrollHeight - list.clientHeight);
+            """)
+            page.wait_for_timeout(300)  # debounce + scroll event
+
+            scroll_top_after_scroll = page.evaluate(
+                "document.getElementById('room-message-list').scrollTop"
+            )
+            print(f"scrollTop after scroll: {scroll_top_after_scroll}")
+            assert scroll_top_after_scroll < -50, (
+                f"Expected negative scrollTop (scrolled up), got {scroll_top_after_scroll}"
+            )
+
+            # Snapshot scrollTop right before the load triggers
+            scroll_before_load = page.evaluate(
+                "document.getElementById('room-message-list').scrollTop"
+            )
+
+            # Wait for older messages to load (triggered by scroll event)
+            page.wait_for_function(
+                f"document.querySelectorAll('.room-message').length > {initial_count}",
+                timeout=8000,
+            )
+
+            new_count = page.locator(".room-message").count()
+            loaded_count = new_count - initial_count
+            print(f"Messages after scroll-load: {new_count} (+{loaded_count})")
+            assert new_count > initial_count, (
+                f"Expected more messages after scrolling up, still got {initial_count}"
+            )
+
+            # ---------------------------------------------------------------
+            # Critical assertion 1: previously-oldest message is still there
+            # (content was prepended, not replaced)
+            # ---------------------------------------------------------------
+            all_texts = page.locator(".room-message").all_inner_texts()
+            assert any(last_dom_msg_text[:20] in t for t in all_texts), (
+                f"Previously visible message '{last_dom_msg_text[:40]}' "
+                "is gone — content was REPLACED instead of prepended!"
+            )
+            print("✓ Previously visible message still present in DOM")
+
+            # ---------------------------------------------------------------
+            # Critical assertion 2: scroll position was preserved
+            # After incremental DOM insert, scrollTop should still be ≈ where
+            # it was before the load (not jumped to 0/bottom).
+            # We allow ±200px tolerance for browser rendering variations.
+            # ---------------------------------------------------------------
+            scroll_top_final = page.evaluate(
+                "document.getElementById('room-message-list').scrollTop"
+            )
+            print(f"scrollTop after load: {scroll_top_final} (was {scroll_before_load})")
+
+            # scrollTop should still be significantly negative (not jumped to 0)
+            assert scroll_top_final < -50, (
+                f"Scroll position JUMPED TO BOTTOM after loading older messages "
+                f"(scrollTop={scroll_top_final}). This is the bug we fixed!"
+            )
+            print("✓ Scroll position preserved after load (still negative)")
+
+            # ---------------------------------------------------------------
+            # Critical assertion 3: older messages are visually ABOVE
+            # (at the physical end of the DOM in column-reverse)
+            # In column-reverse, the LAST DOM child = visual top.
+            # The newly loaded messages (older) must be among the last DOM children.
+            # ---------------------------------------------------------------
+            last_3 = [el.inner_text()[:30] for el in page.locator(".room-message").all()[-3:]]
+            print(f"Last 3 DOM messages (visual top, oldest): {last_3}")
+            # These should be from the older page, i.e. "Message number 1.." etc.
+            # The initial load got msgs 41-60 (newest 20), older load got 21-40.
+            # So last DOM msgs should be around "Message number 20-22"
+            assert any("Message number" in t for t in last_3), (
+                f"Expected older messages at physical DOM end (visual top), got: {last_3}"
+            )
+            print("✓ Older messages correctly inserted at visual top (DOM end)")
+
+            browser.close()
+            print("\n✓ All assertions passed — reverse scroll fix verified")
+
+    def test_sentinel_is_removed_when_exhausted(self, servers):
+        """
+        After loading all pages, the sentinel element should be removed.
+        """
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True)
+            context = browser.new_context(viewport={"width": 375, "height": 812})
+            page = context.new_page()
+
+            page.goto(servers["app"])
+            page.wait_for_load_state("networkidle")
+            page.wait_for_timeout(500)
+
+            page.evaluate(INJECT_JS)
+            page.evaluate(PATCH_API_JS)
+
+            page.wait_for_function("typeof openRoom === 'function'", timeout=10000)
+
+            page.evaluate("""
+                const slug = 'test-slug';
+                const roomId = 'room-test';
+                credentials = CredentialStore.getCredentials(slug);
+                currentSlug = slug;
+                currentRoomId = roomId;
+                openRoom(roomId);
+            """)
+
+            msg_list = page.locator("#room-message-list")
+            msg_list.wait_for(state="visible", timeout=10000)
+            page.wait_for_function(
+                "document.querySelectorAll('.room-message').length > 0",
+                timeout=10000,
+            )
+            page.wait_for_timeout(600)
+
+            # Scroll to top 3 times to exhaust all pages
+            # Total: 60 messages / 20 per page = 3 loads
+            # Initial load: msgs 41-60 (newest 20) → 2 more loads needed
+            for load_num in range(4):
+                sentinel = page.locator("#room-load-more")
+                if not sentinel.is_visible():
+                    print(f"\n✓ Sentinel gone after {load_num} scroll-load(s)")
+                    break
+
+                prev_count = page.locator(".room-message").count()
+                page.evaluate("""
+                    const list = document.getElementById('room-message-list');
+                    list.scrollTop = -(list.scrollHeight - list.clientHeight);
+                """)
+                page.wait_for_timeout(300)
+
+                try:
+                    page.wait_for_function(
+                        f"document.querySelectorAll('.room-message').length > {prev_count} "
+                        "|| !document.getElementById('room-load-more')",
+                        timeout=5000,
+                    )
+                except Exception:
+                    break
+
+            # Sentinel should be gone
+            assert not page.locator("#room-load-more").is_visible(), (
+                "Sentinel still visible after loading all messages — not cleaned up"
+            )
+            final_count = page.locator(".room-message").count()
+            print(f"Final message count: {final_count} (expected 60)")
+            assert final_count == 60, f"Expected all 60 messages, got {final_count}"
+
+            browser.close()

--- a/tests/test_reverse_scroll_playwright.py
+++ b/tests/test_reverse_scroll_playwright.py
@@ -33,7 +33,10 @@ import threading
 import time
 
 import pytest
+
 from playwright.sync_api import sync_playwright
+
+pytestmark = pytest.mark.integration
 
 # Paths
 REPO_ROOT = pathlib.Path(__file__).parent.parent


### PR DESCRIPTION
## Problem

Scrolling up in a room chat loads older messages, but they **replace the current viewport content** instead of prepending above it. Older messages jump to the bottom, or the scroll position resets. PR #56's `scrollTop` delta fix was insufficient.

## Root Cause (observed, not theorized)

Diagnosed via code inspection + Playwright verification:

**Two compounding bugs:**

1. **`overflow-anchor: none`** was set on `#room-message-list` — explicitly disabling the browser's native scroll anchor management.

2. **Full `innerHTML` replacement** in `loadOlderRoomMessages()` → `renderRoomMessages()`. Full innerHTML wipes all DOM nodes; `overflow-anchor` has nothing to anchor to. The `requestAnimationFrame` delta correction then races with the browser's re-layout, causing inconsistent behavior.

The canonical pattern requires that **existing DOM nodes are preserved** when new content is added — that's what lets the browser automatically compensate scrollTop.

## Fix

### CSS (`style.css`)
```css
/* Before */
overflow-anchor: none;  /* We manage scroll anchoring manually on backscroll */

/* After */
overflow-anchor: auto;  /* Browser preserves scroll anchor on DOM appends */
```

### JS — `loadOlderRoomMessages()` (`app.html`)

Replaced: full `renderRoomMessages()` call + rAF scrollTop patch

With: **incremental `DocumentFragment` append**

```javascript
// column-reverse: DOM end = visual top.
// Append older messages at physical end → they appear at visual top.
// overflow-anchor: auto handles scroll preservation automatically.
const fragment = document.createDocumentFragment();
for (let i = olderDisplay.length - 1; i >= 0; i--) {
    fragment.appendChild(renderMessageElement(olderDisplay[i], reactionMap));
}
// sentinel management (kept/removed at DOM end)
list.appendChild(fragment);  // no scrollTop math needed
```

Key invariants:
- **column-reverse DOM order**: newest → oldest (first child = newest, last child = oldest)
- **API returns ASC** (confirmed via `db.py`): oldest first, so we reverse when building the fragment
- **Existing DOM nodes preserved** → `overflow-anchor: auto` compensates scrollTop natively
- **No manual scrollTop manipulation** in the backscroll path

### JS — `renderMessageElement()` helper

Extracted a `renderMessageElement(msg, reactionMap) → HTMLElement` function shared by both the full rebuild path and the incremental path. Cleaner than duplicating the HTML string.

### JS — `renderRoomMessages()` (full rebuild path)

Updated to use `DocumentFragment` + `renderMessageElement()` instead of `innerHTML = strings.join('')`. Full rebuild is still correct for initial load and subscription-driven new-message appends (those happen at the bottom, not the top).

## Verification

Playwright tests (`tests/test_reverse_scroll_playwright.py`) drive a real Chromium browser against a local mock server with 60 messages at PAGE_SIZE=20:

```
Initial message count: 20
Oldest visible message: Message number 41
scrollTop before scroll: 0
scrollTop after scroll: -2179
Messages after scroll-load: 40 (+20)
✓ Previously visible message still present in DOM
scrollTop after load: -2179 (was -2179)
✓ Scroll position preserved after load (still negative)
Last 3 DOM messages (visual top, oldest): ['Message number 23', 'Message number 22', 'Message number 21']
✓ Older messages correctly inserted at visual top (DOM end)

2 passed in 7.47s
```

**Assertions verified:**
1. `scrollTop` stayed at -2179 (not jumped to 0) after loading older messages
2. Previously-visible "Message number 41" still in DOM (not replaced)
3. Older messages at physical DOM end = visual top
4. Sentinel removed after all pages loaded, final count = 60

## Closes
Fixes the root cause of the reverse infinite scroll bug; supersedes the incomplete fix from #56.