### PR TITLE
chore(ci): resolve pre-commit hook failures (pre-existing on main)

### DIFF
--- a/src/deadrop/api.py
+++ b/src/deadrop/api.py
@@ -5,6 +5,7 @@ import contextvars
 import json
 import logging
 import os
+import re as _re
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Annotated, Any, Literal
@@ -131,8 +132,6 @@ async def lifespan(app: FastAPI):
     stop_cache_warming()
     db.close_db()
 
-
-import re as _re
 
 _UUID7_RE = _re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$", _re.I

--- a/src/deadrop/cache.py
+++ b/src/deadrop/cache.py
@@ -256,7 +256,10 @@ async def warm_caches(conn: sqlite3.Connection | None = None) -> dict[str, int]:
         results = {"rooms": 0, "memberships": 0, "identities": 0}
 
         # Warm room cache
-        cursor = c.execute("SELECT room_id, ns, display_name, created_by, created_at FROM rooms", name="cache_warm.rooms")
+        cursor = c.execute(
+            "SELECT room_id, ns, display_name, created_by, created_at FROM rooms",
+            name="cache_warm.rooms",
+        )
         rows = cursor.fetchall()
         room_items = {}
         for row in rows:
@@ -266,7 +269,9 @@ async def warm_caches(conn: sqlite3.Connection | None = None) -> dict[str, int]:
         results["rooms"] = room_cache.set_bulk(room_items)
 
         # Warm membership cache
-        cursor = c.execute("SELECT room_id, identity_id FROM room_members", name="cache_warm.memberships")
+        cursor = c.execute(
+            "SELECT room_id, identity_id FROM room_members", name="cache_warm.memberships"
+        )
         rows = cursor.fetchall()
         member_items = {}
         for row in rows:
@@ -274,7 +279,9 @@ async def warm_caches(conn: sqlite3.Connection | None = None) -> dict[str, int]:
         results["memberships"] = membership_cache.set_bulk(member_items)
 
         # Warm identity hash cache
-        cursor = c.execute("SELECT ns, id, secret_hash FROM identities", name="cache_warm.identities")
+        cursor = c.execute(
+            "SELECT ns, id, secret_hash FROM identities", name="cache_warm.identities"
+        )
         rows = cursor.fetchall()
         identity_items = {}
         for row in rows:

--- a/src/deadrop/db.py
+++ b/src/deadrop/db.py
@@ -104,8 +104,6 @@ WRITE_POOL_SIZE = int(os.environ.get("DEADROP_WRITE_POOL_SIZE", "4"))
 DB_POOL_SIZE = int(os.environ.get("DEADROP_DB_POOL_SIZE", str(READ_POOL_SIZE)))
 
 
-
-
 def get_read_executor():
     """Get the executor for read (SELECT-only) database operations.
 
@@ -595,13 +593,16 @@ def _rows_to_dicts(cursor_description: Any, rows: list) -> list[dict]:
 
 def _ensure_schema_version_table(conn: sqlite3.Connection) -> None:
     """Create the schema_version table if it doesn't exist."""
-    conn.execute("""
+    conn.execute(
+        """
         CREATE TABLE IF NOT EXISTS schema_version (
             version INTEGER PRIMARY KEY,
             applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             description TEXT
         )
-    """, name="schema.ensure_version_table")
+    """,
+        name="schema.ensure_version_table",
+    )
     conn.commit()
 
 
@@ -641,14 +642,18 @@ def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
 def _migrate_001_add_content_type(conn: sqlite3.Connection) -> None:
     """Migration 001: Add content_type column to messages table."""
     if not _column_exists(conn, "messages", "content_type"):
-        conn.execute("ALTER TABLE messages ADD COLUMN content_type TEXT DEFAULT 'text/plain'", name="migrate.001")
+        conn.execute(
+            "ALTER TABLE messages ADD COLUMN content_type TEXT DEFAULT 'text/plain'",
+            name="migrate.001",
+        )
         conn.commit()
 
 
 def _migrate_002_add_rooms(conn: sqlite3.Connection) -> None:
     """Migration 002: Add rooms tables for group communication."""
     # Create rooms table
