### PR TITLE
feat(rooms): large paste → downloadable attachment (chip + metadata dialog)

### DIFF
--- a/src/deadrop/api.py
+++ b/src/deadrop/api.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Annotated, Any, Literal
 
 from fastapi import FastAPI, Header, HTTPException, Query, Request
-from fastapi.responses import FileResponse, HTMLResponse, StreamingResponse
+from fastapi.responses import FileResponse, HTMLResponse, Response, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field
@@ -1540,8 +1540,24 @@ ALLOWED_ATTACHMENT_TYPES = frozenset(
         "image/gif",
         "image/webp",
         "application/pdf",
+        "text/plain",
+        "text/csv",
+        "text/markdown",
+        "text/html",
+        "application/json",
     }
 )
+
+# Content types that must never be served with a renderable Content-Type on the
+# wire. text/html attachments (e.g. from a large paste) could contain <script>
+# and would execute if a browser rendered them inline, so the raw download path
+# serves them as text/plain and always forces Content-Disposition: attachment.
+NON_RENDERABLE_ATTACHMENT_TYPES = frozenset(
+    {
+        "text/html",
+    }
+)
+DOWNLOAD_SAFE_CONTENT_TYPE = "text/plain; charset=utf-8"
 
 MAX_ATTACHMENT_SIZE = 10 * 1024 * 1024  # 10MB per attachment
 MAX_ATTACHMENTS_PER_MESSAGE = 10
@@ -2225,6 +2241,84 @@ async def get_attachment(
         created_at=attachment.get("created_at", ""),
         data=attachment["data"],
     ).model_dump()
+
+
+def _safe_download_headers(filename: str | None, content_type: str) -> tuple[str, dict[str, str]]:
+    """Compute the wire content-type and headers for a raw attachment download.
+
+    Always forces Content-Disposition: attachment so browsers download rather
+    than render. text/html (and any other non-renderable type) is downgraded to
+    text/plain on the wire so a pasted .html with <script> cannot execute.
+    """
+    wire_content_type = content_type
+    if content_type in NON_RENDERABLE_ATTACHMENT_TYPES:
+        wire_content_type = DOWNLOAD_SAFE_CONTENT_TYPE
+    safe_name = (filename or "attachment").replace("\r", "").replace("\n", "").replace('"', "")
+    headers = {
+        "Content-Disposition": f'attachment; filename="{safe_name}"',
+        "X-Content-Type-Options": "nosniff",
+    }
+    return wire_content_type, headers
+
+
+@app.get("/{ns}/attachments/{attachment_id}/download")
+async def download_attachment(
+    ns: str,
+    attachment_id: str,
+    x_inbox_secret: Annotated[str | None, Header()] = None,
+) -> Response:
+    """Serve an attachment's raw bytes as a forced download.
+
+    Unlike the JSON attachment endpoint, this returns the decoded bytes with
+    Content-Disposition: attachment. text/html is served as text/plain so a
+    pasted HTML blob containing <script> cannot be rendered/executed inline
+    (stored-XSS defense). The caller must be a member of the attachment's room.
+    """
+    if not x_inbox_secret:
+        raise HTTPException(401, "X-Inbox-Secret header required")
+
+    caller_id = derive_id(x_inbox_secret)
+
+    def _fetch_and_verify_attachment():
+        attachment = db.get_attachment(attachment_id, include_data=True)
+        if not attachment:
+            return None, "not_found"
+
+        conn = db.get_connection()
+        cursor = conn.execute(
+            "SELECT room_id FROM room_messages WHERE mid = ?",
+            (attachment["message_mid"],),
+            name="download_attachment.lookup_room",
+        )
+        row = cursor.fetchone()
+        if not row:
+            return None, "not_found"
+
+        room_id = row[0]
+        room = db.get_room(room_id)
+        if not room or room["ns"] != ns:
+            return None, "not_found"
+
+        if not db.is_room_member(room_id, caller_id):
+            return None, "forbidden"
+
+        return attachment, None
+
+    attachment, err = await _run_read(_fetch_and_verify_attachment)
+    if err == "not_found":
+        raise HTTPException(404, "Attachment not found")
+    if err == "forbidden":
+        raise HTTPException(403, "Not a room member")
+    if not attachment:
+        raise HTTPException(404, "Attachment not found")
+
+    import base64
+
+    raw = base64.b64decode(attachment["data"])
+    wire_content_type, headers = _safe_download_headers(
+        attachment.get("filename"), attachment["content_type"]
+    )
+    return Response(content=raw, media_type=wire_content_type, headers=headers)
 
 
 @app.post("/{ns}/subscribe")

--- a/src/deadrop/api.py
+++ b/src/deadrop/api.py
@@ -1542,19 +1542,25 @@ ALLOWED_ATTACHMENT_TYPES = frozenset(
         "application/pdf",
         "text/plain",
         "text/csv",
+        "text/tab-separated-values",
         "text/markdown",
         "text/html",
         "application/json",
+        "application/yaml",
+        "application/xml",
     }
 )
 
 # Content types that must never be served with a renderable Content-Type on the
 # wire. text/html attachments (e.g. from a large paste) could contain <script>
