### PR TITLE
feat(api): log user-agent + identity in access log

### DIFF
--- a/src/deadrop/api.py
+++ b/src/deadrop/api.py
@@ -275,14 +275,41 @@ async def add_timing_middleware(request: Request, call_next):
     if not path.startswith("/static") and path != "/health":
         log = structlog.get_logger("deadrop.access")
         log_method = log.warning if duration_ms > 2000 else log.info
+
+        # Identify the calling client so we can correlate access patterns
+        # (e.g. "which client is auto-marking-read?") with an actual
+        # identity/UA pair. The X-Inbox-Secret header derives directly
+        # to an identity_id; UA tells us which client surface is calling.
+        user_agent = request.headers.get("user-agent")
+        secret = request.headers.get("x-inbox-secret")
+        identity_id = None
+        if secret:
+            try:
+                from .auth import derive_id
+
+                identity_id = derive_id(secret)
+            except Exception:
+                identity_id = None
+
+        # Honor X-Forwarded-For when set (we sit behind nginx on dokku);
+        # fall back to request.client.host for direct connections.
+        forwarded_for = request.headers.get("x-forwarded-for")
+        client_ip = (
+            forwarded_for.split(",")[0].strip()
+            if forwarded_for
+            else (request.client.host if request.client else None)
+        )
+
         log_method(
             "request",
             method=request.method,
             path=path,
             status=response.status_code,
             duration_ms=round(duration_ms, 1),
-            client=request.client.host if request.client else None,
+            client=client_ip,
             endpoint=endpoint,
+            user_agent=user_agent,
+            identity_id=identity_id,
         )
 
         # Emit slow-request diagnostic if over threshold


### PR DESCRIPTION
## What

Add `user_agent` and `identity_id` to the per-request structured access log so we can correlate access patterns to specific clients/identities (not just IPs).

Also: honor `X-Forwarded-For` for `client` since we sit behind nginx on dokku — the bare `request.client.host` is always the upstream proxy IP, not the actual caller.

## Why

This morning Sean and I diagnosed an auto-mark-read bug: Sean's `last_read_mid` on the Twin room was advancing within seconds of every Fritz post overnight (including 1am, 3am, 4am PT — Sean was asleep). The unread_notifier feed correctly saw "cursor advanced, no unread, skip notification" and never sent ntfys. Symptom: Sean got zero overnight ntfys for messages he didn't actually read.

Existing access log captured `client=71.212.46.48` (Sean's home IP, CenturyLink/Tukwila) but not which client surface on that machine. Could be:
- Browser tab with deaddrop web app open
- iOS app in background
- Old mac menubar app
- Stale dev daemon

With `user_agent` in the log, the same diagnostic becomes one-grep:
```
grep '71.212.46.48' access.log | jq -r '.user_agent' | sort -u
```

And `identity_id` lets us answer "which identity is doing this" without re-deriving from the secret each time.

## Footprint

- `src/deadrop/api.py`: +27 / -2 in the request-log middleware
- No new tests (observability-only middleware change; existing 626 tests pass)

## Verification

Tests: `uv run pytest tests/ -q` → 626 passed.

## Follow-ups

- Once this is live, the rogue-tab diagnosis becomes mechanical: filter access log to Sean's identity_id, group by user_agent + client_ip, find the offender.
- Separate question: does deaddrop have a "force-disconnect / kick all clients" admin endpoint? Didn't find one in api.py. Worth a follow-up issue if not.

DO NOT MERGE — Sean reviews.