-    conn.execute("""
+    conn.execute(
+        """
         CREATE TABLE IF NOT EXISTS rooms (
             room_id TEXT PRIMARY KEY,
             ns TEXT NOT NULL REFERENCES namespaces(ns) ON DELETE CASCADE,
@@ -656,10 +661,13 @@ def _migrate_002_add_rooms(conn: sqlite3.Connection) -> None:
             created_by TEXT,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )
-    """, name="migrate.002.create_rooms")
+    """,
+        name="migrate.002.create_rooms",
+    )
 
     # Create room_members table with per-user read tracking
-    conn.execute("""
+    conn.execute(
+        """
         CREATE TABLE IF NOT EXISTS room_members (
             room_id TEXT NOT NULL REFERENCES rooms(room_id) ON DELETE CASCADE,
             identity_id TEXT NOT NULL,
@@ -669,10 +677,13 @@ def _migrate_002_add_rooms(conn: sqlite3.Connection) -> None:
             PRIMARY KEY (room_id, identity_id),
             FOREIGN KEY (ns, identity_id) REFERENCES identities(ns, id) ON DELETE CASCADE
         )
-    """, name="migrate.002.create_room_members")
+    """,
+        name="migrate.002.create_room_members",
+    )
 
     # Create room_messages table
-    conn.execute("""
+    conn.execute(
+        """
         CREATE TABLE IF NOT EXISTS room_messages (
             mid TEXT PRIMARY KEY,
             room_id TEXT NOT NULL REFERENCES rooms(room_id) ON DELETE CASCADE,
@@ -681,7 +692,9 @@ def _migrate_002_add_rooms(conn: sqlite3.Connection) -> None:
             content_type TEXT DEFAULT 'text/plain',
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )
-    """, name="migrate.002.create_room_messages")
+    """,
+        name="migrate.002.create_room_messages",
+    )
 
     # Create indexes
     conn.execute("CREATE INDEX IF NOT EXISTS idx_rooms_ns ON rooms(ns)", name="migrate.002.idx")
@@ -721,7 +734,10 @@ def _migrate_004_add_mid_indexes(conn: sqlite3.Connection) -> None:
         "CREATE INDEX IF NOT EXISTS idx_room_messages_room_mid ON room_messages(room_id, mid)",
         name="migrate.004.idx",
     )
-    conn.execute("CREATE INDEX IF NOT EXISTS idx_messages_inbox_mid ON messages(ns, to_id, mid)", name="migrate.004.idx")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_messages_inbox_mid ON messages(ns, to_id, mid)",
+        name="migrate.004.idx",
+    )
     conn.commit()
 
 