-# and would execute if a browser rendered them inline, so the raw download path
-# serves them as text/plain and always forces Content-Disposition: attachment.
+# and would execute if a browser rendered them inline; XML can carry script
+# (e.g. inline SVG) or external-entity payloads. The raw download path serves
+# all of these as text/plain and always forces Content-Disposition: attachment.
 NON_RENDERABLE_ATTACHMENT_TYPES = frozenset(
     {
         "text/html",
+        "application/xml",
+        "text/xml",
     }
 )
 DOWNLOAD_SAFE_CONTENT_TYPE = "text/plain; charset=utf-8"

--- a/src/deadrop/static/js/api.js
+++ b/src/deadrop/static/js/api.js
@@ -167,6 +167,31 @@ const DeadropAPI = {
     },
 
     /**
+     * Fetch an attachment's raw bytes as a downloadable Blob. The server forces
+     * Content-Disposition: attachment and serves text/html as text/plain, so
+     * the bytes can never render inline as live HTML.
+     */
+    async downloadAttachment(credentials, attachmentId) {
+        const response = await fetch(`/${credentials.ns}/attachments/${attachmentId}/download`, {
+            method: 'GET',
+            headers: { 'X-Inbox-Secret': credentials.secret },
+        });
+        if (!response.ok) {
+            const error = await response.json().catch(() => ({ detail: response.statusText }));
+            throw new Error(error.detail || 'Download failed');
+        }
+        const filename = this._filenameFromDisposition(response.headers.get('Content-Disposition'));
+        const blob = await response.blob();
+        return { blob, filename };
+    },
+
+    _filenameFromDisposition(header) {
+        if (!header) return null;
+        const match = /filename="?([^"]+)"?/.exec(header);
+        return match ? match[1] : null;
+    },
+
+    /**
      * Get unread count for a room.
      */
     async getRoomUnread(credentials, roomId) {

--- a/src/deadrop/templates/app.html
+++ b/src/deadrop/templates/app.html
@@ -166,8 +166,11 @@
                     <option value="text/plain">text/plain (.txt)</option>
                     <option value="text/markdown">text/markdown (.md)</option>
                     <option value="text/csv">text/csv (.csv)</option>
+                    <option value="text/tab-separated-values">text/tab-separated-values (.tsv)</option>
                     <option value="application/json">application/json (.json)</option>
+                    <option value="application/yaml">application/yaml (.yaml)</option>
                     <option value="text/html">text/html (.html)</option>
+                    <option value="application/xml">application/xml (.xml)</option>
                 </select>
             </div>
 
@@ -535,9 +538,12 @@
 
     const CONTENT_TYPE_EXTENSIONS = {
         'application/json': 'json',
+        'application/yaml': 'yaml',
+        'application/xml': 'xml',
         'text/html': 'html',
         'text/markdown': 'md',
         'text/csv': 'csv',
+        'text/tab-separated-values': 'tsv',
         'text/plain': 'txt',
     };
 
@@ -561,6 +567,11 @@
         }
 
         const lower = trimmed.toLowerCase();
+        // XML declaration is more specific than a generic angle-bracket doc,
+        // so check it before the HTML heuristic.
+        if (lower.startsWith('<?xml')) {
+            return 'application/xml';
+        }
         if (lower.startsWith('<!doctype html') || lower.startsWith('<html') ||
             /<\/?(html|head|body|div|span|p|a|script|table)[\s>]/i.test(trimmed)) {
             return 'text/html';
@@ -579,11 +590,27 @@
         }
 
         const dataLines = lines.filter(l => l.trim().length > 0);
+        // Tab-separated: every non-empty line shares the same (>=1) tab count.
+        if (dataLines.length >= 2) {
+            const tabCounts = dataLines.map(l => (l.match(/\t/g) || []).length);
+            if (tabCounts[0] >= 1 && tabCounts.every(c => c === tabCounts[0])) {
+                return 'text/tab-separated-values';
+            }
+        }
+        // Comma-separated: same, for commas.
         if (dataLines.length >= 2) {
             const commaCounts = dataLines.map(l => (l.match(/,/g) || []).length);
             if (commaCounts[0] >= 1 && commaCounts.every(c => c === commaCounts[0])) {
                 return 'text/csv';
             }
+        }
+
+        // YAML: a document marker (---) or several "key: value" lines. Kept last
+        // because its markers are the loosest — only reached when nothing more
+        // specific matched.
+        const yamlKeyLines = dataLines.filter(l => /^[A-Za-z0-9_-]+\s*:(\s|$)/.test(l));
+        if (trimmed.startsWith('---') || yamlKeyLines.length >= 2) {
+            return 'application/yaml';
         }
 
         return 'text/plain';

--- a/src/deadrop/templates/app.html
+++ b/src/deadrop/templates/app.html
@@ -145,6 +145,39 @@
         </div>
     </div>
     
