### PR TITLE
feat(db): background Turso DNS/TCP reachability monitor

### DIFF
--- a/src/deadrop/api.py
+++ b/src/deadrop/api.py
@@ -103,6 +103,11 @@ async def lifespan(app: FastAPI):
     # instead of blowing up the first request after an idle window.
     db.start_libsql_health_pinger()
 
+    # Background monitor: resolves Turso hostname and TCP-probes each IP
+    # every 15s. Surfaces the "DNS returns a dead IP" scenario (2026-05-08
+    # incident) in metrics + WARNING logs BEFORE it cascades into 503s.
+    db.start_turso_dns_monitor()
+
     # Enforce namespace TTLs on startup (archive expired namespaces)
     from . import jobs
 
@@ -142,6 +147,7 @@ async def lifespan(app: FastAPI):
     # Stop background cache refresh
     stop_cache_warming()
     db.stop_libsql_health_pinger()
+    db.stop_turso_dns_monitor()
     db.close_db()
 
 

--- a/src/deadrop/db.py
+++ b/src/deadrop/db.py
@@ -90,6 +90,15 @@ LIBSQL_HEALTH_CHECK_TIMEOUT = 5.0
 # cascade).
 LIBSQL_HEALTH_PING_INTERVAL = 15.0  # seconds between ping sweeps
 LIBSQL_HEALTH_PING_TIMEOUT = 2.0  # seconds to wait for each ping
+
+# DNS/TCP reachability monitor — detects the scenario where Turso's NLB
+# returns an IP in DNS but that IP is TCP-dead. Observed 2026-05-08:
+# `3.212.35.170` was in DNS but refused connections on :443; half of new
+# libsql connections hit it and timed out before the NLB health-checked
+# it out of rotation. This monitor surfaces that state in metrics + a
+# WARNING log BEFORE users see 503s.
+TURSO_DNS_MONITOR_INTERVAL = 15.0  # seconds between DNS/TCP sweeps
+TURSO_DNS_TCP_TIMEOUT = 3.0  # seconds per IP TCP-connect probe
 # Max-age recycle was set to 240s in PR #68. Observed post-deploy: every
 # ~4min, every pooled connection got force-recycled. Writes that landed
 # in the cold-start window paid 2-3s (TCP + TLS + Hrana stream init)
@@ -547,6 +556,146 @@ def start_libsql_health_pinger() -> None:
 def stop_libsql_health_pinger() -> None:
     """Signal the health-ping thread to exit. Safe to call on shutdown."""
     _libsql_pinger_stop.set()
