### PR TITLE
fix: render all backfilled pages on scroll-up, not just the first

### DIFF
--- a/src/deadrop/templates/app.html
+++ b/src/deadrop/templates/app.html
@@ -982,8 +982,14 @@
             // Build reaction map across the full updated message set
             const reactionMap = buildReactionMap(roomMessages);
 
-            // Filter out reactions from display set
-            const olderDisplay = olderPage.filter(m => m.content_type !== 'reaction');
+            // Filter out reactions from display set.
+            // IMPORTANT: render ALL backfilled pages (`allOlder`), not just the
+            // first-fetched `olderPage`. Otherwise, when the first page is
+            // reaction-heavy, backfill grows the data model past the DOM — the
+            // next scroll-up cursor (roomMessages[0].mid) points further back
+            // than anything rendered, leaving a permanent rendering gap and
+            // divergence from the localStorage cache.
+            const olderDisplay = allOlder.filter(m => m.content_type !== 'reaction');
 
             // Build a DocumentFragment with the older messages.
             // column-reverse: DOM order is newest→oldest, so older messages
@@ -1032,7 +1038,7 @@
                 }
             });
 
-            console.log(`Loaded ${olderPage.length} older messages (total: ${roomMessages.length})`);
+            console.log(`Loaded ${allOlder.length} older messages (${olderDisplay.length} visible, total: ${roomMessages.length})`);
         } catch (e) {
             console.error('Failed to load older messages:', e);
         } finally {


### PR DESCRIPTION
## Symptom

Sean reported backscroll issues in the web client at deaddrop.dokku.heare.io.

When scrolling up in a room to load older messages:
- The DOM barely grew even when more messages clearly existed
- Subsequent scroll-up fetches left gaps in the rendered history
- localStorage cache diverged from DOM (visible as jumpy behavior across page reloads — the cache-render path on cold load would 'find' messages that the warm session never rendered)

## Root cause

Interaction bug between two recent changes to `loadOlderRoomMessages` in `src/deadrop/templates/app.html`:

- **PR #57** (326a155) introduced the incremental-DOM prepend path: render new messages directly into a `DocumentFragment` and append to the column-reverse list, letting `overflow-anchor: auto` preserve the viewport.
- **5832422** (today) added multi-page backfill for reaction-heavy pages: when the first fetched page is mostly reactions, keep fetching older pages into `allOlder` until we have enough visible messages.

The data-model update was changed to use `allOlder` (the full backfilled set):

```js
roomMessages = [...allOlder, ...roomMessages];
```

But the DOM render step wasn't updated to match — it still iterated `olderPage`, the originally-fetched first page:

```js
const olderDisplay = olderPage.filter(m => m.content_type !== 'reaction');
```

So on a reaction-heavy first page:
1. Data model gained N extra pages of messages ✓
2. DOM gained only the (mostly-empty) first page ✗
3. Next scroll-up cursor = `roomMessages[0].mid` — now points past what's rendered
4. Next fetch requests `beforeMid=<something-already-in-model-but-not-in-DOM>`, creating a permanent rendering gap

The initial-load path (`loadRoomMessages`) was unaffected because it calls `renderRoomMessages()` which re-renders from the full `roomMessages` model. The bug is specific to the incremental-prepend path.

## Fix

One-line change: render `allOlder` instead of `olderPage`. Added a comment documenting the invariant so the next person refactoring either side knows these must stay in lockstep. Log line updated to show visible vs. total for easier diagnosis next time.

```diff
-            // Filter out reactions from display set
-            const olderDisplay = olderPage.filter(m => m.content_type !== 'reaction');
+            // Filter out reactions from display set.
+            // IMPORTANT: render ALL backfilled pages (`allOlder`), not just the
+            // first-fetched `olderPage`. Otherwise, when the first page is
+            // reaction-heavy, backfill grows the data model past the DOM — the
+            // next scroll-up cursor (roomMessages[0].mid) points further back
+            // than anything rendered, leaving a permanent rendering gap and
+            // divergence from the localStorage cache.
+            const olderDisplay = allOlder.filter(m => m.content_type !== 'reaction');
```

## Testing

- No JS unit test harness in this repo (all JS is inline in the Jinja template).
- The bug reproduces naturally given Sean's context: after dumping ~249 catch-up reactions post power-outage, backfill kicks in on scroll-up.
- Verification post-merge: scroll up in a room, check console — `Loaded N older messages (K visible, total: T)` should show K > 0 when backfill was needed, and the DOM should contain K new visible messages.

## Related

- PR #57 (incremental prepend)
- 5832422 (backfill, introduced the regression)