+    <!-- Paste-to-attachment metadata dialog -->
+    <div id="paste-attach-modal" class="hidden" style="position: fixed; inset: 0; background: rgba(0,0,0,0.5); display: flex; align-items: center; justify-content: center; z-index: 1500;">
+        <div class="card" style="width: 100%; max-width: 480px; margin: 20px;">
+            <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px;">
+                <h2>Attach pasted text</h2>
+                <button id="paste-attach-cancel" class="btn btn-icon">✕</button>
+            </div>
+
+            <p class="text-muted text-small" id="paste-attach-size" style="margin-bottom: 12px;"></p>
+
+            <div class="form-group">
+                <label class="form-label" for="paste-attach-name">File name</label>
+                <input id="paste-attach-name" class="form-input" type="text">
+            </div>
+
+            <div class="form-group">
+                <label class="form-label" for="paste-attach-type">Content type</label>
+                <select id="paste-attach-type" class="form-input">
+                    <option value="text/plain">text/plain (.txt)</option>
+                    <option value="text/markdown">text/markdown (.md)</option>
+                    <option value="text/csv">text/csv (.csv)</option>
+                    <option value="application/json">application/json (.json)</option>
+                    <option value="text/html">text/html (.html)</option>
+                </select>
+            </div>
+
+            <div style="display: flex; justify-content: flex-end; gap: 8px;">
+                <button id="paste-attach-close" class="btn btn-secondary">Cancel</button>
+                <button id="paste-attach-confirm" class="btn btn-primary">Attach</button>
+            </div>
+        </div>
+    </div>
+
     <!-- Archived View -->
     <div id="view-archived" class="view hidden">
         <div class="header">
@@ -418,7 +451,10 @@
                             </div>`;
                 }
             } else {
-                return `<div class="file-attachment">📄 ${escapeHtml(att.filename || 'file')} (${formatFileSize(att.size)})</div>`;
+                return `<div class="file-attachment" style="cursor:pointer;"
+                             data-attachment-id="${att.id}"
+                             title="Download"
+                             onclick="downloadFileAttachment('${att.id}')">📄 ${escapeHtml(att.filename || 'file')} (${formatFileSize(att.size)})</div>`;
             }
         });
         return `<div class="message-attachments">${parts.join('')}</div>`;
@@ -493,6 +529,114 @@
         renderAttachmentPreview();
     }
 
+    // Pasted text >= this many bytes becomes a downloadable attachment instead
+    // of a giant inline message body.
+    const LARGE_PASTE_THRESHOLD_BYTES = 10240;
+
+    const CONTENT_TYPE_EXTENSIONS = {
+        'application/json': 'json',
+        'text/html': 'html',
+        'text/markdown': 'md',
+        'text/csv': 'csv',
+        'text/plain': 'txt',
+    };
+
+    function byteLength(text) {
+        return new TextEncoder().encode(text).length;
+    }
+
+    /**
+     * Best-effort content sniff for a pasted text blob. Returns a MIME type
+     * used only to pre-fill the dialog dropdown; the user can override it.
+     */
+    function sniffContentType(text) {
+        const trimmed = text.trim();
+        if (!trimmed) return 'text/plain';
+
+        try {
+            JSON.parse(trimmed);
+            return 'application/json';
+        } catch (e) {
+            // not JSON, keep sniffing
+        }
+
+        const lower = trimmed.toLowerCase();
+        if (lower.startsWith('<!doctype html') || lower.startsWith('<html') ||
+            /<\/?(html|head|body|div|span|p|a|script|table)[\s>]/i.test(trimmed)) {
+            return 'text/html';
+        }
+
+        const lines = text.split('\n');
+        const markdownMarkers = [
+            /^#{1,6}\s/m,
+            /```/,
+            /^\s*[-*]\s/m,
+            /^\s*- \[[ xX]\]/m,
+            /\[[^\]]+\]\([^)]+\)/,
+        ];
+        if (markdownMarkers.some(re => re.test(text))) {
+            return 'text/markdown';
+        }
+
+        const dataLines = lines.filter(l => l.trim().length > 0);
+        if (dataLines.length >= 2) {
+            const commaCounts = dataLines.map(l => (l.match(/,/g) || []).length);
+            if (commaCounts[0] >= 1 && commaCounts.every(c => c === commaCounts[0])) {
+                return 'text/csv';
+            }
+        }
+
+        return 'text/plain';
+    }
+
+    function defaultPasteName() {
+        // pasted-YYYY-MM-DDTHH-MM-SS (colons/dots are invalid in filenames)
+        const iso = new Date().toISOString().replace(/[:.]/g, '-').replace(/-\d{3}Z$/, '');
+        return `pasted-${iso}`;
+    }
+
+    let _pendingPasteText = null;
+
+    /**
+     * Show the metadata dialog for a large pasted text blob. On confirm, builds
+     * a File from the text and hands it to addFileToPreview (chip only).
+     */
+    function openPasteAttachDialog(text) {
+        _pendingPasteText = text;
+        const sniffed = sniffContentType(text);
+        const nameInput = document.getElementById('paste-attach-name');
+        const typeSelect = document.getElementById('paste-attach-type');
+        const sizeEl = document.getElementById('paste-attach-size');
+
+        typeSelect.value = sniffed;
+        nameInput.value = `${defaultPasteName()}.${CONTENT_TYPE_EXTENSIONS[sniffed] || 'txt'}`;
+        sizeEl.textContent = `Pasted ${formatFileSize(byteLength(text))} — will be attached as a file.`;
+
+        document.getElementById('paste-attach-modal').classList.remove('hidden');
+        nameInput.focus();
+    }
+
+    function closePasteAttachDialog() {
+        document.getElementById('paste-attach-modal').classList.add('hidden');
+        _pendingPasteText = null;
+    }
+
+    function confirmPasteAttach() {
+        if (_pendingPasteText === null) {
+            closePasteAttachDialog();
+            return;
+        }
+        const contentType = document.getElementById('paste-attach-type').value;
+        let name = document.getElementById('paste-attach-name').value.trim();
+        if (!name) {
+            const ext = CONTENT_TYPE_EXTENSIONS[contentType] || 'txt';
+            name = `${defaultPasteName()}.${ext}`;
+        }
+        const file = new File([_pendingPasteText], name, { type: contentType });
+        addFileToPreview(file);
+        closePasteAttachDialog();
+    }
+
     function renderAttachmentPreview() {
         const preview = document.getElementById('room-attachment-preview');
         if (!preview) return;
@@ -514,9 +658,31 @@
         }).join('');
     }
 