+
+
+# ---------------------------------------------------------------------------
+# Turso DNS/TCP reachability monitor
+# ---------------------------------------------------------------------------
+
+
+def _turso_hostname() -> str | None:
+    """Extract the hostname from TURSO_URL, or None if not libsql."""
+    db_url = os.environ.get("TURSO_URL", "")
+    if not db_url.startswith("libsql://"):
+        return None
+    # libsql://host[:port]/... — strip scheme, then anything after '/' or ':'
+    rest = db_url[len("libsql://") :]
+    for sep in ("/", ":"):
+        idx = rest.find(sep)
+        if idx != -1:
+            rest = rest[:idx]
+    return rest or None
+
+
+def _tcp_reachable(ip: str, port: int = 443, timeout: float = TURSO_DNS_TCP_TIMEOUT) -> bool:
+    """Return True if a TCP handshake to (ip, port) completes within timeout."""
+    import socket
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(timeout)
+    try:
+        sock.connect((ip, port))
+        return True
+    except (OSError, socket.timeout):
+        return False
+    finally:
+        try:
+            sock.close()
+        except Exception:
+            pass
+
+
+def _turso_dns_sweep() -> tuple[int, int]:
+    """Resolve Turso hostname, TCP-probe each IP, emit metrics.
+
+    Returns (ip_count, unreachable_count). Emits a WARNING log if any IP
+    is unreachable — that's the pre-cascade signal we want to page on.
+    """
+    import logging
+    import socket
+
+    from .metrics import statsd_gauge
+    from . import instrument
+
+    host = _turso_hostname()
+    if host is None:
+        return (0, 0)
+
+    try:
+        _name, _aliases, ips = socket.gethostbyname_ex(host)
+    except (socket.gaierror, OSError) as e:
+        logging.warning(f"turso dns monitor: resolution failed for {host}: {e}")
+        statsd_gauge("turso.dns.ip_count", 0)
+        instrument.sink.counter("turso.dns.resolve_error", tags={"host": host})
+        return (0, 0)
+
+    statsd_gauge("turso.dns.ip_count", len(ips))
+
+    unreachable: list[str] = []
+    for ip in ips:
+        ok = _tcp_reachable(ip, port=443, timeout=TURSO_DNS_TCP_TIMEOUT)
+        # Tagged gauge — backend can slice by IP without exploding metric
+        # name cardinality in aggregators that support tags.
+        instrument.sink.gauge(
+            "turso.ip.tcp_reachable", 1.0 if ok else 0.0, tags={"ip": ip, "host": host}
+        )
+        # Also emit a per-IP dotted name for backends that only do flat
+        # metric names (matches the spec in the original ticket).
+        statsd_gauge(f"turso.ip.{ip}.tcp_reachable", 1 if ok else 0)
+        if not ok:
+            unreachable.append(ip)
+
+    if unreachable:
+        logging.warning(
+            f"turso dns monitor: {len(unreachable)}/{len(ips)} IP(s) for {host} "
+            f"TCP-unreachable on :443: {', '.join(unreachable)}"
+        )
+        instrument.sink.counter(
+            "turso.dns.unreachable_ip",
+            value=len(unreachable),
+            tags={"host": host},
+        )
+
+    return (len(ips), len(unreachable))
+
+
+_turso_dns_monitor_thread: threading.Thread | None = None
+_turso_dns_monitor_stop = threading.Event()
+
+
+def start_turso_dns_monitor() -> None:
+    """Start the background DNS/TCP reachability monitor.
+
+    Idempotent. No-op when libsql is not in use. Call from FastAPI
+    lifespan startup alongside ``start_libsql_health_pinger``.
+    """
+    global _turso_dns_monitor_thread
+    if not is_using_libsql():
+        return
+    if _turso_dns_monitor_thread is not None and _turso_dns_monitor_thread.is_alive():
+        return
+
+    import logging
+
+    host = _turso_hostname()
+    if host is None:
+        return
+
+    def _run() -> None:
+        logging.info(
+            f"turso dns monitor started (host={host}, interval={TURSO_DNS_MONITOR_INTERVAL}s)"
+        )
+        # Run one sweep immediately so startup logs show the current state.
+        try:
+            _turso_dns_sweep()
+        except Exception:
+            logging.exception("turso dns monitor: initial sweep crashed")
+
+        while not _turso_dns_monitor_stop.wait(TURSO_DNS_MONITOR_INTERVAL):
+            try:
+                _turso_dns_sweep()
+            except Exception:
+                logging.exception("turso dns monitor sweep crashed")
+        logging.info("turso dns monitor stopping")
+
+    _turso_dns_monitor_stop.clear()
+    _turso_dns_monitor_thread = threading.Thread(target=_run, name="turso-dns-monitor", daemon=True)
+    _turso_dns_monitor_thread.start()
+
+
+def stop_turso_dns_monitor() -> None:
+    """Signal the DNS monitor thread to exit. Safe to call on shutdown."""
+    _turso_dns_monitor_stop.set()
 
 
 def _is_hrana_stream_error(error: Exception) -> bool:

--- a/tests/test_turso_dns_monitor.py
+++ b/tests/test_turso_dns_monitor.py
@@ -1,0 +1,119 @@
+"""Tests for the Turso DNS/TCP reachability monitor.
+
+These cover the 2026-05-08 dead-IP scenario: Turso's NLB returns an IP in
+DNS that is TCP-dead on :443. The monitor must:
+
+- resolve the Turso hostname
+- TCP-probe each IP
+- emit per-IP reachability gauges + an `ip_count` gauge
+- log a WARNING when any IP is unreachable
+"""
+
+from __future__ import annotations
+
+import logging
+import socket
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deadrop import db
+
+
+@pytest.fixture
+def libsql_env(monkeypatch):
+    monkeypatch.setenv("TURSO_URL", "libsql://example-db.turso.io")
+    yield
+
+
+def test_turso_hostname_extracts_host(libsql_env):
+    assert db._turso_hostname() == "example-db.turso.io"
+
+
+def test_turso_hostname_none_when_not_libsql(monkeypatch):
+    monkeypatch.setenv("TURSO_URL", "")
+    assert db._turso_hostname() is None
+
+
+def test_tcp_reachable_returns_false_on_timeout():
+    """A fake socket that always times out should report unreachable."""
+    fake_sock = MagicMock()
+    fake_sock.connect.side_effect = socket.timeout("boom")
+
+    with patch("socket.socket", return_value=fake_sock):
+        assert db._tcp_reachable("10.0.0.1", port=443, timeout=0.1) is False
+
+
+def test_tcp_reachable_returns_true_on_connect():
+    fake_sock = MagicMock()
+    fake_sock.connect.return_value = None
+
+    with patch("socket.socket", return_value=fake_sock):
+        assert db._tcp_reachable("10.0.0.2", port=443, timeout=0.1) is True
+
+
+def test_dns_sweep_all_reachable_no_warning(libsql_env, caplog):
+    """Happy path: every IP responds on :443. No warning emitted."""
+    ips = ["3.212.35.170", "3.212.35.171"]
+
+    def fake_gethostbyname_ex(host):
+        return (host, [], ips)
+
+    with (
+        patch("socket.gethostbyname_ex", fake_gethostbyname_ex),
+        patch.object(db, "_tcp_reachable", return_value=True),
+        caplog.at_level(logging.WARNING),
+    ):
+        ip_count, unreachable = db._turso_dns_sweep()
+
+    assert ip_count == 2
+    assert unreachable == 0
+    # No warning-level record about unreachable IPs
+    assert not any("unreachable" in r.message.lower() for r in caplog.records)
+
+
+def test_dns_sweep_flags_dead_ip(libsql_env, caplog):
+    """The incident scenario: one IP in DNS is TCP-dead."""
+    ips = ["3.212.35.170", "3.212.35.171"]
+
+    # First IP dead, second IP alive — matches the 2026-05-08 profile.
+    def fake_reachable(ip, port=443, timeout=3.0):
+        return ip != "3.212.35.170"
+
+    with (
+        patch("socket.gethostbyname_ex", return_value=("turso", [], ips)),
+        patch.object(db, "_tcp_reachable", side_effect=fake_reachable),
+        caplog.at_level(logging.WARNING),
+    ):
+        ip_count, unreachable = db._turso_dns_sweep()
+
+    assert ip_count == 2
+    assert unreachable == 1
+    # Warning mentions the dead IP explicitly so ops can grep for it.
+    warning_messages = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("3.212.35.170" in m and "unreachable" in m.lower() for m in warning_messages)
+
+
+def test_dns_sweep_handles_resolution_failure(libsql_env, caplog):
+    """DNS itself failing is itself a signal — log + counter, no crash."""
+    with (
+        patch("socket.gethostbyname_ex", side_effect=socket.gaierror("nxdomain")),
+        caplog.at_level(logging.WARNING),
+    ):
+        ip_count, unreachable = db._turso_dns_sweep()
+
+    assert ip_count == 0
+    assert unreachable == 0
+    assert any("resolution failed" in r.message for r in caplog.records)
+
+
+def test_dns_sweep_noop_when_not_libsql(monkeypatch):
+    """No TURSO_URL → sweep is a no-op, does not attempt DNS."""
+    monkeypatch.setenv("TURSO_URL", "")
+
+    with patch("socket.gethostbyname_ex") as fake_resolve:
+        ip_count, unreachable = db._turso_dns_sweep()
+
+    assert ip_count == 0
+    assert unreachable == 0
+    fake_resolve.assert_not_called()


