### PR TITLE
feat(rooms): PATCH /{ns}/rooms/{room_id} to update display_name

### DIFF
--- a/src/deadrop/api.py
+++ b/src/deadrop/api.py
@@ -1711,6 +1711,35 @@ async def get_room(
     return RoomInfo(**room)
 
 
+class UpdateRoomRequest(BaseModel):
+    display_name: str | None = None
+
+
+@app.patch("/{ns}/rooms/{room_id}", response_model=RoomInfo)
+async def update_room_endpoint(
+    ns: str,
+    room_id: str,
+    request: UpdateRoomRequest,
+    x_inbox_secret: Annotated[str | None, Header()] = None,
+):
+    """Update a room's properties (currently display_name). Requires membership."""
+    room, _ = await _require_room_member(room_id, x_inbox_secret)
+
+    if room["ns"] != ns:
+        raise HTTPException(404, "Room not found in this namespace")
+
+    updated = await _run_write(db.update_room, room_id, request.display_name)
+    if not updated:
+        raise HTTPException(404, "Room not found")
+
+    # Invalidate cached room so subsequent reads see the new display_name.
+    from .cache import invalidate_room
+
+    invalidate_room(room_id)
+
+    return RoomInfo(**updated)
+
+
 @app.delete("/{ns}/rooms/{room_id}")
 def delete_room_endpoint(
     ns: str,

--- a/src/deadrop/db.py
+++ b/src/deadrop/db.py
@@ -2689,6 +2689,41 @@ def get_room(
     return row
 
 
+def update_room(
+    room_id: str,
+    display_name: str | None = None,
+    conn: sqlite3.Connection | None = None,
+) -> dict | None:
+    """Update a room's mutable properties.
+
+    Args:
+        room_id: Room ID
+        display_name: New display name (None = leave unchanged)
+        conn: Optional database connection
+
+    Returns:
+        Updated room info dict, or None if the room does not exist.
+    """
+    conn = _get_conn(conn)
+
+    updates = []
+    params: list[object] = []
+    if display_name is not None:
+        updates.append("display_name = ?")
+        params.append(display_name)
+
+    if updates:
+        params.append(room_id)
+        conn.execute(
+            f"UPDATE rooms SET {', '.join(updates)} WHERE room_id = ?",
+            params,
+            name="update_room",
+        )
+        conn.commit()
+
+    return get_room(room_id, conn=conn)
+
+
 def list_rooms(
     ns: str,
     conn: sqlite3.Connection | None = None,

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -120,6 +120,36 @@ class TestRoomRetrieval:
         assert bob_rooms[0]["room_id"] == room2["room_id"]
 
 
+class TestRoomUpdate:
+    """Tests for updating rooms at the DB layer."""
+
+    def test_update_display_name(self):
+        """Update a room's display name."""
+        ns = db.create_namespace()
+        alice = db.create_identity(ns["ns"])
+        room = db.create_room(ns["ns"], alice["id"], display_name="Old Name")
+
+        updated = db.update_room(room["room_id"], display_name="New Name")
+
+        assert updated is not None
+        assert updated["display_name"] == "New Name"
+        assert db.get_room(room["room_id"])["display_name"] == "New Name"
+
+    def test_update_noop_preserves_name(self):
+        """Calling update with no fields leaves the room unchanged."""
+        ns = db.create_namespace()
+        alice = db.create_identity(ns["ns"])
+        room = db.create_room(ns["ns"], alice["id"], display_name="Keep Me")
+
+        updated = db.update_room(room["room_id"])
+
+        assert updated["display_name"] == "Keep Me"
+
+    def test_update_nonexistent_room(self):
+        """Updating a nonexistent room returns None."""
+        assert db.update_room("nonexistent-room-id", display_name="X") is None
+
+
 class TestRoomDeletion:
     """Tests for deleting rooms."""
 

--- a/tests/test_rooms_api.py
+++ b/tests/test_rooms_api.py
@@ -197,6 +197,99 @@ class TestRoomListing:
         assert response.status_code == 403
 
 
+class TestRoomUpdate:
+    """Tests for the PATCH room endpoint."""
+
+    def test_update_display_name(self, client, setup_identities):
+        """PATCH updates display_name and a subsequent GET reflects it."""
+        data = setup_identities
+
+        room = client.post(
+            f"/{data['ns']}/rooms",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+            json={"display_name": "Old Name"},
+        ).json()
+
+        response = client.patch(
+            f"/{data['ns']}/rooms/{room['room_id']}",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+            json={"display_name": "#general"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["display_name"] == "#general"
+
+        # GET it back to confirm persistence (and cache invalidation).
+        fetched = client.get(
+            f"/{data['ns']}/rooms/{room['room_id']}",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+        )
+        assert fetched.status_code == 200
+        assert fetched.json()["display_name"] == "#general"
+
+    def test_update_room_not_found(self, client, setup_identities):
+        """PATCH on a nonexistent room returns 404 (via membership check)."""
+        data = setup_identities
+
+        response = client.patch(
+            f"/{data['ns']}/rooms/nonexistent-room-id",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+            json={"display_name": "Whatever"},
+        )
+
+        # Not a member of a room that doesn't exist -> auth layer rejects.
+        assert response.status_code in (403, 404)
+
+    def test_update_room_unauthorized(self, client, setup_identities):
+        """PATCH without an inbox secret fails."""
+        data = setup_identities
+
+        room = client.post(
+            f"/{data['ns']}/rooms",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+        ).json()
+
+        response = client.patch(
+            f"/{data['ns']}/rooms/{room['room_id']}",
+            json={"display_name": "Hijacked"},
+        )
+        assert response.status_code == 401
+
+    def test_update_room_not_member(self, client, setup_identities):
+        """A non-member cannot rename a room."""
+        data = setup_identities
+
+        room = client.post(
+            f"/{data['ns']}/rooms",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+        ).json()
+
+        response = client.patch(
+            f"/{data['ns']}/rooms/{room['room_id']}",
+            headers={"X-Inbox-Secret": data["bob"]["secret"]},
+            json={"display_name": "Bob was here"},
+        )
+        assert response.status_code == 403
+
+    def test_update_room_noop_preserves_name(self, client, setup_identities):
+        """PATCH with no display_name leaves the existing name unchanged."""
+        data = setup_identities
+
+        room = client.post(
+            f"/{data['ns']}/rooms",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+            json={"display_name": "Keep Me"},
+        ).json()
+
+        response = client.patch(
+            f"/{data['ns']}/rooms/{room['room_id']}",
+            headers={"X-Inbox-Secret": data["alice"]["secret"]},
+            json={},
+        )
+        assert response.status_code == 200
+        assert response.json()["display_name"] == "Keep Me"
+
+
 class TestRoomMembers:
     """Tests for room member management."""
 


### PR DESCRIPTION
## Why

There is no endpoint to rename a room. The room API exposes only `POST` (create), `GET` (list/detail), and `DELETE` — so a room's `display_name` is immutable after creation. This blocks re-titling a room (e.g. to `#general`).

## What

- **New `PATCH /{ns}/rooms/{room_id}`** with body `UpdateRoomRequest{display_name: str | None}`. Returns the updated room (same shape as `GET /{ns}/rooms/{room_id}`).
- **New `db.update_room(room_id, display_name)`** — symmetric with `db.create_room`, instrumented query (`name="update_room"`). Builds the `UPDATE` only for provided fields; a no-op call returns the room unchanged. Returns `None` if the room doesn't exist.
- Invalidates `room_cache` after the mutation (`cache.invalidate_room`) so subsequent `GET`s / `_require_room_member` cache hits see the new name — mirrors what `DELETE` already does.

## Auth model

Mirrors **`GET /{ns}/rooms/{room_id}`** exactly: `_require_room_member(room_id, x_inbox_secret)`.

- `401` if no `X-Inbox-Secret` header.
- `403` if the caller is not a member of the room (or secret invalid).
- `404` if the room exists but is in a different namespace.

No new auth model invented — same membership gate as the other room read/write endpoints.

## Storage note

`display_name` lives in **one place**: the `rooms.display_name` column. It is *not* duplicated in metadata. (The `metadata.display_name` visible on the members endpoint is identity metadata, unrelated to the room name.) So a single `UPDATE` keeps everything consistent.

## Tests

- **API** (`tests/test_rooms_api.py`, new `TestRoomUpdate`): rename + GET-back asserts persistence/cache invalidation; nonexistent room (404/403 via membership); unauthorized (401); non-member (403); no-op PATCH preserves name.
- **DB** (`tests/test_rooms.py`, new `TestRoomUpdate`): update display_name; no-op preserves; nonexistent returns `None`.

Room suite: **85 passed**. Full suite: **630 passed, 4 deselected** (integration/slow), 0 failed. `ruff check` + `ruff format` + `ty` clean via pre-commit.

## Footprint

4 files: `api.py` (+~29), `db.py` (+~35), two test files. No service layer, no refactor.

**DO NOT MERGE** — for review.