@@ -761,7 +777,8 @@ def _migrate_006_add_attachments(conn: sqlite3.Connection) -> None:
     lightweight. Each attachment belongs to exactly one message (via message_mid)
     and stores its content as base64-encoded text.
     """
-    conn.execute("""
+    conn.execute(
+        """
         CREATE TABLE IF NOT EXISTS attachments (
             id TEXT PRIMARY KEY,
             message_mid TEXT NOT NULL
@@ -772,8 +789,13 @@ def _migrate_006_add_attachments(conn: sqlite3.Connection) -> None:
             size INTEGER NOT NULL DEFAULT 0,
             created_at TEXT NOT NULL
         )
-    """, name="migrate.006.create_attachments")
-    conn.execute("CREATE INDEX IF NOT EXISTS idx_attachments_mid ON attachments(message_mid)", name="migrate.006.idx")
+    """,
+        name="migrate.006.create_attachments",
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_attachments_mid ON attachments(message_mid)",
+        name="migrate.006.idx",
+    )
     conn.commit()
 
 
@@ -1088,7 +1110,11 @@ def get_or_create_namespace_slug(
     """Get existing slug or create one for namespace."""
     conn = _get_conn(conn)
 
-    cursor = conn.execute("SELECT slug, metadata FROM namespaces WHERE ns = ?", (ns,), name="get_or_create_namespace_slug.select")
+    cursor = conn.execute(
+        "SELECT slug, metadata FROM namespaces WHERE ns = ?",
+        (ns,),
+        name="get_or_create_namespace_slug.select",
+    )
     row = _row_to_dict(cursor.description, cursor.fetchone())
 
     if not row:
@@ -1101,7 +1127,11 @@ def get_or_create_namespace_slug(
     base_slug = suggested_slug or slugify(metadata.get("display_name", "")) or ns[:8]
     slug = make_unique_slug(base_slug, exclude_ns=ns, conn=conn)
 
-    conn.execute("UPDATE namespaces SET slug = ? WHERE ns = ?", (slug, ns), name="get_or_create_namespace_slug.update")
+    conn.execute(
+        "UPDATE namespaces SET slug = ? WHERE ns = ?",
+        (slug, ns),
+        name="get_or_create_namespace_slug.update",
+    )
     conn.commit()
     return slug
 
@@ -1114,11 +1144,19 @@ def set_namespace_slug(ns: str, slug: str, conn: sqlite3.Connection | None = Non
     if not clean_slug:
         return False
 
-    cursor = conn.execute("SELECT ns FROM namespaces WHERE slug = ? AND ns != ?", (clean_slug, ns), name="set_namespace_slug.check")
+    cursor = conn.execute(
+        "SELECT ns FROM namespaces WHERE slug = ? AND ns != ?",
+        (clean_slug, ns),
+        name="set_namespace_slug.check",
+    )
     if cursor.fetchone():
         return False
 
-    cursor = conn.execute("UPDATE namespaces SET slug = ? WHERE ns = ?", (clean_slug, ns), name="set_namespace_slug.update")
+    cursor = conn.execute(
+        "UPDATE namespaces SET slug = ? WHERE ns = ?",
+        (clean_slug, ns),
+        name="set_namespace_slug.update",
+    )
     conn.commit()
     return cursor.rowcount > 0
 
@@ -1126,7 +1164,9 @@ def set_namespace_slug(ns: str, slug: str, conn: sqlite3.Connection | None = Non
 def is_namespace_archived(ns: str, conn: sqlite3.Connection | None = None) -> bool:
     """Check if namespace is archived (read-only)."""
     conn = _get_conn(conn)
-    cursor = conn.execute("SELECT archived_at FROM namespaces WHERE ns = ?", (ns,), name="is_namespace_archived")
+    cursor = conn.execute(
+        "SELECT archived_at FROM namespaces WHERE ns = ?", (ns,), name="is_namespace_archived"
+    )
     row = _row_to_dict(cursor.description, cursor.fetchone())
     return row is not None and row["archived_at"] is not None
 
@@ -1136,7 +1176,8 @@ def archive_namespace(ns: str, conn: sqlite3.Connection | None = None) -> bool:
     conn = _get_conn(conn)
     now = datetime.now(timezone.utc).isoformat()
     cursor = conn.execute(
-        "UPDATE namespaces SET archived_at = ? WHERE ns = ? AND archived_at IS NULL", (now, ns),
+        "UPDATE namespaces SET archived_at = ? WHERE ns = ? AND archived_at IS NULL",
+        (now, ns),
         name="archive_namespace",
     )
     conn.commit()
@@ -1156,7 +1197,9 @@ def get_namespace_ttl_hours(ns: str, conn: sqlite3.Connection | None = None) -> 
         return cached
 
     conn = _get_conn(conn)
-    cursor = conn.execute("SELECT ttl_hours FROM namespaces WHERE ns = ?", (ns,), name="get_namespace_ttl_hours")
+    cursor = conn.execute(
+        "SELECT ttl_hours FROM namespaces WHERE ns = ?", (ns,), name="get_namespace_ttl_hours"
+    )
     row = _row_to_dict(cursor.description, cursor.fetchone())
     ttl = row["ttl_hours"] if row else DEFAULT_TTL_HOURS
     _namespace_ttl_cache[ns] = ttl
@@ -1191,7 +1234,9 @@ def verify_namespace_secret(ns: str, secret: str, conn: sqlite3.Connection | Non
         return False
 
     conn = _get_conn(conn)
-    cursor = conn.execute("SELECT secret_hash FROM namespaces WHERE ns = ?", (ns,), name="verify_namespace_secret")
+    cursor = conn.execute(
+        "SELECT secret_hash FROM namespaces WHERE ns = ?", (ns,), name="verify_namespace_secret"
+    )
     row = _row_to_dict(cursor.description, cursor.fetchone())
 
     if not row:
@@ -1218,7 +1263,8 @@ def update_namespace_metadata(
     """Update namespace metadata."""
     conn = _get_conn(conn)
     cursor = conn.execute(
-        "UPDATE namespaces SET metadata = ? WHERE ns = ?", (json.dumps(metadata), ns),
+        "UPDATE namespaces SET metadata = ? WHERE ns = ?",
+        (json.dumps(metadata), ns),
         name="update_namespace_metadata",
     )
     conn.commit()
@@ -1259,7 +1305,8 @@ def get_identity(
     """Get identity by ID."""
     conn = _get_conn(conn)
     cursor = conn.execute(
-        "SELECT id, metadata, created_at FROM identities WHERE ns = ? AND id = ?", (ns, identity_id),
+        "SELECT id, metadata, created_at FROM identities WHERE ns = ? AND id = ?",
+        (ns, identity_id),
         name="get_identity",
     )
     row = _row_to_dict(cursor.description, cursor.fetchone())
@@ -1281,7 +1328,8 @@ def get_identity_secret_hash(
     """Get the secret hash for an identity (used for invite creation)."""
     conn = _get_conn(conn)
     cursor = conn.execute(
-        "SELECT secret_hash FROM identities WHERE ns = ? AND id = ?", (ns, identity_id),
+        "SELECT secret_hash FROM identities WHERE ns = ? AND id = ?",
+        (ns, identity_id),
         name="get_identity_secret_hash",
     )
     row = _row_to_dict(cursor.description, cursor.fetchone())
@@ -1292,7 +1340,8 @@ def list_identities(ns: str, conn: sqlite3.Connection | None = None) -> list[dic
     """List all identities in a namespace."""
     conn = _get_conn(conn)
     cursor = conn.execute(
-        "SELECT id, metadata, created_at FROM identities WHERE ns = ? ORDER BY created_at", (ns,),
+        "SELECT id, metadata, created_at FROM identities WHERE ns = ? ORDER BY created_at",
+        (ns,),
         name="list_identities",
     )
     rows = _rows_to_dicts(cursor.description, cursor.fetchall())
@@ -1333,7 +1382,8 @@ def verify_identity_secret(
     # Cache miss — fall through to DB
     conn = _get_conn(conn)
     cursor = conn.execute(
-        "SELECT secret_hash FROM identities WHERE ns = ? AND id = ?", (ns, identity_id),
+        "SELECT secret_hash FROM identities WHERE ns = ? AND id = ?",
+        (ns, identity_id),
         name="verify_identity_secret",
     )
     row = _row_to_dict(cursor.description, cursor.fetchone())
@@ -1371,7 +1421,8 @@ def verify_identity_in_namespace(
     # Cache miss — fall through to DB
     conn = _get_conn(conn)
     cursor = conn.execute(
-        "SELECT secret_hash FROM identities WHERE ns = ? AND id = ?", (ns, identity_id),
+        "SELECT secret_hash FROM identities WHERE ns = ? AND id = ?",
+        (ns, identity_id),
         name="verify_identity_in_namespace",
     )
     row = _row_to_dict(cursor.description, cursor.fetchone())
@@ -1394,7 +1445,9 @@ def delete_identity(
 ) -> bool:
     """Delete an identity and all its messages."""
     conn = _get_conn(conn)
-    cursor = conn.execute("DELETE FROM identities WHERE ns = ? AND id = ?", (ns, identity_id), name="delete_identity")
+    cursor = conn.execute(
+        "DELETE FROM identities WHERE ns = ? AND id = ?", (ns, identity_id), name="delete_identity"
+    )
     conn.commit()
     return cursor.rowcount > 0
 
@@ -1683,7 +1736,8 @@ def delete_message(
     """Immediately delete a message."""
     conn = _get_conn(conn)
     cursor = conn.execute(
-        "DELETE FROM messages WHERE ns = ? AND to_id = ? AND mid = ?", (ns, identity_id, mid),
+        "DELETE FROM messages WHERE ns = ? AND to_id = ? AND mid = ?",
+        (ns, identity_id, mid),
         name="delete_message",
     )
     conn.commit()
@@ -1907,7 +1961,9 @@ def list_invites(
 def revoke_invite(invite_id: str, conn: sqlite3.Connection | None = None) -> bool:
     """Revoke (delete) an invite."""
     conn = _get_conn(conn)
-    cursor = conn.execute("DELETE FROM invites WHERE invite_id = ?", (invite_id,), name="revoke_invite")
+    cursor = conn.execute(
+        "DELETE FROM invites WHERE invite_id = ?", (invite_id,), name="revoke_invite"
+    )
     conn.commit()
     return cursor.rowcount > 0
 
@@ -2043,11 +2099,14 @@ def get_archive_batches(
 
     if ns:
         cursor = conn.execute(
-            "SELECT * FROM archive_batches WHERE ns = ? ORDER BY created_at", (ns,),
+            "SELECT * FROM archive_batches WHERE ns = ? ORDER BY created_at",
+            (ns,),
             name="get_archive_batches",
         )
     else:
-        cursor = conn.execute("SELECT * FROM archive_batches ORDER BY created_at", name="get_archive_batches")
+        cursor = conn.execute(
+            "SELECT * FROM archive_batches ORDER BY created_at", name="get_archive_batches"
+        )
 
     return _rows_to_dicts(cursor.description, cursor.fetchall())
 
@@ -2077,7 +2136,11 @@ def create_room(
     conn = _get_conn(conn)
 
     # Verify creator exists in namespace
-    cursor = conn.execute("SELECT id FROM identities WHERE ns = ? AND id = ?", (ns, created_by), name="create_room.verify_creator")
+    cursor = conn.execute(
+        "SELECT id FROM identities WHERE ns = ? AND id = ?",
+        (ns, created_by),
+        name="create_room.verify_creator",
+    )
     if not cursor.fetchone():
         raise ValueError(f"Creator {created_by} not found in namespace {ns}")
 
@@ -2279,7 +2342,11 @@ def add_room_member(
     ns = room["ns"]
 
     # Verify identity exists in same namespace
-    cursor = conn.execute("SELECT id FROM identities WHERE ns = ? AND id = ?", (ns, identity_id), name="add_room_member.verify_identity")
+    cursor = conn.execute(
+        "SELECT id FROM identities WHERE ns = ? AND id = ?",
+        (ns, identity_id),
+        name="add_room_member.verify_identity",
+    )
     if not cursor.fetchone():
         raise ValueError(f"Identity {identity_id} not found in namespace {ns}")
 
@@ -3270,10 +3337,9 @@ def get_topic_latest(
     conn = _get_conn(conn)
 
     if topic_key.startswith("room:"):
-        room_id = topic_key[len("room:"):]
+        room_id = topic_key[len("room:") :]
         cursor = conn.execute(
-            "SELECT mid, from_id FROM room_messages "
-            "WHERE room_id = ? ORDER BY mid DESC LIMIT 1",
+            "SELECT mid, from_id FROM room_messages WHERE room_id = ? ORDER BY mid DESC LIMIT 1",
             (room_id,),
             name="get_topic_latest.room",
         )
@@ -3283,7 +3349,7 @@ def get_topic_latest(
         return None
 
     elif topic_key.startswith("inbox:"):
-        identity_id = topic_key[len("inbox:"):]
+        identity_id = topic_key[len("inbox:") :]
         if ns is None:
             return None
         cursor = conn.execute(

--- a/src/deadrop/events.py
+++ b/src/deadrop/events.py
@@ -180,9 +180,7 @@ class InMemoryEventBus(EventBus):
                 try:
                     db_result = self._db_fallback(namespace, topic, last_seen)
                 except Exception:
-                    logger.warning(
-                        "db_fallback failed for topic %s", topic, exc_info=True
-                    )
+                    logger.warning("db_fallback failed for topic %s", topic, exc_info=True)
                     db_result = None
                 if db_result is not None:
                     # Cache it so we never hit the DB for this topic again.

--- a/src/deadrop/instrument.py
+++ b/src/deadrop/instrument.py
@@ -280,7 +280,7 @@ class PrometheusSink:
 
     def generate_latest(self) -> bytes:  # pragma: no cover
         """Return Prometheus text format exposition for /metrics."""
-        return self._prom.generate_latest()  # type: ignore[return-value]
+        return self._prom.generate_latest()
 
 
 # ---------------------------------------------------------------------------
@@ -288,7 +288,7 @@ class PrometheusSink:
 # ---------------------------------------------------------------------------
 
 
-def _build_sink_from_env() -> MetricsSink:  # type: ignore[return]
+def _build_sink_from_env() -> MetricsSink:
     sink_name = os.environ.get("DEADROP_METRICS_SINK", "null").lower().strip()
     prefix = os.environ.get("DEADROP_METRICS_PREFIX", "deadrop")
 

--- a/src/deadrop/metrics.py
+++ b/src/deadrop/metrics.py
@@ -304,9 +304,10 @@ class InstrumentedConnection:
                 name = "sqlite_master"
             else:
                 raise TypeError(
-                    f"InstrumentedConnection.execute() requires name= for query: "
-                    f"{sql[:80]!r}"
+                    f"InstrumentedConnection.execute() requires name= for query: {sql[:80]!r}"
                 )
+        # Every path out of the sentinel branch assigns a str; narrow for the type checker.
+        assert isinstance(name, str)
         t0 = time.perf_counter()
         try:
             result = self._conn.execute(sql, params)

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -127,7 +127,11 @@ class TestDirectMessageDedup:
         window = db.DEDUP_WINDOW_SECONDS
         past = (datetime.now(timezone.utc) - timedelta(seconds=window + 10)).isoformat()
         conn = db._get_conn(None)
-        conn.execute("UPDATE messages SET created_at = ? WHERE mid = ?", (past, msg1["mid"]), name="test.expire_dedup_window")
+        conn.execute(
+            "UPDATE messages SET created_at = ? WHERE mid = ?",
+            (past, msg1["mid"]),
+            name="test.expire_dedup_window",
+        )
         conn.commit()
 
         msg2 = db.send_message(ns, alice_id, bob_id, "Hello!")
@@ -267,7 +271,11 @@ class TestRoomMessageDedup:
         window = db.DEDUP_WINDOW_SECONDS
         past = (datetime.now(timezone.utc) - timedelta(seconds=window + 10)).isoformat()
         conn = db._get_conn(None)
-        conn.execute("UPDATE room_messages SET created_at = ? WHERE mid = ?", (past, msg1["mid"]), name="test.expire_dedup_window")
+        conn.execute(
+            "UPDATE room_messages SET created_at = ? WHERE mid = ?",
+            (past, msg1["mid"]),
+            name="test.expire_dedup_window",
+        )
         conn.commit()
 
         msg2 = db.send_room_message(room_id, alice_id, "Hello!")

--- a/tests/test_instrumented_connection.py
+++ b/tests/test_instrumented_connection.py
@@ -350,7 +350,9 @@ class TestIntegrationNamedQueriesInBuffer:
                 or name.startswith("delete.")
             ), f"Inferred SQL name found — should be explicit: {name!r}"
             # No unnamed queries should exist in production code paths
-            assert name != "unnamed", f"Unnamed query found in request — all queries must have name=: {names}"
+            assert name != "unnamed", (
+                f"Unnamed query found in request — all queries must have name=: {names}"
+            )
 
     def test_send_room_message_has_named_entries(self, client, admin_headers):
         """send_room_message produces explicitly-named per-SQL entries + @timed_query total."""

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -74,7 +74,9 @@ class TestTTLProcessing:
 
         # Verify message is gone
         conn = db.get_connection()
-        row = conn.execute("SELECT * FROM messages WHERE mid = ?", (mid,), name="test_select_message").fetchone()
+        row = conn.execute(
+            "SELECT * FROM messages WHERE mid = ?", (mid,), name="test_select_message"
+        ).fetchone()
         assert row is None
 
     def test_expired_messages_archived_not_deleted(self):
@@ -111,7 +113,9 @@ class TestTTLProcessing:
 
             # Message should still exist (not deleted)
             conn = db.get_connection()
-            row = conn.execute("SELECT * FROM messages WHERE mid = ?", (mid,), name="test_select_message").fetchone()
+            row = conn.execute(
+                "SELECT * FROM messages WHERE mid = ?", (mid,), name="test_select_message"
+            ).fetchone()
             assert row is not None
 
     def test_dry_run(self):
@@ -140,7 +144,9 @@ class TestTTLProcessing:
 
         # Message should still exist
         conn = db.get_connection()
-        row = conn.execute("SELECT * FROM messages WHERE mid = ?", (result["mid"],), name="test_select_message").fetchone()
+        row = conn.execute(
+            "SELECT * FROM messages WHERE mid = ?", (result["mid"],), name="test_select_message"
+        ).fetchone()
         assert row is not None
 
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -150,7 +150,11 @@ class TestMigration001ContentType:
         conn.commit()
 
         # Verify default value
-        cursor = conn.execute("SELECT content_type FROM messages WHERE mid = ?", ("test-mid",), name="test_migration_select")
+        cursor = conn.execute(
+            "SELECT content_type FROM messages WHERE mid = ?",
+            ("test-mid",),
+            name="test_migration_select",
+        )
         row = cursor.fetchone()
         assert row[0] == "text/plain"
 

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -546,8 +546,7 @@ class TestRoomReadTracking:
         poisoned_v4 = "1e141d46-f442-4391-b714-98aeb44c442f"
         conn = db._get_conn(None)
         conn.execute(
-            "UPDATE room_members SET last_read_mid = ? "
-            "WHERE room_id = ? AND identity_id = ?",
+            "UPDATE room_members SET last_read_mid = ? WHERE room_id = ? AND identity_id = ?",
             (poisoned_v4, room["room_id"], alice["id"]),
             name="test.poison_cursor",
         )
@@ -583,8 +582,7 @@ class TestRoomReadTracking:
         poisoned_v4 = "1e141d46-f442-4391-b714-98aeb44c442f"
         conn = db._get_conn(None)
         conn.execute(
-            "UPDATE room_members SET last_read_mid = ? "
-            "WHERE room_id = ? AND identity_id = ?",
+            "UPDATE room_members SET last_read_mid = ? WHERE room_id = ? AND identity_id = ?",
             (poisoned_v4, room["room_id"], bob["id"]),
             name="test.poison_cursor",
         )

--- a/tests/test_subscribe_cold_start.py
+++ b/tests/test_subscribe_cold_start.py
@@ -13,7 +13,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from deadrop.api import app
-from deadrop.events import InMemoryEventBus, get_event_bus, reset_event_bus, set_event_bus
+from deadrop.events import reset_event_bus
 
 
 @pytest.fixture(autouse=True)
@@ -76,9 +76,7 @@ def setup_with_room(client, admin_headers):
 class TestSubscribeColdStart:
     """Subscribe must detect pre-existing messages after event bus restart."""
 
-    def test_subscribe_detects_message_after_event_bus_reset(
-        self, client, setup_with_room
-    ):
+    def test_subscribe_detects_message_after_event_bus_reset(self, client, setup_with_room):
         """The core bug: message exists in DB, event bus restarted,
         subscribe should still detect it."""
         data = setup_with_room
@@ -111,8 +109,7 @@ class TestSubscribeColdStart:
             json={"body": "Are you there?"},
         )
         assert msg2_resp.status_code == 200
-        msg2 = msg2_resp.json()
-        second_mid = msg2["mid"]
+        assert "mid" in msg2_resp.json()  # second message persisted; we'll pick it up post-restart
 
         # *** SIMULATE SERVER RESTART ***
         # Reset the event bus — this is what happens when the process restarts.
@@ -140,13 +137,9 @@ class TestSubscribeColdStart:
             f"Subscribe should detect the pre-existing message, got: {result}"
         )
         events = result["events"]
-        assert f"room:{room_id}" in events, (
-            f"Room topic should be in events, got: {events}"
-        )
+        assert f"room:{room_id}" in events, f"Room topic should be in events, got: {events}"
 
-    def test_subscribe_no_false_positive_when_cursor_is_current(
-        self, client, setup_with_room
-    ):
+    def test_subscribe_no_false_positive_when_cursor_is_current(self, client, setup_with_room):
         """After reset, subscribe with cursor AT latest should NOT fire."""
         data = setup_with_room
         ns = data["ns"]
@@ -184,9 +177,7 @@ class TestSubscribeColdStart:
             f"Subscribe should NOT fire when cursor is at latest, got: {result}"
         )
 
-    def test_subscribe_inbox_detects_message_after_reset(
-        self, client, setup_with_room
-    ):
+    def test_subscribe_inbox_detects_message_after_reset(self, client, setup_with_room):
         """Inbox subscribe also needs cold-start detection."""
         data = setup_with_room
         ns = data["ns"]
@@ -210,7 +201,9 @@ class TestSubscribeColdStart:
             json={"to": bob_id, "body": "Second DM"},
         )
         assert dm2_resp.status_code == 200
-        dm2_mid = dm2_resp.json()["mid"]
+        assert (
+            "mid" in dm2_resp.json()
+        )  # second DM persisted; cold-start subscribe should surface it
 
         # Reset event bus
         reset_event_bus()


### PR DESCRIPTION
## Why

CI on `main` has been red across multiple PRs because pre-commit hooks fail on pre-existing issues in the codebase. The hooks aren't required status checks so functional merges go through, but the signal is cluttered and new PRs inherit the red by default.

PR #61 (v4-cursor leniency) merged with this same CI red. This PR retroactively cleans it up so subsequent work lands on green.

## What changed

Three hook categories, no behavior changes.

### ruff (lint) — 3 errors remaining after auto-fixes

| File | Error | Fix |
|---|---|---|
| `src/deadrop/api.py:135` | E402 `import re as _re` mid-file | Moved to module-level import block |
| `tests/test_subscribe_cold_start.py:115` | F841 unused `second_mid` | Replaced with `assert 'mid' in …json()` structural check |
| `tests/test_subscribe_cold_start.py:213` | F841 unused `dm2_mid` | Same |

### ruff (format)

10 files reformatted to current ruff-format style — mostly long `conn.execute()` calls split onto multiple lines. Purely cosmetic; diffed and verified.

### ty (type check)

- `src/deadrop/metrics.py:313` — `_record_query(name, …)` can't narrow `name: str | object` after the sentinel resolution. Added `assert isinstance(name, str)` which documents the invariant (every branch out of the `_MISSING` check assigns a str) and lets ty see it.
- `src/deadrop/instrument.py:283,291` — two dead `# type: ignore` suppressions that ty flagged as "unused blanket". Removed.

## Verification

```
$ uv run pre-commit run --all-files
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
ty type checker..........................................................Passed
check requirements.txt sync..............................................Passed

$ uv run pytest -q
603 passed in 55.11s
```

## Risk

**Zero.** No functional code changes. No API surface changes. No tests changed behavior (only non-asserting variable bindings replaced with structural asserts). Production deploy (`aa41c9d` on dokku) is unaffected — does not need redeploy.