### PR TITLE
fix(db): silent retry on Hrana 404 stream-not-found via _run_read/_run_write

### DIFF
--- a/src/deadrop/api.py
+++ b/src/deadrop/api.py
@@ -496,14 +496,22 @@ async def _run_read(fn, *args):
 
     ContextVar propagation: captures the current context so that the per-request
     query buffer (metrics.py) is visible to timed_query decorators in the thread.
+
+    Hrana 404 retry: transient `stream not found` errors from Turso's Hrana
+    protocol are retried silently via db._execute_with_retry(). These happen
+    when a connection's stream id expires; reconnecting resolves it.
     """
     loop = asyncio.get_event_loop()
     executor = db.get_read_executor()
     ctx = contextvars.copy_context()
 
+    # Wrap fn in retry logic for Hrana stream errors
+    def _wrapped():
+        return db._execute_with_retry(lambda: fn(*args))
+
     try:
         return await asyncio.wait_for(
-            loop.run_in_executor(executor, ctx.run, fn, *args),
+            loop.run_in_executor(executor, ctx.run, _wrapped),
             timeout=DB_OPERATION_TIMEOUT,
         )
     except asyncio.TimeoutError:
@@ -533,14 +541,20 @@ async def _run_write(fn, *args):
 
     ContextVar propagation: captures the current context so that the per-request
     query buffer (metrics.py) is visible to timed_query decorators in the thread.
+
+    Hrana 404 retry: see _run_read. Same silent-retry behavior for writes.
     """
     loop = asyncio.get_event_loop()
     executor = db.get_write_executor()
     ctx = contextvars.copy_context()
 
+    # Wrap fn in retry logic for Hrana stream errors
+    def _wrapped():
+        return db._execute_with_retry(lambda: fn(*args))
+
     try:
         return await asyncio.wait_for(
-            loop.run_in_executor(executor, ctx.run, fn, *args),
+            loop.run_in_executor(executor, ctx.run, _wrapped),
             timeout=DB_OPERATION_TIMEOUT,
         )
     except asyncio.TimeoutError:

--- a/src/deadrop/static/css/style.css
+++ b/src/deadrop/static/css/style.css
@@ -12,6 +12,8 @@
     --border: #e0e0e0;
     --input-bg: #ffffff;
     --code-bg: rgba(0, 0, 0, 0.06);
+    --code-block-bg: #f6f8fa;        /* Light slate, matches github.min.css hljs theme */
+    --code-block-text: #24292f;      /* Dark slate for readable contrast */
     --table-header-bg: rgba(0, 0, 0, 0.04);
     --unread-bg: rgba(37, 99, 235, 0.05);
 
@@ -40,6 +42,8 @@
     --border: #506c90;          /* was #2a3448 — matches border-color */
     --input-bg: #1a2332;
     --code-bg: rgba(255, 255, 255, 0.07);
+    --code-block-bg: #1e1e2e;        /* Catppuccin mocha — dark bg with readable syntax colors */
+    --code-block-text: #cdd6f4;
     --table-header-bg: rgba(255, 255, 255, 0.05);
     --unread-bg: rgba(77, 142, 240, 0.10); /* was 0.08 — slightly more visible */
 
@@ -647,10 +651,10 @@ textarea.form-input {
     font-size: 0.88em;
 }
 