### PR DESCRIPTION
## What

Adds a background thread — running alongside the existing libsql health-pinger — that resolves `TURSO_URL`'s hostname and TCP-probes each returned IP on :443 every 15s. Emits per-IP reachability gauges and logs a WARNING when any IP is unreachable.

## Why

**2026-05-08 incident recap.** Turso's NLB returned `3.212.35.170` in DNS but the IP was TCP-dead. Half of new libsql connections hit it and timed out before the NLB health-checked it out of rotation. Result: 503 cascade.

[PR #70](https://github.com/clusterfudge/deaddrop/pull/70) swapped to the stable `libsql` package (better stream reuse), which makes the failure less likely to cascade through connection churn. This PR is the other half: **observability for the DNS-level problem itself**, so next time it happens we see it in the logs first.

## Signals emitted

| Metric | Type | Notes |
|---|---|---|
| `turso.dns.ip_count` | gauge | How many IPs in DNS right now |
| `turso.ip.<ip>.tcp_reachable` | gauge (0/1) | Flat name, per IP |
| `turso.ip.tcp_reachable{ip,host}` | gauge (0/1) | Tagged variant for sinks that support tags |
| `turso.dns.resolve_error` | counter | DNS itself fails |
| `turso.dns.unreachable_ip` | counter | Incremented by the number of dead IPs per sweep |

All via the existing `instrument.sink` / `statsd_gauge` layer — no new transport.

## Log output

```
WARNING  turso dns monitor: 1/2 IP(s) for example-db.turso.io TCP-unreachable on :443: 3.212.35.170
```

Dead IPs are named explicitly so ops can grep.

## Shape

- **~140 lines** added to `src/deadrop/db.py` (constants + `_turso_hostname`, `_tcp_reachable`, `_turso_dns_sweep`, `start_turso_dns_monitor`, `stop_turso_dns_monitor`).
- **4 lines** wired into `api.py` lifespan (start on up, stop on down).
- No-op when `TURSO_URL` is unset (local SQLite dev).
- Runs at the same 15s cadence as the libsql health-pinger. Daemon thread.

## Tests

`tests/test_turso_dns_monitor.py` — 8 cases, socket monkeypatched:

- hostname extraction (with / without libsql://)
- `_tcp_reachable` true / false branches
- sweep happy path — no warning when all IPs reachable
- **incident scenario** — `3.212.35.170` dead, other IP alive, WARNING names the dead IP
- DNS resolution failure — logged, counter incremented, no crash
- no-op when `TURSO_URL` unset

```
$ uv run pytest tests/test_turso_dns_monitor.py -q
........                                                                 [100%]
8 passed in 0.04s
```

Full suite: **597 passed** (same as main).
Lint: `ruff check` + `ruff format --check` both clean.

## Not doing (yet)

- No alerting rule. That's a graphite / dashboard-side change — file separately once we confirm the metric names flowing.
- No active remediation (e.g. kicking connections pinned to a dead IP). The point of this PR is visibility first; if we decide we want active remediation, that's a follow-up with real data in hand.