+    /**
+     * Download a non-image attachment via the forced-download endpoint. The
+     * bytes are fetched as a Blob and saved through an object URL, so text/html
+     * attachments are never inserted into the DOM.
+     */
+    async function downloadFileAttachment(attachmentId) {
+        try {
+            const { blob, filename } = await DeadropAPI.downloadAttachment(credentials, attachmentId);
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = filename || 'attachment';
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+            URL.revokeObjectURL(url);
+        } catch (e) {
+            console.error('Failed to download attachment:', e);
+        }
+    }
+
     // Make removeAttachment available globally for onclick
     window.removeAttachment = removeAttachment;
     window.loadAndShowAttachment = loadAndShowAttachment;
+    window.downloadFileAttachment = downloadFileAttachment;
 
     function highlightCodeBlocks(container) {
         if (typeof hljs === 'undefined') return;
@@ -1583,16 +1749,37 @@
         e.target.value = '';  // Reset so same file can be re-selected
     });
 
-    // Paste handler for images
+    // Paste handler: images become attachments; large text pastes become a
+    // downloadable file attachment (chip) via the metadata dialog.
     document.getElementById('room-message-input').addEventListener('paste', (e) => {
-        const items = e.clipboardData?.items;
-        if (!items) return;
-        for (const item of items) {
+        const clipboard = e.clipboardData;
+        if (!clipboard) return;
+
+        for (const item of clipboard.items || []) {
             if (item.type.startsWith('image/')) {
                 e.preventDefault();
                 const file = item.getAsFile();
                 if (file) addFileToPreview(file);
+                return;
             }
+        }
+
+        const text = clipboard.getData('text/plain');
+        if (text && byteLength(text) >= LARGE_PASTE_THRESHOLD_BYTES) {
+            e.preventDefault();
+            openPasteAttachDialog(text);
+        }
+        // Smaller text pastes fall through to the browser's default inline paste.
+    });
+
+    // Paste-to-attachment metadata dialog wiring.
+    document.getElementById('paste-attach-confirm').addEventListener('click', confirmPasteAttach);
+    document.getElementById('paste-attach-close').addEventListener('click', closePasteAttachDialog);
+    document.getElementById('paste-attach-cancel').addEventListener('click', closePasteAttachDialog);
+    document.getElementById('paste-attach-name').addEventListener('keypress', (e) => {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            confirmPasteAttach();
         }
     });
     

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -634,9 +634,12 @@ class TestTextAttachmentAllowlist:
         [
             ("text/plain", b"just some plain text"),
             ("text/csv", b"a,b,c\n1,2,3\n"),
+            ("text/tab-separated-values", b"a\tb\tc\n1\t2\t3\n"),
             ("text/markdown", b"# Heading\n\n- item\n"),
             ("text/html", b"<html><body>hi</body></html>"),
             ("application/json", b'{"k": "v"}'),
+            ("application/yaml", b"key: value\nlist:\n  - a\n"),
+            ("application/xml", b"<?xml version='1.0'?><root/>"),
         ],
     )
     def test_text_types_accepted(self, client, room_setup, content_type, payload):
@@ -701,6 +704,25 @@ class TestSafeAttachmentDownload:
         # The bytes are preserved verbatim (so the user can still read/save them),
         # but the wire content-type prevents inline execution.
         assert resp.content == script
