### PR TITLE
fix(deaddrop): non-v7 cursor handling (DB advance + API read-path leniency)

### DIFF
--- a/src/deadrop/api.py
+++ b/src/deadrop/api.py
@@ -132,10 +132,11 @@ async def lifespan(app: FastAPI):
     db.close_db()
 
 
-
 import re as _re
 
-_UUID7_RE = _re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$", _re.I)
+_UUID7_RE = _re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$", _re.I
+)
 
 
 def _is_valid_uuid7(value: str) -> bool:
@@ -147,6 +148,26 @@ def _require_uuid7(value: str | None, field_name: str) -> None:
     """Raise HTTPException 400 if value is a non-empty string that isn't UUID v7."""
     if value is not None and value != "" and not _is_valid_uuid7(value):
         raise HTTPException(400, f"Invalid {field_name}: must be a UUID v7 (got {value!r})")
+
+
+def _coerce_read_cursor(value: str | None, field_name: str = "cursor") -> str | None:
+    """For READ paths: return value if it's a valid UUID v7, else None.
+
+    Legacy data (pre-e9ec324 when API-layer v7 validation landed) may have
+    seeded UUIDv4 cursors into client-held state — localStorage, SSE topic
+    subscriptions, the web UI's last-rendered mid. A strict 400 on those
+    would wedge the reader forever; instead, quietly fall back to "no
+    cursor" (i.e. latest messages) and log once so we can see the churn.
+
+    Write paths (POST /read, reply reference_mid) stay strict via
+    _require_uuid7 — we do not want new v4s written to the DB.
+    """
+    if value is None or value == "":
+        return None
+    if _is_valid_uuid7(value):
+        return value
+    logger.warning("ignoring non-v7 read cursor for %s: %r", field_name, value)
+    return None
 
 
 app = FastAPI(
@@ -1144,7 +1165,8 @@ async def get_inbox(
     # Only mailbox owner can read their inbox
     await _require_inbox_secret(ns, identity_id, x_inbox_secret)
 
-    _require_uuid7(after, "after")
+    # Read path: non-v7 cursors (legacy poisoning) degrade to "no cursor".
+    after = _coerce_read_cursor(after, "after")
 
     # Fetch and return messages
     messages = await _run_read(
@@ -1782,8 +1804,9 @@ async def get_room_messages(
     if room["ns"] != ns:
         raise HTTPException(404, "Room not found in this namespace")
 
-    _require_uuid7(after, "after")
-    _require_uuid7(before, "before")
+    # Read path: non-v7 cursors (legacy poisoning) degrade to "no cursor".
+    after = _coerce_read_cursor(after, "after")
+    before = _coerce_read_cursor(before, "before")
 
     messages = await _run_read(
         functools.partial(
@@ -2091,7 +2114,8 @@ async def get_attachment(
         # Look up the message's room_id to verify membership
         conn = db.get_connection()
         cursor = conn.execute(
-            "SELECT room_id FROM room_messages WHERE mid = ?", (attachment["message_mid"],),
+            "SELECT room_id FROM room_messages WHERE mid = ?",
+            (attachment["message_mid"],),
             name="get_attachment.lookup_room",
         )
         row = cursor.fetchone()
@@ -2163,8 +2187,12 @@ async def subscribe(
 
     await _validate_subscription_topics(ns, request.topics, caller_id)
 
-    for topic_key, cursor in request.topics.items():
-        _require_uuid7(cursor, f"cursor for {topic_key}")
+    # Subscribe is a READ path — non-v7 cursors degrade to "no cursor"
+    # so legacy v4 values in client state don't wedge the subscription.
+    request.topics = {
+        topic_key: _coerce_read_cursor(cursor, f"cursor for {topic_key}")
+        for topic_key, cursor in request.topics.items()
+    }
 
     event_bus = get_event_bus()
 

--- a/src/deadrop/db.py
+++ b/src/deadrop/db.py
@@ -2701,12 +2701,24 @@ def update_room_read_cursor(
     """
     conn = _get_conn(conn)
 
-    # Only update if cursor moves forward (UUID7 is lexicographically sortable)
+    # Only update if cursor moves forward (UUID7 is lexicographically sortable).
+    #
+    # Legacy data may contain non-v7 cursors (UUIDv4s from before API-level
+    # validation was added). A v4 like '1e14...' is lexicographically greater
+    # than any v7 like '0194...' / '01f0...', so a naive `last_read_mid < ?`
+    # check silently refuses to advance past a poisoned v4 cursor. Treat any
+    # non-v7 stored cursor as "unset" so new v7 writes clobber poisoning.
+    # UUID v7 has version nibble '7' at string position 14 (0-indexed),
+    # i.e. the 15th character — SQL substr is 1-indexed so position 15.
     cursor = conn.execute(
-        """UPDATE room_members 
+        """UPDATE room_members
            SET last_read_mid = ?
            WHERE room_id = ? AND identity_id = ?
-           AND (last_read_mid IS NULL OR last_read_mid < ?)""",
+           AND (
+               last_read_mid IS NULL
+               OR substr(last_read_mid, 15, 1) != '7'
+               OR last_read_mid < ?
+           )""",
         (last_read_mid, room_id, identity_id, last_read_mid),
         name="update_room_read_cursor.update",
     )
@@ -2756,6 +2768,12 @@ def get_room_unread_count(
         return 0  # Not a member
 
     last_read_mid = row[0]
+
+    # Treat legacy non-v7 cursors (e.g. UUIDv4) as unset — they can't be
+    # compared meaningfully against v7 message IDs. See update_room_read_cursor
+    # for the matching write-path defense.
+    if last_read_mid and len(last_read_mid) >= 15 and last_read_mid[14] != "7":
+        last_read_mid = None
 
     # Count messages after the cursor
     if last_read_mid:

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -526,6 +526,74 @@ class TestRoomReadTracking:
 
         assert result is False
 
+    def test_update_room_read_cursor_overrides_poisoned_uuid_v4(self):
+        """Legacy UUIDv4 cursors must NOT block UUIDv7 advancement.
+
+        Regression: pre-validation data may contain a v4 like
+        '1e141d46-f442-4391-b714-98aeb44c442f' stored as last_read_mid.
+        Any v4 lexicographically > any v7 (v7 starts with timestamp bytes
+        like '01f0...' or '0194...', v4 starts with random bytes),
+        so `last_read_mid < new_v7` is false and the UPDATE silently
+        no-ops. New v7 cursor writes must clobber v4 poisoning.
+        """
+        ns = db.create_namespace()
+        alice = db.create_identity(ns["ns"])
+        room = db.create_room(ns["ns"], alice["id"])
+        msg = db.send_room_message(room["room_id"], alice["id"], "hi")
+
+        # Poison the cursor directly (simulating legacy data from before
+        # API-level v7 validation was added).
+        poisoned_v4 = "1e141d46-f442-4391-b714-98aeb44c442f"
+        conn = db._get_conn(None)
+        conn.execute(
+            "UPDATE room_members SET last_read_mid = ? "
+            "WHERE room_id = ? AND identity_id = ?",
+            (poisoned_v4, room["room_id"], alice["id"]),
+            name="test.poison_cursor",
+        )
+        conn.commit()
+
+        # Sanity: the poisoned value is indeed > the new v7 lexicographically
+        assert poisoned_v4 > msg["mid"]
+
+        # Now advance with a real v7. Must succeed.
+        result = db.update_room_read_cursor(room["room_id"], alice["id"], msg["mid"])
+
+        assert result is True
+        info = db.get_room_member_info(room["room_id"], alice["id"])
+        assert info["last_read_mid"] == msg["mid"]
+
+    def test_get_room_unread_count_with_poisoned_v4_cursor(self):
+        """Unread count must be correct even when stored cursor is a v4.
+
+        With a v4 cursor '1e14...' and v7 messages like '01f0...', the
+        `mid > last_read_mid` comparison returns 0 unread even when
+        messages exist. Poisoned cursors should be treated as 'unset'.
+        """
+        ns = db.create_namespace()
+        alice = db.create_identity(ns["ns"])
+        bob = db.create_identity(ns["ns"])
+        room = db.create_room(ns["ns"], alice["id"])
+        db.add_room_member(room["room_id"], bob["id"])
+
+        db.send_room_message(room["room_id"], alice["id"], "msg 1")
+        db.send_room_message(room["room_id"], alice["id"], "msg 2")
+
+        # Poison bob's cursor
+        poisoned_v4 = "1e141d46-f442-4391-b714-98aeb44c442f"
+        conn = db._get_conn(None)
+        conn.execute(
+            "UPDATE room_members SET last_read_mid = ? "
+            "WHERE room_id = ? AND identity_id = ?",
+            (poisoned_v4, room["room_id"], bob["id"]),
+            name="test.poison_cursor",
+        )
+        conn.commit()
+
+        # Two new messages, poisoned cursor => should report 2 unread
+        count = db.get_room_unread_count(room["room_id"], bob["id"])
+        assert count == 2
+
     def test_get_room_unread_count(self):
         """Get count of unread messages."""
         ns = db.create_namespace()

--- a/tests/test_uuid7_validation.py
+++ b/tests/test_uuid7_validation.py
@@ -1,6 +1,7 @@
 """Tests for UUID v7 validation on API endpoints."""
+
 import pytest
-from deadrop.api import _is_valid_uuid7, _require_uuid7
+from deadrop.api import _coerce_read_cursor, _is_valid_uuid7, _require_uuid7
 from fastapi.exceptions import HTTPException
 
 
@@ -50,6 +51,7 @@ class TestUUID7EndpointValidation:
     def client(self):
         from fastapi.testclient import TestClient
         from deadrop.api import app
+
         return TestClient(app)
 
     @pytest.fixture
@@ -85,31 +87,32 @@ class TestUUID7EndpointValidation:
             "room_id": room["room_id"],
         }
 
-    def test_subscribe_rejects_non_v7_cursor(self, client, setup):
+    def test_subscribe_tolerates_non_v7_cursor(self, client, setup):
+        """Read-path leniency: legacy v4 cursor (e.g. from stale client state)
+        is silently coerced to None, subscription starts from latest."""
         resp = client.post(
             f"/{setup['ns']}/subscribe",
-            headers={"X-Inbox-Secret": setup['identity_secret']},
+            headers={"X-Inbox-Secret": setup["identity_secret"]},
             json={
                 "topics": {f"room:{setup['room_id']}": "1e141d46-f442-4391-b714-98aeb44c442f"},
                 "mode": "poll",
                 "timeout": 1,
             },
         )
-        assert resp.status_code == 400
-        assert "UUID v7" in resp.json()["detail"]
+        assert resp.status_code == 200
 
     def test_subscribe_accepts_v7_cursor(self, client, setup):
         # Send a message to get a real v7 mid
         send_resp = client.post(
             f"/{setup['ns']}/rooms/{setup['room_id']}/messages",
-            headers={"X-Inbox-Secret": setup['identity_secret']},
+            headers={"X-Inbox-Secret": setup["identity_secret"]},
             json={"body": "hello"},
         )
         mid = send_resp.json()["mid"]
 
         resp = client.post(
             f"/{setup['ns']}/subscribe",
-            headers={"X-Inbox-Secret": setup['identity_secret']},
+            headers={"X-Inbox-Secret": setup["identity_secret"]},
             json={
                 "topics": {f"room:{setup['room_id']}": mid},
                 "mode": "poll",
@@ -121,7 +124,7 @@ class TestUUID7EndpointValidation:
     def test_subscribe_accepts_null_cursor(self, client, setup):
         resp = client.post(
             f"/{setup['ns']}/subscribe",
-            headers={"X-Inbox-Secret": setup['identity_secret']},
+            headers={"X-Inbox-Secret": setup["identity_secret"]},
             json={
                 "topics": {f"room:{setup['room_id']}": None},
                 "mode": "poll",
@@ -133,7 +136,7 @@ class TestUUID7EndpointValidation:
     def test_send_room_message_rejects_non_v7_reference(self, client, setup):
         resp = client.post(
             f"/{setup['ns']}/rooms/{setup['room_id']}/messages",
-            headers={"X-Inbox-Secret": setup['identity_secret']},
+            headers={"X-Inbox-Secret": setup["identity_secret"]},
             json={
                 "body": "test",
                 "reference_mid": "1e141d46-f442-4391-b714-98aeb44c442f",
@@ -145,26 +148,84 @@ class TestUUID7EndpointValidation:
     def test_read_cursor_rejects_non_v7(self, client, setup):
         resp = client.post(
             f"/{setup['ns']}/rooms/{setup['room_id']}/read",
-            headers={"X-Inbox-Secret": setup['identity_secret']},
+            headers={"X-Inbox-Secret": setup["identity_secret"]},
             json={"last_read_mid": "1e141d46-f442-4391-b714-98aeb44c442f"},
         )
         assert resp.status_code == 400
         assert "UUID v7" in resp.json()["detail"]
 
-    def test_get_messages_rejects_non_v7_after(self, client, setup):
+    def test_get_messages_tolerates_non_v7_after(self, client, setup):
+        """Read-path leniency: non-v7 'after' cursor degrades to no cursor,
+        endpoint returns latest messages instead of 400-ing."""
         resp = client.get(
             f"/{setup['ns']}/rooms/{setup['room_id']}/messages",
-            headers={"X-Inbox-Secret": setup['identity_secret']},
+            headers={"X-Inbox-Secret": setup["identity_secret"]},
             params={"after": "1e141d46-f442-4391-b714-98aeb44c442f"},
         )
-        assert resp.status_code == 400
-        assert "UUID v7" in resp.json()["detail"]
+        assert resp.status_code == 200
 
-    def test_get_inbox_rejects_non_v7_after(self, client, setup):
+    def test_get_messages_tolerates_non_v7_before(self, client, setup):
+        resp = client.get(
+            f"/{setup['ns']}/rooms/{setup['room_id']}/messages",
+            headers={"X-Inbox-Secret": setup["identity_secret"]},
+            params={"before": "1e141d46-f442-4391-b714-98aeb44c442f"},
+        )
+        assert resp.status_code == 200
+
+    def test_get_messages_accepts_v7_after(self, client, setup):
+        """Sanity: real v7 cursor still works as a filter."""
+        # Send two messages, use first's mid as 'after', expect second back.
+        r1 = client.post(
+            f"/{setup['ns']}/rooms/{setup['room_id']}/messages",
+            headers={"X-Inbox-Secret": setup["identity_secret"]},
+            json={"body": "first"},
+        )
+        mid1 = r1.json()["mid"]
+        r2 = client.post(
+            f"/{setup['ns']}/rooms/{setup['room_id']}/messages",
+            headers={"X-Inbox-Secret": setup["identity_secret"]},
+            json={"body": "second"},
+        )
+        mid2 = r2.json()["mid"]
+        resp = client.get(
+            f"/{setup['ns']}/rooms/{setup['room_id']}/messages",
+            headers={"X-Inbox-Secret": setup["identity_secret"]},
+            params={"after": mid1},
+        )
+        assert resp.status_code == 200
+        mids = [m["mid"] for m in resp.json()["messages"]]
+        assert mid2 in mids
+        assert mid1 not in mids
+
+    def test_get_inbox_tolerates_non_v7_after(self, client, setup):
+        """Read-path leniency: non-v7 'after' on inbox GET falls back to
+        no cursor rather than 400."""
         resp = client.get(
             f"/{setup['ns']}/inbox/{setup['identity_id']}",
-            headers={"X-Inbox-Secret": setup['identity_secret']},
+            headers={"X-Inbox-Secret": setup["identity_secret"]},
             params={"after": "1e141d46-f442-4391-b714-98aeb44c442f"},
         )
-        assert resp.status_code == 400
-        assert "UUID v7" in resp.json()["detail"]
+        assert resp.status_code == 200
+
+
+class TestCoerceReadCursor:
+    """Unit tests for _coerce_read_cursor helper."""
+
+    def test_none_returns_none(self):
+        assert _coerce_read_cursor(None) is None
+
+    def test_empty_returns_none(self):
+        assert _coerce_read_cursor("") is None
+
+    def test_valid_v7_passes_through(self):
+        v7 = "069f56ee-6ead-7394-8000-20d966e7dc6e"
+        assert _coerce_read_cursor(v7) == v7
+
+    def test_v4_coerces_to_none(self):
+        assert _coerce_read_cursor("1e141d46-f442-4391-b714-98aeb44c442f") is None
+
+    def test_garbage_coerces_to_none(self):
+        assert _coerce_read_cursor("not-a-uuid") is None
+
+    def test_v1_coerces_to_none(self):
+        assert _coerce_read_cursor("550e8400-e29b-11d4-a716-446655440000") is None


### PR DESCRIPTION
## Symptom

Sean's read cursor in the deaddrop web UI was stuck at an old UUIDv4 value `1e141d46-f442-4391-b714-98aeb44c442f` despite the client correctly POSTing new v7 mids on every render-at-bottom. Downstream, `unread_notifier` polled that stale cursor and either missed messages entirely or (after a bandage fix) spammed.

## Root cause

Two independent bugs, both rooted in v4/v7 mixing with lexicographic comparison.

**v7 vs v4 ordering:** v7 starts with 48 bits of ms-since-epoch (`0194...` / `01f0...`); v4 starts with random hex (`1e14...`). So `'1e14...' > '01f0...'` — any v4 is lexicographically greater than any real-world v7.

### Bug 1 — DB layer (`8525314`)
- `update_room_read_cursor` (db.py:2683): `WHERE last_read_mid IS NULL OR last_read_mid < ?` silently refuses to advance past a poisoned v4. Sean's cursor was wedged.
- `get_room_unread_count` (db.py:2735): `mid > last_read_mid` reports 0 unread when the stored cursor is v4 and all messages are v7.

### Bug 2 — API layer (`0655541`)
Read endpoints call `_require_uuid7` and return **HTTP 400** if the cursor isn't v7. Legacy client state (browser localStorage, stale subscribe topics, polling loops that cached a v4 before `e9ec324` added write-side validation) now wedges the reader — every poll 400s forever, no self-heal path without cache clear.

## Fix

**DB layer:** treat any stored non-v7 cursor (version nibble ≠ `'7'` at string position 14) as "unset" in both read and write paths. SQL `substr(last_read_mid, 15, 1) != '7'` on writes, Python index check on reads.

**API layer:** new helper `_coerce_read_cursor()` coerces non-v7 to `None` on read paths (fall back to 'no cursor' = latest messages) and logs a warning. Applied at:
- `GET /{ns}/inbox/{identity_id}` — `after`
- `GET /{ns}/rooms/{room_id}/messages` — `after` + `before`
- `POST /{ns}/subscribe` — each topic cursor

Write paths remain strict via `_require_uuid7`:
- `POST /{ns}/rooms/{room_id}/read` — `last_read_mid`
- `POST /{ns}/rooms/{room_id}/messages` — `reference_mid`

The two fixes are orthogonal: DB layer fixes what's already written; API layer fixes what clients keep sending.

## Tests

- `test_update_room_read_cursor_overrides_poisoned_uuid_v4` — regression using Sean's exact poisoned UUID
- `test_get_room_unread_count_with_poisoned_v4_cursor` — unread count correct with poisoned cursor
- `TestCoerceReadCursor` — 6 unit tests for the new helper
- `TestUUID7EndpointValidation` — 3 flipped tests (rejects → tolerates) + v7 sanity check
- Full suite: **603 passed**, 0 failed
- E2E against real FastAPI server on :8766: poisoned v4 cursor advances to v7; `unread_count` reports correctly before/after (covered by 8525314's manual verify).

## UUIDv4-vending audit

Exhaustive grep of `src/` for `uuid.uuid4|uuid4()|token_urlsafe|secrets.token_` found 3 hits — none produce message/cursor IDs:

| Site | Use | mid-related? |
|---|---|---|
| `api.py:179` | `request_id = uuid4().hex[:12]` — request tracing, 12-char truncation | no |
| `db.py:3156` | `attachment_id = str(uuid.uuid4())` — attachment IDs (separate column) | no |
| `auth.py:9` | `secrets.token_hex(32)` — identity secrets (hex, not UUID) | no |

Sean's `1e141d46-...` cursor is legacy data from **before** commit `e9ec324` (API-level v7 validation) landed. Nothing in the current codebase vends new v4s into mid/cursor paths.

## Risk

**LOW.** The change is strictly more permissive on read paths (previously 400 → now 200 + fallback) and strictly more defensive on write paths (stored v4 → treated as unset). No schema changes. No auth path. No session state. Write-side v7 strictness preserved (new v4s still can't get in).

## Ship decision

Shipping, not draft. Sean is actively blocked on this.