### PR TITLE
chore(ci): resolve ruff check + format failures on main

### DIFF
--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -680,8 +680,11 @@ class TestExcludeReactions:
             mids.append(msg["mid"])
         for mid in mids:
             db.send_room_message(
-                room["room_id"], fritz["id"], "👀",
-                content_type="reaction", reference_mid=mid,
+                room["room_id"],
+                fritz["id"],
+                "👀",
+                content_type="reaction",
+                reference_mid=mid,
             )
 
         # Without exclude: 10 messages (5 text + 5 reactions)
@@ -707,8 +710,11 @@ class TestExcludeReactions:
             mids.append(msg["mid"])
         for mid in mids:
             db.send_room_message(
-                room["room_id"], fritz["id"], "👀",
-                content_type="reaction", reference_mid=mid,
+                room["room_id"],
+                fritz["id"],
+                "👀",
+                content_type="reaction",
+                reference_mid=mid,
             )
 
         # limit=3 with exclude: should get exactly 3 text messages
@@ -733,8 +739,11 @@ class TestExcludeReactions:
             mids.append(msg["mid"])
         for mid in mids:
             db.send_room_message(
-                room["room_id"], fritz["id"], "👀",
-                content_type="reaction", reference_mid=mid,
+                room["room_id"],
+                fritz["id"],
+                "👀",
+                content_type="reaction",
+                reference_mid=mid,
             )
 
         # Get newest 5 text messages
@@ -760,12 +769,15 @@ class TestExcludeReactions:
         db.add_room_member(room["room_id"], fritz["id"])
 
         # 1 text, then 25 different text messages each with a reaction
-        msg0 = db.send_room_message(room["room_id"], alice["id"], "Hello")
+        db.send_room_message(room["room_id"], alice["id"], "Hello")
         for i in range(25):
             m = db.send_room_message(room["room_id"], alice["id"], f"Filler {i}")
             db.send_room_message(
-                room["room_id"], fritz["id"], "👀",
-                content_type="reaction", reference_mid=m["mid"],
+                room["room_id"],
+                fritz["id"],
+                "👀",
+                content_type="reaction",
+                reference_mid=m["mid"],
             )
 
         # Without exclude, limit=20: all 20 are the tail (mix of text+reactions)
@@ -790,10 +802,13 @@ class TestExcludeReactions:
         for i in range(5):
             m = db.send_room_message(room["room_id"], alice["id"], f"Filler {i}")
             db.send_room_message(
-                room["room_id"], fritz["id"], "👀",
-                content_type="reaction", reference_mid=m["mid"],
+                room["room_id"],
+                fritz["id"],
+                "👀",
+                content_type="reaction",
+                reference_mid=m["mid"],
             )
-        msg_last = db.send_room_message(room["room_id"], alice["id"], "Last")
+        db.send_room_message(room["room_id"], alice["id"], "Last")
 
         # Forward from msg1: without exclude gets all 11 (5 text + 5 reactions + 1 last)
         all_after = db.get_room_messages(room["room_id"], after_mid=msg1["mid"], limit=20)

--- a/tests/test_rooms_api.py
+++ b/tests/test_rooms_api.py
@@ -470,8 +470,6 @@ class TestRoomMessages:
 
         assert response.status_code == 403
 
-
-
     def test_get_room_messages_exclude_reactions(self, client, setup_identities):
         """exclude_reactions query param filters reactions server-side."""
         data = setup_identities
@@ -522,6 +520,7 @@ class TestRoomMessages:
         msgs = resp.json()["messages"]
         assert len(msgs) == 3
         assert all(m["content_type"] != "reaction" for m in msgs)
+
 
 class TestRoomReadTracking:
     """Tests for read cursor tracking."""


### PR DESCRIPTION
## What

Fixes the pre-commit CI failure that's been red on every PR for the past few merges.

## Why

Two F841 (unused-local) lints + two ruff-format nits landed in \`28949c3\` (feat: server-side exclude_reactions) — that commit must have been pushed with pre-commit bypassed locally, so CI was the first place to catch it. Since pre-commit runs with \`--all-files\`, every subsequent PR (including #64 and #65 this afternoon) has been failing the CI gate on these pre-existing issues, not on their own diffs.

## Changes

\`tests/test_rooms.py\`:
- Drop \`msg0 =\` and \`msg_last =\` on two throwaway writes — the send is still exercised, just not named.
- Pick up incidental \`ruff format\` reflow in the same file (whitespace / linebreaks, nothing load-bearing).

\`tests/test_rooms_api.py\`:
- Class-separator blank-line hygiene (extra blank line removed between two tests, missing blank line added before the next class).

## Verified

- \`uv run ruff check .\` → All checks passed
- \`uv run ruff format --check .\` → 58 files already formatted
- \`uv run pytest tests/test_rooms.py tests/test_rooms_api.py\` → 77/77 passing

No behavior change. Pure CI-unsticker.