+
+    def test_xml_served_as_text_plain_not_xml(self, client, room_setup):
+        """XSS/XXE: an application/xml attachment must be served as text/plain
+        and forced to download, never as renderable/parseable XML inline."""
+        s = room_setup
+        payload = b"<?xml version='1.0'?><root><script>alert(1)</script></root>"
+        att_id = self._upload(client, s, "data.xml", "application/xml", payload)
+
+        resp = client.get(
+            f"/{s['ns']}/attachments/{att_id}/download",
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        assert resp.status_code == 200
+        ctype = resp.headers["content-type"]
+        assert "xml" not in ctype
+        assert ctype.startswith("text/plain")
+        assert resp.headers["content-disposition"].startswith("attachment")
+        assert resp.headers["x-content-type-options"] == "nosniff"
+        assert resp.content == payload
 
     def test_plain_text_download_forces_attachment(self, client, room_setup):
         s = room_setup

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -390,8 +390,8 @@ class TestAttachmentAPI:
 
 
 class TestAttachmentValidation:
-    def test_reject_html_content_type(self, client, room_setup):
-        """Stored XSS: text/html must be rejected."""
+    def test_accept_html_content_type(self, client, room_setup):
+        """text/html is accepted (large-paste feature) but must be served safely."""
         s = room_setup
         import base64
 
@@ -399,15 +399,14 @@ class TestAttachmentValidation:
         resp = client.post(
             f"/{s['ns']}/rooms/{s['room_id']}/messages",
             json={
-                "body": "XSS attempt",
+                "body": "HTML paste",
                 "attachments": [
-                    {"filename": "evil.html", "content_type": "text/html", "data": html_b64},
+                    {"filename": "note.html", "content_type": "text/html", "data": html_b64},
                 ],
             },
             headers={"X-Inbox-Secret": s["alice_secret"]},
         )
-        assert resp.status_code == 400
-        assert "Unsupported attachment type" in resp.json()["detail"]
+        assert resp.status_code == 200
 
     def test_reject_svg_content_type(self, client, room_setup):
         """SVG can contain scripts — must be rejected."""
@@ -620,3 +619,128 @@ class TestAttachmentMigration:
         fk = fks[0]
         assert fk[2] == "room_messages"  # table
         assert fk[4] == "mid"  # to column
+
+
+# ---------------------------------------------------------------------------
+# Large-paste text attachment tests (allowlist + safe download)
+# ---------------------------------------------------------------------------
+
+
+class TestTextAttachmentAllowlist:
+    """Each text MIME type added for the large-paste feature is accepted."""
+
+    @pytest.mark.parametrize(
+        ("content_type", "payload"),
+        [
+            ("text/plain", b"just some plain text"),
+            ("text/csv", b"a,b,c\n1,2,3\n"),
+            ("text/markdown", b"# Heading\n\n- item\n"),
+            ("text/html", b"<html><body>hi</body></html>"),
+            ("application/json", b'{"k": "v"}'),
+        ],
+    )
+    def test_text_types_accepted(self, client, room_setup, content_type, payload):
+        s = room_setup
+        b64 = base64.b64encode(payload).decode()
+        resp = client.post(
+            f"/{s['ns']}/rooms/{s['room_id']}/messages",
+            json={
+                "body": "paste",
+                "attachments": [
+                    {
+                        "filename": f"pasted.{content_type}",
+                        "content_type": content_type,
+                        "data": b64,
+                    },
+                ],
+            },
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["attachments"][0]["content_type"] == content_type
+
+
+class TestSafeAttachmentDownload:
+    """The raw download path must force download and never render HTML inline."""
+
+    def _upload(self, client, s, filename, content_type, payload):
+        b64 = base64.b64encode(payload).decode()
+        resp = client.post(
+            f"/{s['ns']}/rooms/{s['room_id']}/messages",
+            json={
+                "body": "paste",
+                "attachments": [
+                    {"filename": filename, "content_type": content_type, "data": b64},
+                ],
+            },
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        assert resp.status_code == 200, resp.text
+        return resp.json()["attachments"][0]["id"]
+
+    def test_html_served_as_text_plain_not_html(self, client, room_setup):
+        """XSS: a text/html attachment with <script> must NOT be served as
+        renderable text/html — it is downgraded to text/plain and forced to
+        download so it can't execute in the room."""
+        s = room_setup
+        script = b"<html><body><script>alert('xss')</script></body></html>"
+        att_id = self._upload(client, s, "evil.html", "text/html", script)
+
+        resp = client.get(
+            f"/{s['ns']}/attachments/{att_id}/download",
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        assert resp.status_code == 200
+        # Wire content-type must not be renderable HTML.
+        ctype = resp.headers["content-type"]
+        assert "text/html" not in ctype
+        assert ctype.startswith("text/plain")
+        # Must force download.
+        assert resp.headers["content-disposition"].startswith("attachment")
+        assert resp.headers["x-content-type-options"] == "nosniff"
+        # The bytes are preserved verbatim (so the user can still read/save them),
+        # but the wire content-type prevents inline execution.
+        assert resp.content == script
+
+    def test_plain_text_download_forces_attachment(self, client, room_setup):
+        s = room_setup
+        payload = b"hello world"
+        att_id = self._upload(client, s, "note.txt", "text/plain", payload)
+        resp = client.get(
+            f"/{s['ns']}/attachments/{att_id}/download",
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        assert resp.status_code == 200
+        assert resp.headers["content-disposition"].startswith("attachment")
+        assert resp.content == payload
+
+    def test_download_requires_auth(self, client, room_setup):
+        s = room_setup
+        resp = client.get(f"/{s['ns']}/attachments/any-id/download")
+        assert resp.status_code == 401
+
+    def test_download_requires_room_membership(self, client, two_member_setup):
+        s = two_member_setup
+        att_id = self._upload(client, s, "note.txt", "text/plain", b"secret")
+        charlie = client.post(
+            f"/{s['ns']}/identities",
+            headers={"X-Namespace-Secret": s["ns_secret"]},
+            json={"metadata": {"display_name": "Charlie"}},
+        ).json()
+        resp = client.get(
+            f"/{s['ns']}/attachments/{att_id}/download",
+            headers={"X-Inbox-Secret": charlie["secret"]},
+        )
+        assert resp.status_code == 403
+
+    def test_download_filename_header_sanitized(self, client, room_setup):
+        """Newlines/quotes in filename can't break out of the header."""
+        s = room_setup
+        att_id = self._upload(client, s, 'bad"\r\nname.txt', "text/plain", b"x")
+        resp = client.get(
+            f"/{s['ns']}/attachments/{att_id}/download",
+            headers={"X-Inbox-Secret": s["alice_secret"]},
+        )
+        assert resp.status_code == 200
+        cd = resp.headers["content-disposition"]
+        assert "\r" not in cd and "\n" not in cd

--- a/tests/test_paste_attachment_playwright.py
+++ b/tests/test_paste_attachment_playwright.py
@@ -1,0 +1,269 @@
+"""
+Playwright test for the large-paste-to-attachment feature.
+
+Verifies that pasting a large (>= 10 KB) block of text into the room message
+composer:
+  1. Triggers the paste-to-attachment metadata dialog (does NOT insert the
+     text inline into the composer).
+  2. Pre-fills a file name and a sniffed content-type.
+  3. On confirm, produces an attachment chip in the compose preview (NOT a
+     giant inline message body), leaving the composer empty.
+
+It also directly exercises the client-side content sniffer.
+
+Test approach mirrors tests/test_reverse_scroll_playwright.py: the app.html
+template is rendered with minimal Jinja2 substitution and served via a local
+HTTP server, so we drive the real client JS in a real browser without needing
+FastAPI/Jinja2 at runtime.
+
+Paste events: a real OS-clipboard paste is unreliable in headless browsers
+(clipboard permission prompts, no real clipboard). Instead we dispatch a
+synthetic `paste` ClipboardEvent carrying a DataTransfer with >= 10 KB of
+text/plain — this drives the exact handler wired at
+templates/app.html (room-message-input 'paste' listener).
+"""
+
+import http.server
+import pathlib
+import re
+import socket
+import threading
+import time
+
+import pytest
+
+from playwright.sync_api import sync_playwright
+
+pytestmark = pytest.mark.integration
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent
+STATIC_DIR = REPO_ROOT / "src" / "deadrop" / "static"
+TEMPLATES_DIR = REPO_ROOT / "src" / "deadrop" / "templates"
+
+TEST_HTTP_PORT = 19110
+
+_rendered_app_html: str | None = None
+
+
+def _build_app_html() -> str:
+    global _rendered_app_html
+    if _rendered_app_html is not None:
+        return _rendered_app_html
+
+    base_html = (TEMPLATES_DIR / "base.html").read_text()
+    app_html = (TEMPLATES_DIR / "app.html").read_text()
+
+    title_match = re.search(r"\{% block title %\}(.+?)\{% endblock %\}", app_html, re.DOTALL)
+    body_match = re.search(r"\{% block body %\}(.+?)\{% endblock %\}", app_html, re.DOTALL)
+    scripts_match = re.search(r"\{% block scripts %\}(.+?)\{% endblock %\}", app_html, re.DOTALL)
+
+    title = title_match.group(1).strip() if title_match else "Deadrop"
+    body_content = body_match.group(1) if body_match else ""
+    scripts_content = scripts_match.group(1) if scripts_match else ""
+
+    rendered = base_html
+    rendered = re.sub(
+        r"\{% block title %\}.*?\{% endblock %\}", lambda _: title, rendered, flags=re.DOTALL
+    )
+    rendered = re.sub(
+        r"\{% block body %\}.*?\{% endblock %\}", lambda _: body_content, rendered, flags=re.DOTALL
+    )
+    rendered = re.sub(
+        r"\{% block scripts %\}.*?\{% endblock %\}",
+        lambda _: scripts_content,
+        rendered,
+        flags=re.DOTALL,
+    )
+    rendered = re.sub(
+        r"\{% block head %\}.*?\{% endblock %\}", lambda _: "", rendered, flags=re.DOTALL
+    )
+
+    rendered = (
+        rendered.replace("{{ slug | tojson if slug else 'null' }}", "null")
+        .replace("{{ peer_id | tojson if peer_id is defined and peer_id else 'null' }}", "null")
+        .replace("{{ view | tojson if view is defined and view else 'null' }}", "null")
+        .replace("{{ room_id | tojson if room_id is defined and room_id else 'null' }}", "null")
+        .replace("{{ ROOM_PAGE_SIZE }}", "20")
+    )
+
+    _rendered_app_html = rendered
+    return rendered
+
+
+class StaticHandler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        pass
+
+    def do_GET(self):
+        path = self.path.split("?")[0]
+        if path in ("/", "/app", "/app/"):
+            body_bytes = _build_app_html().encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body_bytes)))
+            self.end_headers()
+            self.wfile.write(body_bytes)
+            return
+        if path.startswith("/static/"):
+            rel = path[len("/static/") :]
+            file_path = STATIC_DIR / rel
+            if file_path.exists() and file_path.is_file():
+                data = file_path.read_bytes()
+                ct = {
+                    ".js": "application/javascript",
+                    ".css": "text/css",
+                    ".html": "text/html",
+                }.get(file_path.suffix, "application/octet-stream")
+                self.send_response(200)
+                self.send_header("Content-Type", ct)
+                self.send_header("Content-Length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+                return
+        self.send_response(404)
+        self.end_headers()
+
+
+def start_static_server():
+    server = http.server.HTTPServer(("127.0.0.1", TEST_HTTP_PORT), StaticHandler)
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    for _ in range(50):
+        try:
+            s = socket.create_connection(("127.0.0.1", TEST_HTTP_PORT), timeout=0.2)
+            s.close()
+            break
+        except (ConnectionRefusedError, OSError):
+            time.sleep(0.1)
+    return server
+
+
+@pytest.fixture(scope="module")
+def server():
+    http_server = start_static_server()
+    yield f"http://127.0.0.1:{TEST_HTTP_PORT}"
+    http_server.shutdown()
+
+
+# Dispatch a synthetic paste of `text` into #room-message-input.
+DISPATCH_PASTE_JS = """
+    (text) => {
+        const el = document.getElementById('room-message-input');
+        const dt = new DataTransfer();
+        dt.setData('text/plain', text);
+        const evt = new ClipboardEvent('paste', {
+            clipboardData: dt,
+            bubbles: true,
+            cancelable: true,
+        });
+        el.dispatchEvent(evt);
+    }
+"""
+
+
+class TestLargePasteToAttachment:
+    def _open_composer(self, page):
+        # Reveal the room view + compose input; the app hides it behind routing,
+        # but the elements exist in the DOM. We show the room view container and
+        # the input so the paste handler (attached on DOMContentLoaded) can fire.
+        page.evaluate("""
+            const view = document.getElementById('view-room');
+            if (view) view.classList.remove('hidden');
+            const input = document.getElementById('room-message-input');
+            if (input) input.focus();
+        """)
+
+    def test_large_paste_shows_dialog_and_produces_chip(self, server):
+        big_text = "x" * 15000  # 15 KB, well over the 10 KB threshold
+
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True)
+            context = browser.new_context(viewport={"width": 375, "height": 812})
+            page = context.new_page()
+
+            page.goto(server)
+            page.wait_for_load_state("networkidle")
+            page.wait_for_function("typeof addFileToPreview === 'function'", timeout=10000)
+            self._open_composer(page)
+
+            # Sanity: sniffer + threshold constant are wired.
+            assert page.evaluate("LARGE_PASTE_THRESHOLD_BYTES") == 10240
+            assert page.evaluate("sniffContentType('{\"a\":1}')") == "application/json"
+            assert page.evaluate("sniffContentType('# Title\\n\\n- a\\n')") == "text/markdown"
+            assert page.evaluate("sniffContentType('<!DOCTYPE html><html></html>')") == "text/html"
+            assert page.evaluate("sniffContentType('a,b,c\\n1,2,3\\n')") == "text/csv"
+            assert page.evaluate("sniffContentType('plain words here')") == "text/plain"
+
+            # Dispatch the large paste.
+            page.evaluate(DISPATCH_PASTE_JS, big_text)
+
+            # The metadata dialog must appear.
+            dialog = page.locator("#paste-attach-modal")
+            dialog.wait_for(state="visible", timeout=5000)
+            assert "hidden" not in (dialog.get_attribute("class") or "")
+
+            # Composer must NOT have received the giant text inline.
+            composer_value = page.evaluate("document.getElementById('room-message-input').value")
+            assert len(composer_value) < 100, (
+                f"Composer should be empty, got {len(composer_value)} chars inline"
+            )
+
+            # Name + content-type are pre-filled.
+            name_val = page.input_value("#paste-attach-name")
+            assert name_val.startswith("pasted-"), name_val
+            type_val = page.input_value("#paste-attach-type")
+            assert type_val in {
+                "text/plain",
+                "text/markdown",
+                "text/csv",
+                "application/json",
+                "text/html",
+            }
+
+            # Confirm the dialog.
+            page.click("#paste-attach-confirm")
+
+            # Dialog closes and an attachment chip appears in the preview.
+            dialog.wait_for(state="hidden", timeout=5000)
+            page.wait_for_function(
+                "document.querySelectorAll('#room-attachment-preview .thumb').length === 1",
+                timeout=5000,
+            )
+            chip_count = page.evaluate(
+                "document.querySelectorAll('#room-attachment-preview .thumb').length"
+            )
+            assert chip_count == 1, f"Expected 1 attachment chip, got {chip_count}"
+
+            # The pending attachment carries the full 15 KB payload (as a file),
+            # not an inline body.
+            pending_size = page.evaluate("pendingAttachments[0].size")
+            assert pending_size == 15000, pending_size
+
+            browser.close()
+
+    def test_small_paste_falls_through_inline(self, server):
+        small_text = "just a little text"
+
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True)
+            context = browser.new_context(viewport={"width": 375, "height": 812})
+            page = context.new_page()
+
+            page.goto(server)
+            page.wait_for_load_state("networkidle")
+            page.wait_for_function("typeof addFileToPreview === 'function'", timeout=10000)
+            self._open_composer(page)
+
+            page.evaluate(DISPATCH_PASTE_JS, small_text)
+            page.wait_for_timeout(300)
+
+            # No dialog for small pastes.
+            dialog = page.locator("#paste-attach-modal")
+            assert "hidden" in (dialog.get_attribute("class") or "")
+            # No attachment chip either.
+            chip_count = page.evaluate(
+                "document.querySelectorAll('#room-attachment-preview .thumb').length"
+            )
+            assert chip_count == 0
+
+            browser.close()


### PR DESCRIPTION
## What

Pasting a large block of text (≥ **10 KB**) into the room composer now converts it into a downloadable **file attachment** (a chip) instead of a giant inline message body. A metadata dialog lets the user set the filename + content-type (sniff-prefilled, overridable).

Closes the standing "deaddrop can't attach CSV/TSV/JSON/etc." gap (the Goodreads-export case).

## Behavior

- Paste `< 10 KB` → unchanged (normal inline paste).
- Paste `≥ 10 KB` of text → metadata dialog (name defaults to `pasted-<timestamp>`, content-type sniff-prefilled), then a chip. **No inline preview** — chip only.
- Content sniff (pre-fills the dropdown, user overrides): JSON → `application/json`; `<?xml` → `application/xml`; HTML tags → `text/html`; markdown markers → `text/markdown`; tab-columns → `text/tab-separated-values`; comma-columns → `text/csv`; `---`/`key: value` → `application/yaml`; else `text/plain`.

## Allowlist

`ALLOWED_ATTACHMENT_TYPES` gains: `text/plain`, `text/csv`, `text/tab-separated-values`, `text/markdown`, `text/html`, `application/json`, `application/yaml`, `application/xml`.

## 🔒 Security (the load-bearing part)

Text attachments — **especially `text/html` and `application/xml`** — must never render inline (stored-XSS / SVG-script / XXE). The raw download path (`/{ns}/attachments/{id}/download`, `api.py`):

- Forces `Content-Disposition: attachment` for **all** attachments.
- Adds `X-Content-Type-Options: nosniff`.
- Downgrades non-renderable types (`text/html`, `application/xml`, `text/xml`) to `text/plain; charset=utf-8` on the wire, so a pasted `.html` with `<script>` or an XML with an inline-SVG script cannot execute. Bytes are preserved verbatim for the user to read/save.

## Tests

- **Backend** — `tests/test_attachments.py`: **43 passed**. Adds an accept-test per new MIME type + XSS tests proving `text/html` and `application/xml` are served as forced-download `text/plain`, not renderable.
- **Client (Playwright)** — `tests/test_paste_attachment_playwright.py`: **2 passed**. Dispatches a real 15 KB paste into `#room-message-input`, asserts the metadata dialog appears, the composer body stays empty (paste NOT inlined), the name pre-fills, and exactly one attachment chip appears on confirm.
- `ruff format` + `ruff check` clean; `ty` type checker passes (pre-commit hook).

## Files

- `src/deadrop/api.py` — allowlist, `NON_RENDERABLE_ATTACHMENT_TYPES`, `_safe_download_headers()`, `/download` endpoint.
- `src/deadrop/templates/app.html` — paste handler text branch, metadata dialog, `sniffContentType()`, extension map.
- `src/deadrop/static/js/api.js` — client upload wiring.
- `tests/test_attachments.py`, `tests/test_paste_attachment_playwright.py` — coverage.