-/* Code blocks */
+/* Code blocks — theme-aware background + text, syntax colors from highlight.js theme */
 .message-body.markdown-body pre {
-    background: #1e1e2e;
-    color: #cdd6f4;
+    background: var(--code-block-bg);
+    color: var(--code-block-text);
     padding: 14px 16px;
     border-radius: var(--radius);
     overflow-x: auto;
@@ -658,6 +662,7 @@ textarea.form-input {
     font-size: 13px;
     line-height: 1.5;
     -webkit-overflow-scrolling: touch;
+    border: 1px solid var(--border-color);
 }
 
 .message-body.markdown-body pre code {

--- a/tests/test_hrana_retry.py
+++ b/tests/test_hrana_retry.py
@@ -1,0 +1,108 @@
+"""Tests for Hrana stream-not-found silent retry behavior."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from deadrop import db
+
+
+def test_is_hrana_stream_error_detects_stream_not_found():
+    err = ValueError(
+        'Hrana: `api error: `status=404 Not Found, body={"error":"stream not found: abc:def"}`'
+    )
+    assert db._is_hrana_stream_error(err)
+
+
+def test_is_hrana_stream_error_rejects_other_errors():
+    err = ValueError("something unrelated")
+    assert not db._is_hrana_stream_error(err)
+
+
+def test_execute_with_retry_recovers_from_hrana_404(monkeypatch):
+    """First call raises Hrana 404, second call succeeds."""
+    # Pretend libsql backend is active so retry kicks in
+    monkeypatch.setattr(db, "_is_libsql", True)
+
+    call_count = {"n": 0}
+
+    def flaky_op():
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise ValueError(
+                'Hrana: `api error: `status=404 Not Found, body={"error":"stream not found: abc"}`'
+            )
+        return "ok"
+
+    with patch.object(db, "_reset_libsql_connection"):
+        result = db._execute_with_retry(flaky_op, max_retries=2)
+
+    assert result == "ok"
+    assert call_count["n"] == 2
+
+
+def test_execute_with_retry_exhausts_after_max(monkeypatch):
+    """Always-failing Hrana 404 eventually propagates."""
+    monkeypatch.setattr(db, "_is_libsql", True)
+
+    def always_fails():
+        raise ValueError(
+            'Hrana: `api error: `status=404 Not Found, body={"error":"stream not found: abc"}`'
+        )
+
+    with patch.object(db, "_reset_libsql_connection"):
+        import pytest
+
+        with pytest.raises(ValueError, match="stream not found"):
+            db._execute_with_retry(always_fails, max_retries=2)
+
+
+def test_execute_with_retry_doesnt_retry_non_hrana_errors(monkeypatch):
+    """Non-Hrana exceptions propagate immediately, no retry."""
+    monkeypatch.setattr(db, "_is_libsql", True)
+    call_count = {"n": 0}
+
+    def different_error():
+        call_count["n"] += 1
+        raise RuntimeError("something else entirely")
+
+    with patch.object(db, "_reset_libsql_connection"):
+        import pytest
+
+        with pytest.raises(RuntimeError):
+            db._execute_with_retry(different_error, max_retries=2)
+
+    # Only called once — no retry
+    assert call_count["n"] == 1
+
+
+def test_execute_with_retry_no_retry_on_sqlite(monkeypatch):
+    """With _is_libsql=False (plain sqlite3), no retry even for Hrana-looking errors."""
+    monkeypatch.setattr(db, "_is_libsql", False)
+    call_count = {"n": 0}
+
+    def fails_with_hrana_message():
+        call_count["n"] += 1
+        raise ValueError(
+            'Hrana: `api error: `status=404 Not Found, body={"error":"stream not found: abc"}`'
+        )
+
+    import pytest
+
+    with pytest.raises(ValueError):
+        db._execute_with_retry(fails_with_hrana_message, max_retries=2)
+
+    assert call_count["n"] == 1
+
+
+def test_execute_with_retry_success_on_first_try(monkeypatch):
+    """Happy path: operation succeeds first time, no retry."""
+    monkeypatch.setattr(db, "_is_libsql", True)
+    call_count = {"n": 0}
+
+    def ok_op():
+        call_count["n"] += 1
+        return "hello"
+
+    assert db._execute_with_retry(ok_op, max_retries=2) == "hello"
+    assert call_count["n"] == 1


### PR DESCRIPTION
## Problem

deaddrop logs show recurring:
```
ValueError: Hrana: \`api error: \`status=404 Not Found, body={"error":"stream not found: <id>"}\`\`
```

Transient — Turso's Hrana protocol sometimes rotates stream ids / connections expire. Reconnecting resolves it.

## Root cause

`_execute_with_retry()` + `_reset_libsql_connection()` already exist in db.py to handle this, but **only ONE caller used them**. API async handlers go through `_run_read` / `_run_write` which bypassed the retry wrapper → errors propagated as 500s to clients.

## Fix

Wrap the fn call inside `_run_read` and `_run_write` with `db._execute_with_retry()`. Silent retry for libsql Hrana 404s, transparent passthrough for non-libsql + non-matching errors.

## Tests

7 new tests in `tests/test_hrana_retry.py`:
- Hrana 404 detection
- Retry recovery (fail once → retry → success)
- Retry exhaustion (propagates after max)
- No-retry on non-Hrana exceptions
- No-retry when `_is_libsql=False`
- Happy path (no retry needed)

All pass.