### PR TITLE
fix(web): poll loop is time-bounded so SSE retry can resume

### DIFF
--- a/src/deadrop/static/js/api.js
+++ b/src/deadrop/static/js/api.js
@@ -444,7 +444,22 @@ class SubscriptionManager {
         if (this.onStatusChange) this.onStatusChange('polling');
         this.reconnectDelay = 1000;
 
+        // Bound the poll loop so the outer `start()` loop can retry SSE
+        // periodically. Without this, once SSE fails and we fall to poll,
+        // we stay in poll forever — even if SSE would work on a fresh
+        // attempt. Return after `pollLoopMaxDurationMs` (default 3 min)
+        // so start() cycles back to the SSE attempt.
+        const maxDurationMs = this.pollLoopMaxDurationMs || 3 * 60 * 1000;
+        const startedAt = Date.now();
+
         while (this.running) {
+            // Time-bound: if we've been polling for maxDurationMs,
+            // return so start() can retry SSE.
+            if (Date.now() - startedAt >= maxDurationMs) {
+                if (this.onStatusChange) this.onStatusChange('sse-retry');
+                return;
+            }
+
             try {
                 const currentTopics = this._refreshTopics(topics);
                 const result = await DeadropAPI.subscribePoll(


### PR DESCRIPTION
Web client was stuck in poll mode forever after a single SSE failure. _runPollLoop() was an infinite while — the outer start() loop could never retry SSE.

Fix: bound poll loop to 3 min (configurable via `pollLoopMaxDurationMs`). On timeout return cleanly; outer loop retries SSE. If SSE works, back to real-time. If not, another 3-min poll window.

Sean observed today: tab stuck in 30s-poll mode after transient SSE disconnect (probably my mid-deploy container cycle). ntfy pushes arrived instantly; web UI lagged by up to 30s.